### PR TITLE
Add a map_id parameter to the gamescoreboard URL

### DIFF
--- a/rcongui/package.json
+++ b/rcongui/package.json
@@ -27,6 +27,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.4",
     "react-toastify": "^5.5.0",
+    "react-copy-to-clipboard": "^5.0.3",
     "recompose": "^0.30.0"
   },
   "scripts": {

--- a/rcongui/src/App.js
+++ b/rcongui/src/App.js
@@ -332,6 +332,9 @@ function App() {
             <Route path={process.env.REACT_APP_PUBLIC_BUILD ? "/" : "/livescore"} default={process.env.REACT_APP_PUBLIC_BUILD} exact>
               <LiveScore classes={classes} />
             </Route>
+            <Route path="/gamescoreboard/:slug">
+              <GamesScore classes={classes} />
+            </Route>
             <Route path="/gamescoreboard">
               <GamesScore classes={classes} />
             </Route>

--- a/rcongui/src/components/Scoreboard/GamesScore.js
+++ b/rcongui/src/components/Scoreboard/GamesScore.js
@@ -21,6 +21,7 @@ import Scores from "./Scores";
 import map_to_pict from "./utils";
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import { useParams } from "react-router-dom";
 
 const useStyles = makeStyles((theme) => ({
   singleLine: {
@@ -111,21 +112,19 @@ const GamesScore = ({ classes }) => {
   const durationToHour = (val) =>
     new Date(val * 1000).toISOString().substr(11, 5);
 
+  let { slug } = useParams();
+
   const lastRefresh = scores.get("snapshot_timestamp")
     ? moment.unix(scores.get("snapshot_timestamp")).format()
     : "N/A";
 
-  const queryParams = new URLSearchParams(window.location.search)
-  const doSelectNewMap = (map_id) => {
-    if (queryParams.has('map_id')) {
-      queryParams.set('map_id', map_id);
-      window.location.replace(window.location.origin + window.location.pathname + '?' + queryParams.toString() + window.location.hash);
-    } else {
-      setCurrentMapId(map_id);
-    };
-  };
   const getShareableLink = () => {
-    return window.location.origin + window.location.pathname + `?map_id=${currentMapId}` + window.location.hash;
+    return window.location.href;
+  };
+  const doSelectMap = (map_id) => {
+    window.location.hash = `#/gamescoreboard/${map_id}`;
+    setCurrentMapId(map_id)
+    console.log(`Change to ${map_id}`);
   };
 
   const [hasCopiedLink, setHasCopiedLink] = React.useState(false);
@@ -163,14 +162,16 @@ const GamesScore = ({ classes }) => {
   };
 
   React.useEffect(() => {
-    if (queryParams.has("map_id")) {
-      const currentMapIdFromURL = parseInt(queryParams.get("map_id"));
-      setCurrentMapId(currentMapIdFromURL);
-      console.log(`Using ID ${currentMapIdFromURL} from URL`);
-    }
     if (!currentMapId) {
       return;
     }
+    if (!parseInt(slug)) {
+      window.location.hash = `#/gamescoreboard/${currentMapId}`
+      console.log(`No ID supplied, redirecting to ${window.location.hash}`);
+    } else {
+      setCurrentMapId(parseInt(slug));
+    };
+
     get(`get_map_scoreboard?map_id=${currentMapId}`)
       .then((res) => showResponse(res, "get_map_scoreboard", false))
       .then((data) =>
@@ -241,7 +242,7 @@ const GamesScore = ({ classes }) => {
                 return (
                   <GridListTile
                     className={styles.clickable}
-                    onClick={() => doSelectNewMap(m.get("id"))}
+                    onClick={() => doSelectMap(m.get("id"))}
                     key={`${m.get("name")}${m.get("start")}${m.get("end")}`}
                   >
                     <img alt="Map" src={map_to_pict[m.get("just_name")]} />
@@ -270,7 +271,7 @@ const GamesScore = ({ classes }) => {
                         </IconButton>,
                         <IconButton
                           color="inherit"
-                          onClick={() => doSelectNewMap(m.get("id"))}
+                          onClick={() => doSelectMap(m.get("id"))}
                         >
                           <VisibilityIcon color="inherit" />
                         </IconButton>

--- a/rcongui/src/components/Scoreboard/GamesScore.js
+++ b/rcongui/src/components/Scoreboard/GamesScore.js
@@ -6,7 +6,6 @@ import {
   GridListTile,
   GridListTileBar,
   IconButton,
-  Button,
   Paper
 } from "@material-ui/core";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
@@ -87,6 +86,9 @@ const useStyles = makeStyles((theme) => ({
     height: 38,
     width: 38,
   },
+  black: {
+    backgroundColor: theme.palette.primary.main,
+  },
 }));
 
 const GamesScore = ({ classes }) => {
@@ -113,17 +115,19 @@ const GamesScore = ({ classes }) => {
     ? moment.unix(scores.get("snapshot_timestamp")).format()
     : "N/A";
 
-  const hashString = window.location.hash;
-  const queryString = hashString.substr(hashString.indexOf('?')+1);
-  const queryParams = queryString.split('&').reduce(function (res, item) {
-    var parts = item.split('=');
-    res[parts[0]] = parts[1];
-    return res;
-  }, {});
-
-  const getShareableLink = () => {
-    return window.location.href.split('?')[0] + `?map_id=${currentMapId}`;
+  const queryParams = new URLSearchParams(window.location.search)
+  const doSelectNewMap = (map_id) => {
+    if (queryParams.has('map_id')) {
+      queryParams.set('map_id', map_id);
+      window.location.replace(window.location.origin + window.location.pathname + '?' + queryParams.toString() + window.location.hash);
+    } else {
+      setCurrentMapId(map_id);
+    };
   };
+  const getShareableLink = () => {
+    return window.location.origin + window.location.pathname + `?map_id=${currentMapId}` + window.location.hash;
+  };
+
   const [hasCopiedLink, setHasCopiedLink] = React.useState(false);
   const onCopyLink = () => {
     setHasCopiedLink(true);
@@ -159,8 +163,8 @@ const GamesScore = ({ classes }) => {
   };
 
   React.useEffect(() => {
-    if ("map_id" in queryParams) {
-      const currentMapIdFromURL = parseInt(queryParams["map_id"]);
+    if (queryParams.has("map_id")) {
+      const currentMapIdFromURL = parseInt(queryParams.get("map_id"));
       setCurrentMapId(currentMapIdFromURL);
       console.log(`Using ID ${currentMapIdFromURL} from URL`);
     }
@@ -237,7 +241,7 @@ const GamesScore = ({ classes }) => {
                 return (
                   <GridListTile
                     className={styles.clickable}
-                    onClick={() => setCurrentMapId(m.get("id"))}
+                    onClick={() => doSelectNewMap(m.get("id"))}
                     key={`${m.get("name")}${m.get("start")}${m.get("end")}`}
                   >
                     <img alt="Map" src={map_to_pict[m.get("just_name")]} />
@@ -266,7 +270,7 @@ const GamesScore = ({ classes }) => {
                         </IconButton>,
                         <IconButton
                           color="inherit"
-                          onClick={() => setCurrentMapId(m.get("id"))}
+                          onClick={() => doSelectNewMap(m.get("id"))}
                         >
                           <VisibilityIcon color="inherit" />
                         </IconButton>
@@ -278,6 +282,24 @@ const GamesScore = ({ classes }) => {
             </GridList>
           </div>
         </Grid>
+        {currentMapId ? (
+          <Grid item xs={6} justify="center" className={`${styles.black}`}>
+            <Grid container justify="center" alignItems="center">
+              <Grid item xs={11} zeroMinWidth>
+                <Paper>
+                  <Typography variant="h5" noWrap>{getShareableLink()}</Typography>
+                </Paper>
+              </Grid>
+              <Grid item xs={1}>
+                <IconButton color="inherit">
+                  <CopyToClipboard text={getShareableLink()} onCopy={onCopyLink}>
+                    {hasCopiedLink ? <CheckIcon color="secondary" /> : <LinkIcon color="secondary" />}
+                  </CopyToClipboard>
+                </IconButton>
+              </Grid>
+            </Grid>
+          </Grid>
+        ) : ""}
       </Grid>
       <Grid container spacing={2} justify="center" className={classes.padding}>
         <Scores

--- a/rcongui/src/components/Scoreboard/GamesScore.js
+++ b/rcongui/src/components/Scoreboard/GamesScore.js
@@ -6,9 +6,13 @@ import {
   GridListTile,
   GridListTileBar,
   IconButton,
+  Button,
+  Paper
 } from "@material-ui/core";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import VisibilityIcon from "@material-ui/icons/Visibility";
+import LinkIcon from '@material-ui/icons/Link';
+import CheckIcon from '@material-ui/icons/Check';
 import React from "react";
 import { get, handle_http_errors, showResponse } from "../../utils/fetchUtils";
 import { List as iList, Map, fromJS, List } from "immutable";
@@ -17,6 +21,7 @@ import { useTheme } from "@material-ui/core/styles";
 import Scores from "./Scores";
 import map_to_pict from "./utils";
 import { fade } from '@material-ui/core/styles/colorManipulator';
+import { CopyToClipboard } from "react-copy-to-clipboard";
 
 const useStyles = makeStyles((theme) => ({
   singleLine: {
@@ -108,6 +113,25 @@ const GamesScore = ({ classes }) => {
     ? moment.unix(scores.get("snapshot_timestamp")).format()
     : "N/A";
 
+  const hashString = window.location.hash;
+  const queryString = hashString.substr(hashString.indexOf('?')+1);
+  const queryParams = queryString.split('&').reduce(function (res, item) {
+    var parts = item.split('=');
+    res[parts[0]] = parts[1];
+    return res;
+  }, {});
+
+  const getShareableLink = () => {
+    return window.location.href.split('?')[0] + `?map_id=${currentMapId}`;
+  };
+  const [hasCopiedLink, setHasCopiedLink] = React.useState(false);
+  const onCopyLink = () => {
+    setHasCopiedLink(true);
+    setTimeout(() => {
+      setHasCopiedLink(false);
+    }, 1000);
+  };
+  
   moment.relativeTimeThreshold("m", 120);
   const getData = () => {
     setIsLoading(true);
@@ -135,6 +159,11 @@ const GamesScore = ({ classes }) => {
   };
 
   React.useEffect(() => {
+    if ("map_id" in queryParams) {
+      const currentMapIdFromURL = parseInt(queryParams["map_id"]);
+      setCurrentMapId(currentMapIdFromURL);
+      console.log(`Using ID ${currentMapIdFromURL} from URL`);
+    }
     if (!currentMapId) {
       return;
     }
@@ -230,7 +259,11 @@ const GamesScore = ({ classes }) => {
                       title={`${start.format("dddd, MMM Do ")}`}
                       subtitle={`Started at: ${start.format("HH:mm")}`}
                       actionIcon={isSelected(
-                        "",
+                        <IconButton color="inherit">
+                          <CopyToClipboard text={getShareableLink()} onCopy={onCopyLink}>
+                            {hasCopiedLink ? <CheckIcon color="inherit" /> : <LinkIcon color="inherit" />}
+                          </CopyToClipboard>
+                        </IconButton>,
                         <IconButton
                           color="inherit"
                           onClick={() => setCurrentMapId(m.get("id"))}

--- a/rcongui/src/components/Scoreboard/GamesScore.js
+++ b/rcongui/src/components/Scoreboard/GamesScore.js
@@ -283,24 +283,6 @@ const GamesScore = ({ classes }) => {
             </GridList>
           </div>
         </Grid>
-        {currentMapId ? (
-          <Grid item xs={6} justify="center" className={`${styles.black}`}>
-            <Grid container justify="center" alignItems="center">
-              <Grid item xs={11} zeroMinWidth>
-                <Paper>
-                  <Typography variant="h5" noWrap>{getShareableLink()}</Typography>
-                </Paper>
-              </Grid>
-              <Grid item xs={1}>
-                <IconButton color="inherit">
-                  <CopyToClipboard text={getShareableLink()} onCopy={onCopyLink}>
-                    {hasCopiedLink ? <CheckIcon color="secondary" /> : <LinkIcon color="secondary" />}
-                  </CopyToClipboard>
-                </IconButton>
-              </Grid>
-            </Grid>
-          </Grid>
-        ) : ""}
       </Grid>
       <Grid container spacing={2} justify="center" className={classes.padding}>
         <Scores


### PR DESCRIPTION
Allows for having persistent links to directly select a specific match, for instance http://62.171.172.221:7041/?map_id=3793#/gamescoreboard

This also adds a bar displaying the link that can be shared to reference the currently selected map, as well as a button to directly copy it.

One flaw. When a map id is specified in the URL it has to fully redirect the user to a URL with the new ID.