### PR TITLE
Force discord.py version to be 1.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ sentry-sdk==0.17.1
 redistimeseries==0.8.0
 python-dateutil==2.8.1
 git+https://github.com/MarechJ/python-discord-webhook.git@36b420749258fc03c8f8163cc105997e0baba8f3
-discord>=1.0.1
+discord==1.7.3
 requests>=2.21.0
 steam==1.0.2
 pyaml==21.10.1


### PR DESCRIPTION
The library discord.py released a new 2.0.0 version a couple of weeks ago, which includes some breaking changes. For the CRCON, this means that webhooks would break. Since the library is used for nothing else and the API is not being deprecated it is fine to keep using the old version.

Currently in `requirements.txt` the latest version is downloaded. We simply change that to 1.7.3, which is the most recent version prior to 2.0.0.