### PR TITLE
Fix bug where the same log line would appear twice

### DIFF
--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -367,6 +367,7 @@ def get_recent_logs(
                     # Handle action_filter being empty
                     elif not action_filter:
                         logs.append(line)
+                        break
         elif action_filter:
             # Filter out anything that isn't in action_filter
             if inclusive_filter and is_action(
@@ -380,6 +381,7 @@ def get_recent_logs(
                 logs.append(line)
         elif not player_search and not action_filter:
             logs.append(line)
+
         if p1 := line["player"]:
             all_players.add(p1)
         if p2 := line["player2"]:


### PR DESCRIPTION
When filtering log lines by players, when selecting two players the log line would appear twice, once for each player in the log line.

Did a clean build from a freshly pulled repository and tested it successfully on our event server.