### PR TITLE
Use npm ci to install JS deps

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -10,7 +10,7 @@ RUN mkdir /pw
 COPY rcongui/package.json package.json
 COPY rcongui/package-lock.json package-lock.json
 
-RUN npm install
+RUN npm ci
 
 ENV REACT_APP_API_URL /api/
 

--- a/Dockerfile-frontend-arm32
+++ b/Dockerfile-frontend-arm32
@@ -10,7 +10,7 @@ RUN mkdir /pw
 COPY rcongui/package.json package.json
 COPY rcongui/package-lock.json package-lock.json
 
-RUN npm install
+RUN npm ci
 
 ENV REACT_APP_API_URL /api/
 

--- a/Dockerfile-frontend-arm64
+++ b/Dockerfile-frontend-arm64
@@ -9,7 +9,7 @@ RUN mkdir /pw
 COPY rcongui/package.json package.json
 COPY rcongui/package-lock.json package-lock.json
 
-RUN npm install
+RUN npm ci
 
 ENV REACT_APP_API_URL /api/
 


### PR DESCRIPTION
This is faster and [recommended by NPM](https://docs.npmjs.com/cli/v7/commands/npm-ci) for automated build processes