### PR TITLE
Fix frontend entrypoint

### DIFF
--- a/rcongui/entrypoint.sh
+++ b/rcongui/entrypoint.sh
@@ -6,9 +6,9 @@ then
     exit 0
 fi
 
-if [ ! -f "/certs/cert.crt" || ! -f "/certs/key.key" ]; then
-echo "No certificates found. Generating self signed"
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /certs/key.key -out /certs/cert.crt -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=$RCONWEB_EXTERNAL_ADDRESS" 
+if [ ! -f "/certs/cert.crt" ] || [ ! -f "/certs/key.key" ]; then
+    echo "No certificates found. Generating self signed"
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /certs/key.key -out /certs/cert.crt -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=$RCONWEB_EXTERNAL_ADDRESS" 
 fi
 
 nginx -g "daemon off;"


### PR DESCRIPTION
it's either bash:
```
[[ ! -f "/certs/cert.crt" || ! -f "/certs/key.key" ]]
```
or shell:
```
[ ! -f "/certs/cert.crt" ] || [ ! -f "/certs/key.key" ]
```
but not a combination of both.