### PR TITLE
do not load new team_view before time after "old" team_view request expired

### DIFF
--- a/rcongui/src/components/GameView/index.js
+++ b/rcongui/src/components/GameView/index.js
@@ -478,8 +478,13 @@ const GameView = ({ classes: globalClasses }) => {
   };
 
   const myInterval = React.useMemo(() => (func, ms) => {
-    const handle = setTimeout(() => {
-      func().then(() => myInterval(func, ms)).catch(() => myInterval(func, ms));
+    const handle = setTimeout(async () => {
+      try {
+        await func();
+      } catch (e)  {
+        console.warn('Error in periodic refresh', e);
+      }
+      myInterval(func, ms);
     }, ms);
     setIntervalHandle(handle);
   }, []);

--- a/rcongui/src/components/GameView/index.js
+++ b/rcongui/src/components/GameView/index.js
@@ -466,7 +466,7 @@ const GameView = ({ classes: globalClasses }) => {
 
   const loadData = () => {
     setIsLoading(true);
-    get("get_team_view")
+    return get("get_team_view")
       .then((response) => showResponse(response, "get_team_view"))
       .then((data) => {
         setIsLoading(false);
@@ -479,8 +479,7 @@ const GameView = ({ classes: globalClasses }) => {
 
   const myInterval = React.useMemo(() => (func, ms) => {
     const handle = setTimeout(() => {
-      func();
-      return myInterval(func, ms);
+      func().then(() => myInterval(func, ms)).catch(() => myInterval(func, ms));
     }, ms);
     setIntervalHandle(handle);
   }, []);


### PR DESCRIPTION
When the team_view takes longer than the configured refresh interval, it might result in requests to server piling up. As this is pretty pointless, simply wait until the response is there and _then_ schedule the next interval.