### PR TITLE
Convert milliseconds to seconds properly

### DIFF
--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -537,7 +537,7 @@ def auto_ban_if_tks_right_after_connection(
                 logger.debug(
                     "Not counting TK as offense due to elapsed time exclusion, last connection time %s, tk time %s",
                     datetime.datetime.fromtimestamp(last_connect_time / 1000),
-                    datetime.datetime.fromtimestamp(log["timestamp_ms"]),
+                    datetime.datetime.fromtimestamp(log["timestamp_ms"] / 1000),
                 )
                 continue
 


### PR DESCRIPTION
Convert milliseconds to seconds, Python will currently throw a `ValueError` because it exceeds the maximum date allowed (on top of being the wrong datetime anyway).

Built and tested on our event server and it does ban people properly now.