### PR TITLE
Fix get player

### DIFF
--- a/rcon/auto_settings.py
+++ b/rcon/auto_settings.py
@@ -257,7 +257,7 @@ def run():
                 rule_matched = True
                 if can_invoke_multiple_rules:
                     logger.info(
-                        f"Rule validation succeded, moving to next one. ({can_invoke_multiple_rules})"
+                        f"Rule validation succeded, moving to next one. ({can_invoke_multiple_rules=})"
                     )
                     continue
                 else:

--- a/rconweb/api/history.py
+++ b/rconweb/api/history.py
@@ -56,12 +56,18 @@ def get_map_history(request):
 def get_player(request):
     data = _get_data(request)
     res = {}
+
+    try:
+        nb_sessions = int(data.get("nb_sessions", 10))
+    except ValueError:
+        nb_sessions = 10
+
     try:
         if s := data.get("steam_id_64"):
-            res = get_player_profile(s, nb_sessions=data.get("nb_sessions", 10))
+            res = get_player_profile(s, nb_sessions=nb_sessions)
         else:
             res = get_player_profile_by_id(
-                data["id"], nb_sessions=data.get("nb_sessions", 10)
+                data["id"], nb_sessions=nb_sessions
             )
         failed = False
     except:


### PR DESCRIPTION
In the current iteration the request `/api/player?steam_id_64=76543219876543210&nb_sessions=20` does not work since the provided `nb_sessions` value is interpreted as string