### PR TITLE
Reduce resulting image size of frontend image by utilising multi-stage build

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -1,9 +1,6 @@
-FROM node:15-stretch
+FROM node:15-stretch as build
 
 WORKDIR /code
-
-RUN apt-get update -y && apt-get install -y nginx apache2-utils
-
 
 RUN mkdir /pw
 
@@ -17,25 +14,25 @@ ENV REACT_APP_API_URL /api/
 COPY rcongui/src/ src/
 COPY rcongui/public/ public/
 
-
 COPY .git/ .git/
 RUN npx browserslist@latest --update-db
 # Normal build
 RUN npm run build
 
-RUN mv /code/build /var/www/
+RUN mv /code/build /www
 # Public build
 ENV REACT_APP_PUBLIC_BUILD on
 RUN npm run build
-RUN mkdir /var/www_public/
-RUN mv /code/build /var/www_public/
+RUN mv /code/build /www_public
 
-RUN rm -rf src/
-RUN rm -rf public/
-RUN rm -rf node_modules/
+FROM nginx:mainline-alpine
 
-COPY rcongui/nginx.conf /etc/nginx/sites-available/default
+COPY rcongui/nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /var/www
+
+RUN mkdir /var/www_public/
+COPY --from=build /www_public /var/www_public/
+COPY --from=build /www /var/www/
 
 VOLUME /certs
 COPY rcongui/entrypoint.sh /code/entrypoint.sh

--- a/Dockerfile-frontend-arm32
+++ b/Dockerfile-frontend-arm32
@@ -1,44 +1,37 @@
-FROM arm32v7/node:15-stretch
+FROM arm32v7/node:15-stretch as build
 
 WORKDIR /code
-
-RUN apt-get update -y && apt-get install -y nginx apache2-utils
-
 
 RUN mkdir /pw
 
 COPY rcongui/package.json package.json
 COPY rcongui/package-lock.json package-lock.json
 
-
-ENV GENERATE_SOURCEMAP false
-
 RUN npm ci
-
 
 ENV REACT_APP_API_URL /api/
 
 COPY rcongui/src/ src/
 COPY rcongui/public/ public/
 
-
 COPY .git/ .git/
 # Normal build
 RUN npm run build
 
-RUN mv /code/build /var/www/
+RUN mv /code/build /www/
 # Public build
 ENV REACT_APP_PUBLIC_BUILD on
 RUN npm run build
-RUN mkdir /var/www_public/
-RUN mv /code/build /var/www_public/
+RUN mv /code/build /www_public/
 
-RUN rm -rf src/
-RUN rm -rf public/
-RUN rm -rf node_modules/
+FROM arm32v7/nginx:mainlaine-alpine
 
-COPY rcongui/nginx.conf /etc/nginx/sites-available/default
+COPY rcongui/nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /var/www
+
+RUN mkdir /var/www_public/
+COPY --from=build /www_public /var/www_public/
+COPY --from=build /www /var/www/
 
 VOLUME /certs
 COPY rcongui/entrypoint.sh /code/entrypoint.sh

--- a/Dockerfile-frontend-arm64
+++ b/Dockerfile-frontend-arm64
@@ -1,8 +1,6 @@
-FROM arm64v8/node:15-stretch
+FROM arm64v8/node:15-stretch as build
 
 WORKDIR /code
-
-RUN apt-get update -y && apt-get install -y nginx apache2-utils
 
 RUN mkdir /pw
 
@@ -16,24 +14,24 @@ ENV REACT_APP_API_URL /api/
 COPY rcongui/src/ src/
 COPY rcongui/public/ public/
 
-
 COPY .git/ .git/
 # Normal build
 RUN npm run build
 
-RUN mv /code/build /var/www/
+RUN mv /code/build /www
 # Public build
 ENV REACT_APP_PUBLIC_BUILD on
 RUN npm run build
-RUN mkdir /var/www_public/
-RUN mv /code/build /var/www_public/
+RUN mv /code/build /www_public
 
-RUN rm -rf src/
-RUN rm -rf public/
-RUN rm -rf node_modules/
+FROM arm64v8/nginx:mainline-alpine
 
-COPY rcongui/nginx.conf /etc/nginx/sites-available/default
+COPY rcongui/nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /var/www
+
+RUN mkdir /var/www_public/
+COPY --from=build /www_public /var/www_public/
+COPY --from=build /www /var/www/
 
 VOLUME /certs
 COPY rcongui/entrypoint.sh /code/entrypoint.sh

--- a/rcongui/entrypoint.sh
+++ b/rcongui/entrypoint.sh
@@ -1,5 +1,7 @@
-#!/usr/bin/env bash
-  
+#!/usr/bin/env sh
+
+export REACT_APP_VERSION=$(cat /code/tag_version)
+
 if [ "$HLL_HOST" == '' ] 
 then
     $echo "HLL_HOST is not set. stopping"

--- a/rcongui/nginx.conf
+++ b/rcongui/nginx.conf
@@ -42,7 +42,7 @@ server {
         #
         # include snippets/snakeoil.conf;
 
-        root /var/www/build;
+        root /var/www;
 
         # Add index.php to the list if you are using PHP
         index index.html index.htm index.nginx-debian.html;
@@ -119,7 +119,7 @@ server {
         #
         # include snippets/snakeoil.conf;
 
-        root /var/www_public/build;
+        root /var/www_public;
 
         # Add index.php to the list if you are using PHP
         index index.html index.htm index.nginx-debian.html;


### PR DESCRIPTION
Locally, the multi-stages are still cached, the resulting image size is reduced (on my machine) from 1.6 GB to around 75MB.

I tested the amd64 image, only, not the ARM ones, however, they should be fairly the same, if anyone else can test them, though? 🤔 