### PR TITLE
Typos and add run-dev-server.sh script to launch development env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Hell Let Loose (HLL) advanced RCON  
+# Hell Let Loose (HLL) advanced RCON
 
 An extended RCON tool for Hell Let loose.
 It's composed of HTTP Api, a friendly GUI and if you need it a cli or use it as a library to build your own client.
 
-Please join us on discord if you use it, for feedback, troubleshooting and informations about updates: https://discord.gg/hZx6gn3
+Please join us on discord if you use it, for feedback, troubleshooting and information about updates: https://discord.gg/hZx6gn3
 
 Feel free to contribute, some parts would need a rewrite (I single-handedly built it so I took some shortcuts).
 There's a LOT of new cool features that could be added, I'd be happy to walk through the code with you if you want to get involved.
@@ -13,12 +13,12 @@ Here's a small sample:
 
 # How to install the App
 
-### Pre-requistes:
+### Pre-requisites:
 
   - Having some basic shell (command prompt) skills. Feel free to ask for help on the Discord
   - Having a dedicated server - This app is meant to run 24/7 (it's a website with attached services)
-  - The below isntalled on the server where you install it:
-     - (Otionnal but recommanded) GIT: https://git-scm.com/downloads
+  - The below installed on the server where you install it:
+     - (Optional but recommended) GIT: https://git-scm.com/downloads
      - Docker Engine (Community) installed: https://docs.docker.com/install/
      - Docker Compose installed: https://docs.docker.com/compose/install/
 
@@ -39,9 +39,9 @@ Note: If you have several servers, clone it multiple times in different director
 
 __From here all the commands assume that you are at the root of the repo you just cloned__
 
-### 2. Set your server informations. Edit the `.env` file and fill in the blanks (for all your servers) like so:
+### 2. Set your server information. Edit the `.env` file and fill in the blanks (for all your servers) like so:
 
-Note if you don't see the `.env` file you need to activate the show hidden files option on windows. On linux don't forget the `-a`: `ls -a`
+Note if you don't see the `.env` file you need to activate the show hidden files option on Windows. On linux don't forget the `-a`: `ls -a`
 
     # Ip address of the game server
     HLL_HOST=22.33.44.55
@@ -70,7 +70,7 @@ Note if you don't see the `.env` file you need to activate the show hidden files
 Note for power users:
 
 You could also just export the variables in your terminal before running the docker-compose commands
-OR edit the `docker-compose.yml` and replace the `${variable}` directly in there, however you might have a conflic next time you update the sources.
+OR edit the `docker-compose.yml` and replace the `${variable}` directly in there, however you might have a conflict next time you update the sources.
 Alternatively you can also specify them in the command line. [More details](https://docs.docker.com/compose/environment-variables/#set-environment-variables-with-docker-compose-run)
 
 ### 3. RUN it!
@@ -104,7 +104,8 @@ After that you can start adding youR users with this: http://prntscr.com/u3t2u4
 Make sure you specify their steam id it will be used in upcoming features: http://prntscr.com/u3t2yq
 Once the user is created you'll end up on that page: http://prntscr.com/u3t3to
 I recommend NOT CHANGING ANYTHING except for a select few of your most trusted staff members you can tick the `Superuser status`.
-Please note that users won't be able to change their password by themselves unless you tick the `staff status` so that they can access this admin page, however i DO NOT RECOMMEND doing as I won't be maintaining special permissions on admin models on the future (just manage password for them). 
+Please note that users won't be able to change their password by themselves unless you tick the `staff status` so that they can access 
+this admin page, however I DO NOT RECOMMEND doing as I won't be maintaining special permissions on admin models on the future (just manage password for them). 
 To change the password of one of your user, in the users list click on him, then there: http://prntscr.com/u3ytzi
 
 
@@ -114,13 +115,13 @@ You're done, ENJOY!
 
 ### To update to the latest version:
 
-#### In case it says your local changes the `.env` would be overriden when you git pull:
+#### In case it says your local changes the `.env` would be overridden when you `git pull`:
 
 You can do 
 
    git stash && git pull
 
-Then either: `git stash apply` edit to remove the conflit then `git reset .env`
+Then either: `git stash apply` edit to remove the conflict then `git reset .env`
 Or just fill the `.env` manually again.
 Then run the docker-compose commands.
 This won't happen for every updates.
@@ -146,11 +147,11 @@ This won't happen for every updates.
 
 Or download the [latest zip release](https://github.com/MarechJ/hll_rcon_tool/releases/latest)
 
-Note that it's important you get the sources every time, or at least the docker-compose files, as new dependancies might be introduced
+Note that it's important you get the sources every time, or at least the docker-compose files, as new dependencies might be introduced
 
 ### To downgrade (in case of issue) to a previous version:
 
-Check the availabe versions numbers on docker hub (or github releases):
+Check the available versions numbers on docker hub (or github releases):
 https://hub.docker.com/r/maresh/hll_rcon/tags
 https://github.com/MarechJ/hll_rcon_tool/releases
 
@@ -169,10 +170,10 @@ To the version you want (here we use v1.9)
 
 ## Known issues and limitations
 
-- After a sometime without being used the API will lose the connection to the game server so when you open the GUI the first time you might see an error that it can't fetch the list of players. However this will recover on its own just refresh or wait til the next auto refresh
+- After a sometime without being used the API will lose the connection to the game server so when you open the GUI the first time you might see an error that it can't fetch the list of players. However, this will recover on its own just refresh or wait til the next auto refresh
 - The game server in rare case fails to return the steam ID of a player. 
 - When logs are completely empty the game server will fail to respond to the request causing an error to show in the API/GUI
-- The RCON api server truncates the name of players to a maximum of 20 charcheters even though, up to 32 characters are displayed in game. Bottom line you don't always see the full name
+- The RCON api server truncates the name of players to a maximum of 20 characters even though, up to 32 characters are displayed in game. Bottom line you don't always see the full name
 
 
 ## How to use
@@ -203,7 +204,7 @@ More or less in order of priorities
 ### Build the image
     $ docker build . -t rcon
 
-### Set your server info as environement variables and run the cli
+### Set your server info as environment variables and run the cli
 
     $ docker run -it -e HLL_HOST=1.1.1.1 -e HLL_PORT=20300 -e HLL_PASSWORD=mypassword rcon python -m rcon.cli
      
@@ -244,14 +245,17 @@ The backbone of the application is HLLConnection + ServerCtl it is what binds th
 The `Rcon` and `RecordedRcon` provide some wrapping around the raw results of the game server. And expose some new commands that are a combination of basic commands.
 The `Rcon` class also adds a caching layer using Redis (or falling back to in-memory) in order to go easy on the server. 
 The `RecordedRcon` is an additional wrapping where all the commands that should be saved, or use the Database should go.
-I made the choice of separating the `ServerCtl`, `Rcon` and `RecorededRcon` into serparated layers to leave the possiblity to choose the right level of abstraction for what you need.
+I made the choice of separating the `ServerCtl`, `Rcon` and `RecorededRcon` into separated layers to leave the possibility to choose the right level of abstraction for what you need.
 
 The API in django is a very thin layer that basically loops over all the methods available in `RecorededRcon` (and therefore all those of `ServerCtl` and `Rcon`) and binds them to a route see [/rconweb/api/views.py](/rconweb/api/views.py).
-This is a bit hackish, but it saved me a lot of time a the begining, it also removes a lot of boilerplate, but it should probably change at some point to provide a cleaner set of endpoints.
+This is a bit hackish, but it saved me a lot of time at the beginning, it also removes a lot of boilerplate, but it should probably 
+change at some point to provide a cleaner set of endpoints.
 
 ### Start a development instance
 
-#### First boot up the dependancies. I use docker for that but you can also install Redis and Postgres natively if you prefer
+You may edit and launch the `run-dev-server.sh` script to launch all you need. But, please read following information to get more details.
+
+#### First boot up the dependencies. I use `docker` for that, but you can also install Redis and Postgres natively if you prefer
 
     docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis postgres
 
@@ -274,14 +278,14 @@ This will make redis and postgres available on you localhost with their default 
 
     # from the root of the repo
     pip install -r requirements.txt
-    PYTHONPATH=$PWD  DJANGO_DEBUG=true ./rconweb/manage.py runserver
+    PYTHONPATH=$PWD DJANGO_DEBUG=true ./rconweb/manage.py runserver
 
 This will run a development server on http://127.0.0.1:8000/ it auto refreshes on code changes
-If you change the port rember that you will also need to change it in rcongui/.env for the frontend to know where to talk to the API
+If you change the port remember that you will also need to change it in rcongui/.env for the frontend to know where to talk to the API
 
 Hitting http://127.0.0.1:8000/api/ with Django DEBUG set to true will show you all the available endpoints. They are basically named after the methods of the `Rcon` class
-All endpoints accept GET querystring parameters OR (not both at the same time) a json payload. The parameters are the same as the parameter names of the `Rcon` methodds (all that is auto generated remember).
-It is not best practice to have endpoints that do write operations accept a GET with query string parameters but it was just easier that way. 
+All endpoints accept GET querystring parameters OR (not both at the same time) a json payload. The parameters are the same as the parameter names of the `Rcon` methods (all that is auto generated remember).
+It is not best practice having endpoints that do write operations accept a GET with query string parameters but it was just easier that way. 
 
 #### Now start the frontend:
 
@@ -302,5 +306,6 @@ Now test on http://localhost:8010
 
 #### General notes:
 
-If you have problems with dependancies or versions of python or nodejs please refer to the respective Dockerfile that can act as a guide on how to setup a development environment.
+If you have problems with dependencies or versions of python or nodejs please refer to the respective Dockerfile that can act as a guide 
+on how to set up a development environment.
 If you need a refresher on which process needs what variables have a look at the docker-compose file.

--- a/run-dev-server.sh
+++ b/run-dev-server.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+trap 'echo Stopping dev env...; kill $(jobs -p); wait; exit' SIGINT SIGTERM
+
+export HLL_PASSWORD=<fill in yours>
+export HLL_PORT=<fill in yours>
+export HLL_HOST=<fill in yours>
+export HLL_DB_PASSWORD=<fill in yours>
+export DJANGO_DEBUG=True
+
+export DB_URL=postgres://rcon:$HLL_DB_PASSWORD@localhost:5432
+export REDIS_URL=redis://localhost:6379/0
+
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis postgres
+
+pip install -r requirements.txt
+PYTHONPATH=$PWD DJANGO_DEBUG=$DJANGO_DEBUG ./rconweb/manage.py makemigrations; ./rconweb/manage.py migrate; ./rconweb/manage.py runserver &
+
+cd rcongui/
+npm install
+npm start &
+
+echo 'Press CTRL+C to quit'
+
+wait


### PR DESCRIPTION
fixes some typos in README.md file.
Add run-dev-server.sh script to launch development env.