### PR TITLE
Hotfix/django migrations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ then
   ./manage.py init_db
   ./manage.py register_api
   cd rconweb 
+  ./manage.py makemigrations --no-input
   ./manage.py migrate --noinput
   ./manage.py collectstatic --noinput
   echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin') if not User.objects.filter(username='admin').first() else None" | python manage.py shell

--- a/rconweb/api/models.py
+++ b/rconweb/api/models.py
@@ -8,6 +8,7 @@ class SteamPlayer(models.Model):
 
 
 class RconUser(User):
+    """api_rconuser table"""
     class Meta:
         permissions = (
             ("can_not_change_server_settings", "Can NOT Change Server Settings"),

--- a/rconweb/entrypoint.sh
+++ b/rconweb/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-
-python manage.py makemigrations --no-input
-python manage.py migrate --no-input
-python manage.py collectstatic --no-input
-echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'admin')" | python manage.py shell
-gunicorn -w 4 -b 0.0.0.0 rconweb.wsgi


### PR DESCRIPTION
Removes the unused `rconweb/entrypoint.sh` and adds creation of Django migrations to the root `entrypoint.sh`

The `api_rconuser` relation which correlates to `RconUser` in `rconweb.api.models` migration was not being generated which was blocking the deletion of user accounts from the Admin panel.