### PR TITLE
Clean up and adapt public_info for new data

### DIFF
--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -862,7 +862,7 @@ class Rcon(ServerCtl):
         super().set_broadcast(formatted)
         return prev.decode() if prev else ""
 
-    @ttl_cache(ttl=20)
+    @ttl_cache(ttl=5)
     def get_slots(self):
         res = super().get_slots()
         if not self.slots_regexp.match(res):

--- a/rcon/scorebot.py
+++ b/rcon/scorebot.py
@@ -95,7 +95,7 @@ def get_header_embed(public_info):
 
     embed = discord.Embed(
         title=f"{public_info['name']}",
-        description=f"**{public_info['current_map']['human_name']} - {ELAPSED_TIME}{round(elapsed_time_minutes)} min. - {public_info['nb_players']} {PLAYERS}**",
+        description=f"**{public_info['current_map']['human_name']} - {ELAPSED_TIME}{round(elapsed_time_minutes)} min. - {public_info['player_count']}/{public_info['max_player_count']} {PLAYERS}**",
         color=13734400,
         timestamp=datetime.datetime.utcnow(),
         url=SCOREBOARD_PUBLIC_URL,
@@ -106,7 +106,7 @@ def get_header_embed(public_info):
         winning_map_votes = public_info["vote_status"]["winning_maps"][0][1]
 
     embed.add_field(
-        name=f"{NEXT_MAP_TEXT} {public_info['next_map']}",
+        name=f"{NEXT_MAP_TEXT} {public_info['next_map']['human_name']}",
         value=f"{winning_map_votes}/{total_votes} {VOTE}",
     )
     embed.set_author(

--- a/rcongui/src/components/Embeds/ServerInfo.js
+++ b/rcongui/src/components/Embeds/ServerInfo.js
@@ -103,7 +103,7 @@ const ServerInfo = ({ classes }) => {
       ?.get("winning_maps")
       ?.get(0) || ["", 0];
     const totalVotes = serverState.get("vote_status")?.get("total_votes");
-    const nextMap = serverState.get("next_map");
+    const nextMap = serverState.get("next_map")?.get("name");
 
     if (map === nextMap) {
       return `Nextmap ${nextMap} ${nbVotes}/${totalVotes} votes`;
@@ -133,7 +133,7 @@ const ServerInfo = ({ classes }) => {
         />
         <GridListTileBar
           className={styles.titleBarBottom}
-          title={`Time: ${started} - Players: ${serverState.get("nb_players")}`}
+          title={`Time: ${started} - Players: ${serverState.get("player_count")}/${serverState.get("max_player_count")}`}
           subtitle={nextMapString}
           titlePosition="bottom"
         />

--- a/rcongui/src/components/Scoreboard/LiveScore.js
+++ b/rcongui/src/components/Scoreboard/LiveScore.js
@@ -256,7 +256,7 @@ const LiveHeader = ({
       ?.get("winning_maps")
       ?.get(0) || ["", 0];
     const totalVotes = serverState.get("vote_status")?.get("total_votes");
-    const nextMap = serverState.get("next_map");
+    const nextMap = serverState.get("next_map")?.get("name");
 
     if (map === nextMap) {
       return `Nextmap ${nextMap} with ${nbVotes} out of ${totalVotes} votes`;
@@ -317,9 +317,7 @@ const LiveHeader = ({
             />
             <GridListTileBar
               className={styles.titleBarBottom}
-              title={`Elapsed: ${started} - Players: ${serverState.get(
-                "nb_players"
-              )}`}
+              title={`Elapsed: ${started} - Players: ${serverState.get("player_count")}/${serverState.get("max_player_count")}`}
               subtitle={nextMapString}
               titlePosition="bottom"
             />

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -82,30 +82,44 @@ def get_version(request):
 
 @csrf_exempt
 def public_info(request):
-    status = ctl.get_status()
+    gamestate = ctl.get_gamestate()
+    curr_players, max_players = tuple(map(int, ctl.get_slots().split("/")))
     try:
-        current_map = MapsHistory()[0]
+        current_map_start = MapsHistory(max_len=1)[0]["start"]
     except IndexError:
         logger.error("Can't get current map time, map_recorder is probably offline")
-        current_map = {"name": status["map"], "start": None, "end": None}
-    current_map = dict(
-        just_name=map_name(current_map["name"]),
-        human_name=LONG_HUMAN_MAP_NAMES.get(current_map["name"], current_map["name"]),
-        **current_map,
-    )
-    vote_status = get_votes_status(none_on_fail=True)
-    next_map = ctl.get_next_map()
+        current_map_start = None
+
+    def explode_map_info(game_map: str, start) -> dict:
+        return dict(
+            just_name = map_name(game_map),
+            human_name = LONG_HUMAN_MAP_NAMES.get(game_map, game_map),
+            name = game_map,
+            start = start
+        )
+
     return api_response(
-        result=dict(
-            current_map=current_map,
-            **status,
-            vote_status=vote_status,
-            next_map=next_map,
+        result = dict(
+            current_map = explode_map_info(gamestate["current_map"], current_map_start),
+            next_map = explode_map_info(ctl.get_next_map(), None),
+            player_count = curr_players,
+            max_player_count = max_players,
+            players = dict(
+                allied = gamestate["num_allied_players"],
+                axis = gamestate["num_axis_players"]
+            ),
+            score = dict(
+                allied = gamestate["allied_score"],
+                axis = gamestate["axis_score"]
+            ),
+            vote_status = get_votes_status(none_on_fail=True),
+            name = ctl.get_name(),
+            short_name = os.getenv("SERVER_SHORT_NAME", "HLL RCON"),
             public_stats_port=os.getenv('PUBLIC_STATS_PORT', "Not defined"),
             public_stats_port_https=os.getenv('PUBLIC_STATS_PORT_HTTPS', "Not defined")
         ),
-        failed=False,
-        command="public_info",
+        failed = False,
+        command = "public_info",
     )
 
 

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -92,34 +92,34 @@ def public_info(request):
 
     def explode_map_info(game_map: str, start) -> dict:
         return dict(
-            just_name = map_name(game_map),
-            human_name = LONG_HUMAN_MAP_NAMES.get(game_map, game_map),
-            name = game_map,
-            start = start
+            just_name=map_name(game_map),
+            human_name=LONG_HUMAN_MAP_NAMES.get(game_map, game_map),
+            name=game_map,
+            start=start
         )
 
     return api_response(
         result = dict(
-            current_map = explode_map_info(gamestate["current_map"], current_map_start),
-            next_map = explode_map_info(ctl.get_next_map(), None),
-            player_count = curr_players,
-            max_player_count = max_players,
-            players = dict(
-                allied = gamestate["num_allied_players"],
-                axis = gamestate["num_axis_players"]
+            current_map=explode_map_info(gamestate["current_map"], current_map_start),
+            next_map=explode_map_info(ctl.get_next_map(), None),
+            player_count=curr_players,
+            max_player_count=max_players,
+            players=dict(
+                allied=gamestate["num_allied_players"],
+                axis=gamestate["num_axis_players"]
             ),
-            score = dict(
-                allied = gamestate["allied_score"],
-                axis = gamestate["axis_score"]
+            score=dict(
+                allied=gamestate["allied_score"],
+                axis=gamestate["axis_score"]
             ),
-            vote_status = get_votes_status(none_on_fail=True),
-            name = ctl.get_name(),
-            short_name = os.getenv("SERVER_SHORT_NAME", "HLL RCON"),
+            vote_status=get_votes_status(none_on_fail=True),
+            name=ctl.get_name(),
+            short_name=os.getenv("SERVER_SHORT_NAME", "HLL RCON"),
             public_stats_port=os.getenv('PUBLIC_STATS_PORT', "Not defined"),
             public_stats_port_https=os.getenv('PUBLIC_STATS_PORT_HTTPS', "Not defined")
         ),
-        failed = False,
-        command = "public_info",
+        failed=False,
+        command="public_info",
     )
 
 


### PR DESCRIPTION
Include the newly available information (via the `gamestate` command) into the data returned by public_info.

Unfortunately the `time_remaining` does not really contain useful information (not even sure what the game-server will return for this value on offensive maps).
Therefore the cumbersome way of loading the start time of the current map via the MapsHistory is still included.

Furthermore redundant fields are removed and additional information for the `next_map` is included.

Removed the `nb_players` field and instead added the `max_player_count` field.