### PR TITLE
add info about characters that break db connection to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Note if you don't see the `.env` file you need to activate the show hidden files
     # Your rcon password (the one you use with your current Rcon)
     HLL_PASSWORD=mypassword
     # Choose a password for your Database (you probably won't need it)
+    # Prohibited characters for HLL_DB_PASSWORD: %#
     HLL_DB_PASSWORD=mydatabasepassword
 
     # The two below are the username and password that will be required to access the ronc website. 


### PR DESCRIPTION
when doing my initial setup  i couldnt connect to the db
after some digging i found that my HLL_DB_PASSWORD contained # which broke the code to connect to the db
sofar i found that # and % break it

most ideally this should be also included in .env but it doesnt make sense to change .env for such minor changes

for the changes to .env i would propose a second pr that gets merged before meaningful changes are done to .env