### PR TITLE
Skip sourcemap generation on arm32

### DIFF
--- a/Dockerfile-frontend-arm32
+++ b/Dockerfile-frontend-arm32
@@ -10,6 +10,8 @@ RUN mkdir /pw
 COPY rcongui/package.json package.json
 COPY rcongui/package-lock.json package-lock.json
 
+ENV GENERATE_SOURCEMAP false
+
 RUN npm install
 
 ENV REACT_APP_API_URL /api/


### PR DESCRIPTION
The React build process runs out of memory on small systems with the default settings. Skipping sourcemap generation saves a lot of memory, allowing the process to complete on these arm32 devices which typically have only 2 gigs of RAM.