### PR TITLE
Feature/u13 updates

### DIFF
--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -676,7 +676,7 @@ class Rcon(ServerCtl):
             r"Remaining Time: (\d):(\d{2}):(\d{2})", raw_time_remaining
         ).groups()
 
-        current_map = raw_current_map.split(":")[1]
+        current_map = raw_current_map.split(": ")[1]
         next_map = raw_next_map.split(": ")[1]
 
         return {


### PR DESCRIPTION
Remove unused imports.

Add a `TypedDict` for `Rcon.get_gamestate()` typing and add docstring.

Add `ttl_cache` for methods that rely on `Rcon.get_gamestate()`.

Fix `Rcon.get_gamestate()` so `current_map` doesn't include a leading space.

Rename methods that rely on `Rcon.get_gamestate()` for use in other parts of the backend so they aren't exposed through the API as `get_gamestate()` is called to generate them and they would be redundant.