### PR TITLE
JSON stringify object column values

### DIFF
--- a/rcongui/src/components/Scoreboard/Scores.js
+++ b/rcongui/src/components/Scoreboard/Scores.js
@@ -224,6 +224,20 @@ const RawScores = pure(({ classes, scores }) => {
               selectableRows: "none",
               rowsPerPageOptions: [10, 25, 50, 100, 250, 500, 1000],
               onChangeRowsPerPage: (v) => setRowsPerPage(v),
+              onDownload: (buildHead, buildBody, columns, data) => {
+                // Convert any column values that are objects to JSON so they display in the csv as data instead of [object Object]
+                const expandedData = data.map((row) => {
+                  return {
+                    index: row.index,
+                    data: row.data.map((colValue) =>
+                      typeof colValue === "object"
+                        ? JSON.stringify(colValue)
+                        : colValue
+                    ),
+                  };
+                });
+                return buildHead(columns) + buildBody(expandedData);
+              },
             }}
             data={scores ? scores.toJS() : []}
             columns={[


### PR DESCRIPTION
JSON stringify any column values that are objects leaving non-object values untouched.

e.g. "[object Object]" will show as ""{""WALTHER P38"":1,""GEWEHR 43"":1,""FELDSPATEN"":1}""