### PR TITLE
Do not throw away connection on FAIL

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -274,7 +274,7 @@ class ServerCtl:
 
         if (decode and result == "FAIL") or (not decode and result == b"FAIL"):
             if can_fail:
-                raise BrokenHllConnection() from CommandFailedError(command)
+                raise CommandFailedError(command)
             else:
                 raise HLLServerError(f"Got FAIL for {command}")
 


### PR DESCRIPTION
When the game server returns a FAIL, this usually does not mean that the connection itself is broken, hence it should not be discarded.

This also fixes the set_map logic that ensures that the map is in the rotation if changing the map fails.