### PR TITLE
Work around for game server returning wrong player data

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -225,12 +225,10 @@ class ServerCtl:
 
     def get_player_info(self, player, can_fail=False):
         data = self._request(f"playerinfo {player}", can_fail=can_fail)
-        try:
-            with open(f'/logs/players/{player}.log', 'a') as f:
-                f.write(data)
-                f.write('\n')
-        except:
-            pass
+        if player not in data:
+            data = self._request(f"playerinfo {player}", can_fail=can_fail)
+        if player not in data:
+            raise CommandFailedError("The game server is returning the wrong player info for %s we got %s", player, data)
         return data
 
     def get_admin_ids(self):

--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -226,7 +226,7 @@ class ServerCtl:
     def get_player_info(self, player, can_fail=False):
         data = self._request(f"playerinfo {player}", can_fail=can_fail)
         try:
-            with open(f'/logs/players/{player}.log', 'wa') as f:
+            with open(f'/logs/players/{player}.log', 'a') as f:
                 f.write(data)
                 f.write('\n')
         except:

--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -224,7 +224,14 @@ class ServerCtl:
         return self._get("playerids", True, can_fail=False)
 
     def get_player_info(self, player, can_fail=False):
-        return self._request(f"playerinfo {player}", can_fail=can_fail)
+        data = self._request(f"playerinfo {player}", can_fail=can_fail)
+        try:
+            with open(f'/logs/players/{player}.log', 'wa') as f:
+                f.write(data)
+                f.write('\n')
+        except:
+            pass
+        return data
 
     def get_admin_ids(self):
         return self._get("adminids", True, can_fail=False)

--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -1,6 +1,7 @@
 import logging
 import socket
 import time
+import re
 from dataclasses import dataclass
 from functools import wraps
 
@@ -223,11 +224,19 @@ class ServerCtl:
     def get_playerids(self):
         return self._get("playerids", True, can_fail=False)
 
+    def _is_info_correct(self, player, raw_data):
+        try:
+            lines = raw_data.split('\n')
+            return lines[0] == f"Name: {player}"
+        except Exception:
+            logger.exception("Bad playerinfo data")
+            return False
+
     def get_player_info(self, player, can_fail=False):
         data = self._request(f"playerinfo {player}", can_fail=can_fail)
-        if player not in data:
+        if not self._is_info_correct(player, data):
             data = self._request(f"playerinfo {player}", can_fail=can_fail)
-        if player not in data:
+        if not self._is_info_correct(player, data):
             raise CommandFailedError("The game server is returning the wrong player info for %s we got %s", player, data)
         return data
 

--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -343,7 +343,6 @@ class Rcon(ServerCtl):
     def _get_default_info_dict(self, player):
         return dict(
             name=player,
-            steam_id_64=None,
             unit_id=None,
             unit_name=None,
             loadout=None,

--- a/rcon/squad_automod/automod.py
+++ b/rcon/squad_automod/automod.py
@@ -212,7 +212,7 @@ def get_punitions_to_apply(rcon, config: NoLeaderConfig) -> PunitionsToApply:
                     raise SquadHasLeader()
 
                 if squad_name is None or squad is None:
-                    continue
+                    raise SquadHasLeader()
                 
                 logger.info("Squad %s - %s doesn't have leader", team, squad_name)
 


### PR DESCRIPTION
After quite a lengthy investigation we found that the game server returns data for a player different than the one you made a query for. This is a workaround to make the command fail in case it happens.