### PR TITLE
Use React BrowserRouter over HashRouter

### DIFF
--- a/rcongui/src/App.js
+++ b/rcongui/src/App.js
@@ -13,7 +13,7 @@ import CssBaseline from "@material-ui/core/CssBaseline";
 import HLLSettings from "./components/SettingsView/hllSettings";
 import { ThemeProvider } from '@material-ui/styles';
 import {
-  HashRouter as Router,
+  BrowserRouter as Router,
   Switch,
   Route,
   Link as RouterLink


### PR DESCRIPTION
For cleaner URL (/settings vs /#/settings)
Prevents /asdfasdf resulting to /asdfasdf#/settings upon navigation

Unless there is an other reason to use HashRouter? @MarechJ be4d54c1b79d830363118adab888cca2c82e698b