### PR TITLE
Print the YAML validation error for easier troubleshooting

### DIFF
--- a/rcon/config.py
+++ b/rcon/config.py
@@ -35,8 +35,9 @@ def get_config():
             user_config = yaml.safe_load(stream=f)
     except FileNotFoundError:
         logger.warning("No user config found, defaults only are loaded")
-    except yaml.YAMLError:
+    except yaml.YAMLError as e:
         logger.error("User config at '%s' is invalid YAML", str(user_config_path))
+        logger.error(e)
 
     config.update(user_config)
     return config


### PR DESCRIPTION
Print the actual YAML validation error when loading invalid YAML so users can troubleshoot easier.

For example:

```
[2023-03-03 19:26:43,343][ERROR] rcon.config config.py:get_config:39 | User config at '/config/config.yml' is invalid YAML
[2023-03-03 19:26:43,343][ERROR] rcon.config config.py:get_config:40 | while scanning for the next token
found character '\t' that cannot start any token
  in "/config/config.yml", line 329, column 38
```