### PR TITLE
Increase restart attempts for scorebot service

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -57,7 +57,7 @@ autostart=true
 [program:scorebot]
 command=python -m rcon.scorebot
 environment=LOGGING_FILENAME=scorebot_%(ENV_SERVER_NUMBER)s.log
-startretries=10
+startretries=24
 startsecs=10
 autostart=true
 


### PR DESCRIPTION
Scorebot depends on the backend being started and responsive but starts much more quickly than the backend does.

With 10 attempts scorebot will always end up in a fatal state on an RCON restart or initial start.

Increasing restart attempts to 24 will allow scorebot to start automatically when starting/restarting RCON, it will attempt to start for ~5 minutes with the progressive back off times used by supervisord.

[As documented here](http://supervisord.org/subprocess.html#process-states) 

   > Retries will take increasingly more time depending on the number of subsequent attempts made, adding one second each time.
   >
   > So if you set startretries=3, supervisord will wait one, two and then three seconds between each restart attempt, for a total of 5 seconds.```

I tested the change on our server and with it scorebot is able to start automatically after a restart.