### PR TITLE
fix building docker image on aarch64

### DIFF
--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -1,7 +1,8 @@
 FROM arm64v8/python:3.8.12-bullseye
 
 WORKDIR /code
-RUN apt-get update -y && apt-get install -y cron logrotate cargo
+RUN apt-get update -y && apt-get install -y cron logrotate
+RUN curl https://sh.rustup.rs -sSf | nohup sh -s -- -y --profile minimal
 COPY requirements.txt .
 RUN pip install -U pip
 RUN pip install -r requirements.txt


### PR DESCRIPTION
fix building python "cryptography" module by installing rust via rustup