### PR TITLE
Adjust auto settings default to be inline with changed command

### DIFF
--- a/config/auto_settings.default.json
+++ b/config/auto_settings.default.json
@@ -84,7 +84,7 @@
     "do_remove_map_from_rotation": { "map_name": "stmariedumont_warfare" },
     "do_remove_maps_from_rotation": { "maps": ["stmariedumont_warfare", "kursk_offensive_rus"] },
     "do_randomize_map_rotation": { "maps": ["An optional list of maps", "that will replace the current rotation"] },
-    "set_maprotation": { "maps": ["Overwrites the current rotation", "Yes the spelling is intentional"] },
+    "set_maprotation": { "rotation": ["Overwrites the current rotation", "Yes the spelling is intentional"] },
     "do_punish": { "player": "12345678901234567", "reason": "Get rekt" },
     "do_kick": { "player": "12345678901234567", "reason": "Get rekt" },
     "do_temp_ban": {


### PR DESCRIPTION
This will reduce confusion for users setting up CRCON in the future.

Users that have it already set up will be confused, since they probably have the default config still included in their autosettings (at least we do) which indicates another variation of the `set_maprotation` command.

[Regarding this commit](https://github.com/MarechJ/hll_rcon_tool/commit/8ed7dd278dfc8f24183a0b9f91df6dbfcf98d1bc)