### PR TITLE
Hotfix/message log line

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -375,7 +375,12 @@ class ServerCtl:
     def do_switch_player_now(self, player):
         return self._request(f"switchteamnow {player}", log_info=True)
 
-    def do_add_map_to_rotation(self, map_name: str, after_map_name: str = None, after_map_name_number: str = None):
+    def do_add_map_to_rotation(
+        self,
+        map_name: str,
+        after_map_name: str = None,
+        after_map_name_number: str = None,
+    ):
         cmd = f"rotadd {map_name}"
         if after_map_name:
             cmd = f"{cmd} {after_map_name}"
@@ -447,7 +452,7 @@ class ServerCtl:
     @_escape_params
     def do_message_player(self, player_name=None, steam_id_64=None, message=""):
         return self._request(
-            f'message "{steam_id_64 or player_name}" "{message}"',
+            f'message "{steam_id_64 or player_name}" {message}',
             log_info=True,
         )
 

--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -805,7 +805,7 @@ class Rcon(ServerCtl):
         if not self.map_regexp.match(current_map):
             raise CommandFailedError("Server returned wrong data")
 
-        return current_map.replace("_RESTART", "")
+        return current_map
 
     @mod_users_allowed
     @ttl_cache(ttl=60 * 60)

--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -48,6 +48,7 @@ LOG_ACTIONS = [
     "MATCH",
     "MATCH START",
     "MATCH ENDED",
+    "MESSAGE",
 ]
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,10 @@ class GameState(TypedDict):
     current_map: str
     next_map: str
 
+
 MOD_ALLOWED_CMDS = set()
+
+
 def mod_users_allowed(func):
     """Wrapper to flag a method as something that moderator
     accounts are allowed to use.
@@ -653,7 +657,6 @@ class Rcon(ServerCtl):
         bans = self.get_bans()
         return list(filter(lambda x: x.get("steam_id_64") == steam_id_64, bans))
 
-
     @mod_users_allowed
     @ttl_cache(ttl=60 * 60)
     def get_vip_ids(self) -> List[Dict[str, Union[str, Optional[datetime]]]]:
@@ -801,7 +804,8 @@ class Rcon(ServerCtl):
         current_map = super().get_map()
         if not self.map_regexp.match(current_map):
             raise CommandFailedError("Server returned wrong data")
-        return current_map
+
+        return current_map.replace("_RESTART", "")
 
     @mod_users_allowed
     @ttl_cache(ttl=60 * 60)
@@ -1126,9 +1130,13 @@ class Rcon(ServerCtl):
                 raise CommandFailedError("Server return wrong data")
         return l
 
-    def do_add_map_to_rotation(self, map_name, after_map_name: str = None, after_map_name_number: str = None):
+    def do_add_map_to_rotation(
+        self, map_name, after_map_name: str = None, after_map_name_number: str = None
+    ):
         with invalidates(Rcon.get_map_rotation):
-            super().do_add_map_to_rotation(map_name, after_map_name, after_map_name_number)
+            super().do_add_map_to_rotation(
+                map_name, after_map_name, after_map_name_number
+            )
 
     def do_remove_map_from_rotation(self, map_name, map_number: str = None):
         with invalidates(Rcon.get_map_rotation):
@@ -1350,6 +1358,15 @@ class Rcon(ServerCtl):
                 elif rest.upper().startswith("MATCH ENDED"):
                     action = "MATCH ENDED"
                     _, sub_content = rest.split("MATCH ENDED ")
+                elif rest.upper().startswith("MESSAGE"):
+
+                    action = "MESSAGE"
+                    groups = re.match(
+                        r"MESSAGE: player \[(.+)\((\d+)\)\], content \[(.+)\]", rest
+                    ).groups()
+                    player, steam_id_64_1, content = groups
+                    content = f"{player}({steam_id_64_1}): {content}"
+
                 else:
                     logger.error("Unkown type line: '%s'", line)
                     continue


### PR DESCRIPTION
Removes quotes from `do_message_player` raw command that is sent to the game server.

Trim `_RESTART` from map names

Add `MESSAGE` log type to log actions and add support for parsing