### PR TITLE
Add GET run_raw_command endpoint for debugging purposes

### DIFF
--- a/rcon/discord_chat.py
+++ b/rcon/discord_chat.py
@@ -2,6 +2,7 @@ import logging
 import os
 from functools import lru_cache
 import re
+from datetime import datetime
 
 import discord.utils
 import requests
@@ -20,6 +21,8 @@ PING_TRIGGER_WORDS = os.getenv("DISCORD_PING_TRIGGER_WORDS")
 PING_TRIGGER_ROLES = os.getenv("DISCORD_PING_TRIGGER_ROLES")
 SEND_KILLS = os.getenv("DISCORD_SEND_KILL_UPDATES")
 SEND_TEAM_KILLS = os.getenv("DISCORD_SEND_TEAM_KILL_UPDATES")
+
+SERVER_SHORT_NAME = os.getenv("SERVER_SHORT_NAME")
 
 STEAM_PROFILE_URL = "http://steamcommunity.com/profiles/{id64}"
 
@@ -148,10 +151,11 @@ class DiscordWebhookHandler:
             action = action.split("CHAT")[1]
             color = CHAT_ACTION_TO_COLOR[action]
 
-            embed = discord.Embed(description=message, color=color)
+            embed = discord.Embed(description=message, color=color, timestamp=datetime.utcnow())
             embed.set_author(
                 name=f"{player} {action}", url=STEAM_PROFILE_URL.format(id64=steam_id)
             )
+            embed.set_footer(text=SERVER_SHORT_NAME)
 
             content = ""
             triggered = False


### PR DESCRIPTION
Running this endpoint and passing a `command` parameter will return the response returned by the game server in plain text without attempting to parse it (eg. in case of an array). If an internal error occurs the stack trace is printed out.

This makes it easier to investigate why a command failed, but may also be used to fix server misconfigurations that are preventing it to be done through the regular API, for instance if a ban reason contains a tab.

And apparently there's some small changes still left on the same branch from a while ago that adds some small details to the embed which was requested by someone who wanted to send the chat logs of multiple servers into the same channel.