### PR TITLE
Fix rcon mod wrongfully considering kill as "during seeding"

### DIFF
--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -119,6 +119,7 @@ def punish_squads(rcon: RecordedRcon):
     punitions_to_apply = get_punitions_to_apply(rcon, mods)
 
     do_punitions(rcon, punitions_to_apply)
+    global first_run_done
     first_run_done = True
 
 

--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -23,6 +23,7 @@ from rcon.automods.no_leader import NoLeaderAutomod
 from rcon.automods.seeding_rules import SeedingRulesAutomod
 
 logger = logging.getLogger(__name__)
+first_run_done = False
 
 
 def get_punitions_to_apply(rcon, moderators) -> PunitionsToApply:
@@ -118,6 +119,7 @@ def punish_squads(rcon: RecordedRcon):
     punitions_to_apply = get_punitions_to_apply(rcon, mods)
 
     do_punitions(rcon, punitions_to_apply)
+    first_run_done = True
 
 
 def audit(discord_webhook_url: str, msg: str, author: str):
@@ -127,6 +129,9 @@ def audit(discord_webhook_url: str, msg: str, author: str):
 
 @on_kill
 def on_kill(rcon: RecordedRcon, log: StructuredLogLine):
+    if not first_run_done:
+        logger.debug("Kill event received, but not automod run done yet, giving mods time to warmup")
+        return
     mods = enabled_moderators()
     if len(mods) == 0:
         logger.debug("No automod is enabled")
@@ -147,6 +152,9 @@ pendingTimers = {}
 @on_connected
 @inject_player_ids
 def on_connected(rcon: RecordedRcon, _, name: str, steam_id_64: str):
+    if not first_run_done:
+        logger.debug("Kill event received, but not automod run done yet, giving mods time to warmup")
+        return
     mods = enabled_moderators()
     if len(mods) == 0:
         logger.debug("No automod is enabled")


### PR DESCRIPTION
In rare cases, the rcon tool might not yet recognized that the server reached enough population to disable seeding rules (something around 2-7 seconds, depending on how long it takes for the first call to get_team_view).

Kills during this time are handled by an event, while the seeding automod assumes the server did not reach the seeding threshold yet. This might result in kills being punished as they were made with a seeding-disallowed-weapon, despite the server having enough players.

This commit fixes this by giving automods generally a bit of time after restaret of the rcon tool to warmup. This might defer or miss enforcements on some kills, but at least no-one is punished wrongfully.