### PR TITLE
Fix team view when no Steam API key is used

### DIFF
--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -1,10 +1,8 @@
 import logging
 import os
-import profile
 import random
 import re
 import socket
-from cmath import inf
 from datetime import datetime, timedelta
 from time import sleep
 
@@ -148,7 +146,9 @@ class Rcon(ServerCtl):
             profile = steam_profiles.get(player.get("steam_id_64"), {}) or {}
             player["profile"] = profile
             player["is_vip"] = steam_id_64 in vips
-            player["country"] = profile.get("steaminfo", {}).get("country", "private")
+            player["country"] = ""
+            if profile.get("steaminfo") is not None:
+                player["country"] = profile.get("steaminfo", {}).get("country", "private")
             # TODO refresh ban info and store into DB to avoid IOs here
             player["steam_bans"] = get_player_has_bans(steam_id_64)
             teams.setdefault(player.get("team"), {}).setdefault(player.get("unit_name"), {}).setdefault("players", []).append(player)    


### PR DESCRIPTION
In this case, the steaminfo could be None always resulting in an error.