### PR TITLE
Hotfix/votemap messaging2

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 @on_chat
 def count_vote(rcon: RecordedRcon, struct_log: StructuredLogLine):
     enabled = VoteMap().handle_vote_command(rcon=rcon, struct_log=struct_log)
-    if enabled and (match := re.match(r"\d", struct_log["sub_content"].strip())):
+    if enabled and (match := re.match(r"\d\s*$", struct_log["sub_content"].strip())):
         rcon.do_message_player(
             steam_id_64=struct_log["steam_id_64_1"],
             message=f"INVALID VOTE\n\nUse: !votemap {match.group()}",

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -50,18 +50,18 @@ logger = logging.getLogger(__name__)
 
 @on_chat
 def count_vote(rcon: RecordedRcon, struct_log: StructuredLogLine):
-    VoteMap().handle_vote_command(rcon=rcon, struct_log=struct_log)
-    if match := re.match(r"\d", struct_log["sub_content"].strip()):
+    enabled = VoteMap().handle_vote_command(rcon=rcon, struct_log=struct_log)
+    if enabled and (match := re.match(r"\d", struct_log["sub_content"].strip())):
         rcon.do_message_player(
             steam_id_64=struct_log["steam_id_64_1"],
-            message=f"INVALID VOTE\n\nUse: !votemap {match.group()}"
+            message=f"INVALID VOTE\n\nUse: !votemap {match.group()}",
         )
 
 
 def initialise_vote_map(rcon: RecordedRcon, struct_log):
     config = VoteMapConfig()
 
-    logger.info("New match started initilising vote map. %s", struct_log)
+    logger.info("New match started initializing vote map. %s", struct_log)
     try:
         vote_map = VoteMap()
         vote_map.clear_votes()
@@ -70,6 +70,7 @@ def initialise_vote_map(rcon: RecordedRcon, struct_log):
         vote_map.apply_results()
     except:
         logger.exception("Something went wrong in vote map init")
+
 
 @on_match_end
 def remind_vote_map(rcon: RecordedRcon, struct_log):

--- a/rcon/user_config.py
+++ b/rcon/user_config.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql.expression import false, true
 
 from rcon.commands import CommandFailedError
 from rcon.models import UserConfig, enter_session
+from rcon.cache_utils import ttl_cache, invalidates
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ def _get_conf(sess, key):
     return sess.query(UserConfig).filter(UserConfig.key == key).one_or_none()
 
 
-def get_user_config(key, default=None):
+def get_user_config(key, default=None) -> bool:
     logger.debug("Getting user config for %s", key)
     with enter_session() as sess:
         res = _get_conf(sess, key)
@@ -315,7 +316,8 @@ class VoteMapConfig:
         return set_user_config(self.VOTEMAP_NO_VOTE_TEXT, value)
 
     def set_vote_enabled(self, value):
-        return set_user_config(self.VOTE_ENABLED, bool(value))
+        with invalidates(VoteMapConfig.get_vote_enabled):
+            return set_user_config(self.VOTE_ENABLED, bool(value))
 
     def set_votemap_number_of_options(self, value):
         return set_user_config(self.VOTEMAP_NUMBER_OF_OPTIONS, int(value))
@@ -364,7 +366,8 @@ class VoteMapConfig:
     def get_votemap_no_vote_text(self):
         return get_user_config(self.VOTEMAP_NO_VOTE_TEXT)
 
-    def get_vote_enabled(self):
+    @ttl_cache(ttl=60, cache_falsy=True)
+    def get_vote_enabled(self) -> bool:
         return get_user_config(self.VOTE_ENABLED)
 
     def get_votemap_number_of_options(self):


### PR DESCRIPTION
Invalid vote messages were appearing for any chat message that started with a number even with map voting disabled.

Prevents this and caches the map vote settings since it is now checked for every chat message.

Fix a spelling mistake.

Maybe we want to bump the cache time to longer than 60 seconds?

Built and tested on our event server and it still registers votes, we don't use the map vote feature so I am unfamiliar with it but I do not think I broke it.

