### PR TITLE
Add steam ID to scores table

### DIFF
--- a/rcongui/src/components/Scoreboard/Scores.js
+++ b/rcongui/src/components/Scoreboard/Scores.js
@@ -227,6 +227,7 @@ const RawScores = pure(({ classes, scores }) => {
             }}
             data={scores ? scores.toJS() : []}
             columns={[
+              { name: "steam_id_64", label: "Steam ID" },
               { name: "player", label: "Name" },
               { name: "kills", label: "Kills" },
               { name: "deaths", label: "Deaths" },


### PR DESCRIPTION
Add the steam ID 64 column to the scores table as requested in https://github.com/MarechJ/hll_rcon_tool/issues/120

Resolves #120 