### PR TITLE
Fix log timestamp parsing

### DIFF
--- a/rcon/extended_commands.py
+++ b/rcon/extended_commands.py
@@ -1133,7 +1133,6 @@ class Rcon(ServerCtl):
             else:
                 raise ValueError(f"Unable to parse line: {raw_line}")
         elif raw_line.startswith("KICK") or raw_line.startswith("BAN"):
-
             if "FOR TEAM KILLING" in raw_line:
                 action = "TK AUTO"
 
@@ -1260,8 +1259,8 @@ class Rcon(ServerCtl):
                 log_line = Rcon.parse_log_line(raw_log_line)
                 parsed_log_lines.append(
                     {
-                        "version": 1,
-                        "timestamp_ms": int(time.timestamp() * 1000),
+                        "version": 3,
+                        "timestamp_ms": int(time.timestamp()),
                         "relative_time_ms": (time - now).total_seconds() * 1000,
                         "raw": raw_relative_time + " " + raw_log_line,
                         "line_without_time": raw_log_line,


### PR DESCRIPTION
The Unix epoch timestamp sent from the game server was already milliseconds and we were double converting it which would then break anything that then converted it to a Python datetime because it would exceed the maximum allowed year.

For instance: `[299 ms (1677864556)] TEAMSWITCH Solid Cake (None > Allies` would be stored as `1677864556000` (the year 55,139)  instead of `1677864556`

Bumps the log version.

I did build this and test it against our event server, it is working correctly and the TK auto punish feature now works again.