### PR TITLE
do not overwrite map rotation with vote map when vote map is not enabled

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -59,11 +59,11 @@ def count_vote(rcon: RecordedRcon, struct_log: StructuredLogLine):
 
 
 def initialise_vote_map(rcon: RecordedRcon, struct_log):
-    logger.info("New match started initilising vote map. %s", struct_log)
     config = VoteMapConfig()
     if not config.get_vote_enabled():
         return
 
+    logger.info("New match started initilising vote map. %s", struct_log)
     try:
         vote_map = VoteMap()
         vote_map.clear_votes()

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -60,6 +60,10 @@ def count_vote(rcon: RecordedRcon, struct_log: StructuredLogLine):
 
 def initialise_vote_map(rcon: RecordedRcon, struct_log):
     logger.info("New match started initilising vote map. %s", struct_log)
+    config = VoteMapConfig()
+    if not config.get_vote_enabled():
+        return
+
     try:
         vote_map = VoteMap()
         vote_map.clear_votes()

--- a/rcon/vote_map.py
+++ b/rcon/vote_map.py
@@ -329,7 +329,7 @@ class VoteMap:
         if not config.get_vote_enabled():
             rcon.do_message_player(
                 steam_id_64=steam_id_64_1,
-                message="Vote map is not enabled on thi server",
+                message="Vote map is not enabled on this server",
             )
             return
 
@@ -603,6 +603,9 @@ class VoteMap:
 
     def apply_results(self):
         config = VoteMapConfig()
+        if not config.get_vote_enabled():
+            return
+
         votes = self.get_votes()
         first = Counter(votes.values()).most_common(1)
         if not first:


### PR DESCRIPTION
On a match start event, vote map is initialised and applied. Applying vote map settings should, however, only be done when the vote map feature is actually enable.d