### PR TITLE
When reading log list, use the same connection (where the data resides)

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -428,7 +428,7 @@ class ServerCtl:
     def get_logs(self, since_min_ago, filter_="", conn: HLLConnection = None):
         if conn is None:
             raise ValueError("conn parameter should never be None")
-        res = self._request(f"showlog {since_min_ago}")
+        res = self._request(f"showlog {since_min_ago}", conn=conn)
         if res == "EMPTY":
             return ""
         for i in range(30):


### PR DESCRIPTION
Otherwise, a connection is returned to the pool with still having data that is not read from the socket, or it tries to read data from a command of one connection from a new connection, which cannot work :D