### PR TITLE
Fix reduced permissions moderator accounts

### DIFF
--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -102,7 +102,7 @@ def _can_change_server_settings(user):
 
     Superusers always are able to change server settings, regardles of what other perms
     their account is given."""
-    return user.is_superuser or not user.has_perm("auth.can_not_change_server_settings")
+    return user.is_superuser or not user.has_perm("api.can_not_change_server_settings")
 
 
 @csrf_exempt


### PR DESCRIPTION
Update the moderator account feature to use the correct Django `app label`.

https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.models.User.has_perm

`User.has_perm()` returns False by default and since we're testing the inverse permission this was silently failing.

Built an image and tested it against our event server and it would no longer let me add VIPs so this appears to fix it, I did not do any in-depth testing to verify setting by setting though.