### PR TITLE
Fix historical log download parameter typo

### DIFF
--- a/rcongui/src/components/LogsHistory/logsHistory.js
+++ b/rcongui/src/components/LogsHistory/logsHistory.js
@@ -331,7 +331,7 @@ class LogsHistory extends React.Component {
 
   handleDownload() {
     postData(`${process.env.REACT_APP_API_URL}get_historical_logs`, {
-      player_name: this.statename,
+      player_name: this.state.name,
       log_type: this.state.type,
       steam_id_64: this.state.steamId64,
       from: this.state.from,


### PR DESCRIPTION
The player name parameter was incorrectly set to `this.statename` rather than `this.state.name` causing the historical log CSV download to not filter by player name. The data table would show the correct results but on downloading the resulting POST request would return results for all players.

I tested the change on our event server that has access to historical data and it appeared to work correctly.