### PR TITLE
Do not record duplicated player sessions

### DIFF
--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -352,10 +352,22 @@ def save_start_player_session(
             )
             return
 
+        start_time = datetime.datetime.fromtimestamp(timestamp)
+        already_saved = (
+            sess.query(PlayerSession)
+            .filter(PlayerSession.steamid == player)
+            .filter(PlayerSession.start == start_time)
+            .first()
+        )
+
+        if already_saved is not None:
+            logger.info(f"Player session starting at {start_time} for player {steam_id_64} already recorded, skipping...")
+            return
+
         sess.add(
             PlayerSession(
                 steamid=player,
-                start=datetime.datetime.fromtimestamp(timestamp),
+                start=start_time,
                 server_name=server_name,
                 server_number=server_number,
             )


### PR DESCRIPTION
Hooks might be called twice (when the log event loop crashes or gets restarted for another reason while processing hooks). There should never be a reason to save the same player session twice, anyway.