### PR TITLE
Update frontend Dockerfile to install openssl due to switch to alpine…

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -27,6 +27,7 @@ RUN mv /code/build /www_public
 
 FROM nginx:mainline-alpine
 
+RUN apk add openssl
 COPY rcongui/nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /var/www
 


### PR DESCRIPTION
`openssl` is not installed by default on `alpine` which is now being used for the `nginx` image for the frontend.