### PR TITLE
Fix announcing seeding rules on connect

### DIFF
--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -3,6 +3,8 @@ import time
 from threading import Timer
 from typing import List
 
+from redis.client import Redis
+
 from rcon.automods.models import (
     ActionMethod,
     NoLeaderConfig,
@@ -23,7 +25,6 @@ from rcon.settings import SERVER_INFO
 from rcon.types import StructuredLogLineType
 
 logger = logging.getLogger(__name__)
-red = get_redis_client()
 first_run_done_key = "first_run_done"
 
 
@@ -46,10 +47,10 @@ def get_punitions_to_apply(rcon, moderators) -> PunitionsToApply:
 
 
 def _do_punitions(
-    rcon: RecordedRcon,
-    method: ActionMethod,
-    players: List[PunishPlayer],
-    mods,
+        rcon: RecordedRcon,
+        method: ActionMethod,
+        players: List[PunishPlayer],
+        mods,
 ):
     for aplayer in players:
         try:
@@ -127,6 +128,8 @@ def do_punitions(rcon: RecordedRcon, punitions_to_apply: PunitionsToApply):
 
 
 def enabled_moderators():
+    red = get_redis_client()
+
     try:
         config = get_config()
         no_leader_config = NoLeaderConfig(**config["NOLEADER_AUTO_MOD"])
@@ -146,15 +149,15 @@ def enabled_moderators():
     )
 
 
-def is_first_run_done() -> bool:
-    return red.exists(first_run_done_key)
+def is_first_run_done(r: Redis) -> bool:
+    return r.exists(first_run_done_key) == 1
 
 
-def set_first_run_done():
-    red.setex(first_run_done_key, 4 * 60, "1")
+def set_first_run_done(r: Redis):
+    r.setex(first_run_done_key, 4 * 60, "1")
 
 
-def punish_squads(rcon: RecordedRcon):
+def punish_squads(rcon: RecordedRcon, r: Redis):
     mods = enabled_moderators()
     if len(mods) == 0:
         logger.debug("No automod is enabled")
@@ -163,7 +166,7 @@ def punish_squads(rcon: RecordedRcon):
     punitions_to_apply = get_punitions_to_apply(rcon, mods)
 
     do_punitions(rcon, punitions_to_apply)
-    set_first_run_done()
+    set_first_run_done(r)
 
 
 def audit(discord_webhook_url: str, msg: str, author: str):
@@ -175,7 +178,8 @@ def audit(discord_webhook_url: str, msg: str, author: str):
 
 @on_kill
 def on_kill(rcon: RecordedRcon, log: StructuredLogLineType):
-    if not is_first_run_done():
+    red = get_redis_client()
+    if not is_first_run_done(red):
         logger.debug(
             "Kill event received, but not automod run done yet, giving mods time to warmup"
         )
@@ -200,7 +204,8 @@ pendingTimers = {}
 @on_connected
 @inject_player_ids
 def on_connected(rcon: RecordedRcon, _, name: str, steam_id_64: str):
-    if not is_first_run_done():
+    red = get_redis_client()
+    if not is_first_run_done(red):
         logger.debug(
             "Kill event received, but not automod run done yet, giving mods time to warmup"
         )
@@ -239,10 +244,11 @@ def on_connected(rcon: RecordedRcon, _, name: str, steam_id_64: str):
 
 def run():
     rcon = RecordedRcon(SERVER_INFO)
+    red = get_redis_client()
 
     while True:
         try:
-            punish_squads(rcon)
+            punish_squads(rcon, red)
             time.sleep(5)
         except Exception:
             logger.exception("Squad automod: Something unexpected happened")

--- a/rcon/automods/seeding_rules.py
+++ b/rcon/automods/seeding_rules.py
@@ -82,10 +82,10 @@ class SeedingRulesAutomod:
         disallowed_weapons = set(self.config.disallowed_weapons.weapons.values())
 
         if self.config.announce_seeding_active.enabled and (
-            len(disallowed_weapons) != 0 or len(disallowed_weapons) != 0
+            len(disallowed_roles) != 0 or len(disallowed_weapons) != 0
         ):
             if all(
-                [self._is_seeding_rule_disabled(r) is True for r in SEEDING_RULE_NAMES]
+                [self._is_seeding_rule_disabled(r) for r in SEEDING_RULE_NAMES]
             ):
                 return p
 


### PR DESCRIPTION
A global variable set during an automod run is not available when en event from the log event loop is processed. Save this shared state in redis instead.

Also make announcement work when only disallowed roles is configured.