### PR TITLE
Enforce Cap Fight during seeding

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -262,8 +262,8 @@ SEEDING_AUTO_MOD:
   punish_interval_seconds: 60
   # This is the message that will be used in the punish
   # The following variables are available to fill into the text
-  #  {player_name}, {received_punishes}, {max_punishes} and {next_check_seconds}
-  punish_message: "You violated seeding rules on this server.\nYou're being punished by a bot ({received_punishes}/{max_punishes}).\nNext check in {next_check_seconds} seconds"
+  #  {player_name}, {received_punishes}, {max_punishes} and {next_check_seconds}, {violation}
+  punish_message: "You violated seeding rules on this server: {violation}.\nYou're being punished by a bot ({received_punishes}/{max_punishes}).\nNext check in {next_check_seconds} seconds"
 
   # Step number 4
   # Set the below value to false if you don't want to kick players after they reached the max amount of punishes
@@ -327,6 +327,24 @@ SEEDING_AUTO_MOD:
     # The message used when the player is punished.
     #  {weapon}
     message: "{weapon} are not allowed when server is seeding"
+
+  enforce_cap_fight:
+    # the player count of the server needed for this rule to be enforced. The number is inclusive, which means, if you use 5
+    # this rule will be enforced for players 5 to max_players. If there are only 4 players on the server, the rules will
+    # not be enforced.
+    min_players: 5
+    # the player count of the server under which this rule should be enforced. The number is exclusive, which means, if you use 30
+    # this rule will be enforced for players 1 to 29, once the 30 player connected, the rule will not be enforced anymore.
+    max_players: 30
+    # The maximum number of caps a team can have while seeding. When a player gains offensive points while is team has
+    # this number of caps capped, they will be warned/punished by this automod.
+    max_caps: 3
+    # A boolean to indicate if this rule should go straight to punish the player (instead of warn them first). This might be valuable
+    # to enable, as the game will only refresh offensive points (which this rule is based upon) every minute. Capping a point takes 2 minutes in warfare mode.
+    # A player might get warnings, but the damage capping a point with "just" two warnings might justify directly punishing the player.
+    skip_warning: false
+    # The message used when player is punished. There are no parameters available.
+    message: "Attacking 4th cap while seeding is not allowed"
 
 # Set your custom text or transalation for each of the below keys. Logo urls and prefered stats and such
 # If you have more that 3 server copy the whole SERVER_1 section

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -262,7 +262,7 @@ SEEDING_AUTO_MOD:
   punish_interval_seconds: 60
   # This is the message that will be used in the punish
   # The following variables are available to fill into the text
-  #  {player_name}, {received_punishes}, {max_punishes} and {next_check_seconds}, {violation}
+  #  {player_name}, {received_punishes}, {max_punishes}, {next_check_seconds} and {violation}
   punish_message: "You violated seeding rules on this server: {violation}.\nYou're being punished by a bot ({received_punishes}/{max_punishes}).\nNext check in {next_check_seconds} seconds"
 
   # Step number 4

--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -31,6 +31,7 @@ first_run_done_key = "first_run_done"
 def get_punitions_to_apply(rcon, moderators) -> PunitionsToApply:
     logger.debug("Getting team info")
     team_view = rcon.get_team_view()
+    gamestate = rcon.get_gamestate()
     punitions_to_apply = PunitionsToApply()
 
     for team in ["allies", "axis"]:
@@ -40,7 +41,7 @@ def get_punitions_to_apply(rcon, moderators) -> PunitionsToApply:
         for squad_name, squad in team_view[team]["squads"].items():
             for mod in moderators:
                 punitions_to_apply.merge(
-                    mod.punitions_to_apply(team_view, squad_name, team, squad)
+                    mod.punitions_to_apply(team_view, squad_name, team, squad, gamestate)
                 )
 
     return punitions_to_apply

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import field
 from datetime import datetime
 from enum import Enum, auto
-from typing import List, Mapping
+from typing import List, Mapping, TypedDict
 
 from pydantic import validator
 from pydantic.dataclasses import dataclass
@@ -22,8 +22,14 @@ class NoSeedingViolation(Exception):
     pass
 
 
+class OffensiveDefensiveState(TypedDict):
+    offensive_points: int
+    defensive_points: int
+
 @dataclass
 class WatchStatus:
+    offensive_points: Mapping[str, int] = field(default_factory=dict)
+
     noted: Mapping[str, List[datetime]] = field(default_factory=dict)
     warned: Mapping[str, List[datetime]] = field(default_factory=dict)
     punished: Mapping[str, List[datetime]] = field(default_factory=dict)
@@ -142,6 +148,15 @@ class DisallowedWeaponConfig:
 
 
 @dataclass
+class EnforceCapFightConfig:
+    min_players: int = 0
+    max_players: int = 0
+    max_caps: int = 3
+    skip_warning: bool = False
+    message: str = ""
+
+
+@dataclass
 class AnnounceSeedingActiveConfig:
     enabled: bool = False
     message: str = ""
@@ -185,6 +200,9 @@ class SeedingRulesConfig:
     )
     disallowed_weapons: DisallowedWeaponConfig = field(
         default_factory=DisallowedWeaponConfig
+    )
+    enforce_cap_fight: EnforceCapFightConfig = field(
+        default_factory=EnforceCapFightConfig
     )
 
 

--- a/rcon/automods/no_leader.py
+++ b/rcon/automods/no_leader.py
@@ -2,6 +2,7 @@ import logging
 import pickle
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from typing import Literal
 
 import redis
 
@@ -38,7 +39,7 @@ class NoLeaderAutomod:
         return self.config.enabled
 
     def get_message(
-        self, watch_status: WatchStatus, aplayer: PunishPlayer, method: ActionMethod
+            self, watch_status: WatchStatus, aplayer: PunishPlayer, method: ActionMethod
     ):
         data = {}
 
@@ -101,7 +102,7 @@ class NoLeaderAutomod:
             )
 
     def punitions_to_apply(
-        self, team_view, squad_name: str, team: str, squad: dict
+            self, team_view, squad_name: str, team: Literal["axis", "allies"], squad: dict
     ) -> PunitionsToApply:
         punitions_to_apply = PunitionsToApply()
         if not squad_name:
@@ -151,7 +152,7 @@ class NoLeaderAutomod:
                     punitions_to_apply.warning.append(aplayer)
                     punitions_to_apply.add_squad_state(team, squad_name, squad)
                 if (
-                    state == PunishStepState.WAIT
+                        state == PunishStepState.WAIT
                 ):  # only here to make the tests pass, otherwise useless
                     punitions_to_apply.add_squad_state(team, squad_name, squad)
                 if not state in [
@@ -189,7 +190,7 @@ class NoLeaderAutomod:
         return punitions_to_apply
 
     def should_note_player(
-        self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
+            self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
     ):
         if self.config.number_of_notes == 0:
             self.logger.debug("Notes are disabled. number_of_notes is set to 0")
@@ -222,15 +223,15 @@ class NoLeaderAutomod:
         return PunishStepState.GO_TO_NEXT_STEP
 
     def should_warn_player(
-        self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
+            self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
     ):
         if self.config.number_of_warning == 0:
             self.logger.debug("Warnings are disabled. number_of_warning is set to 0")
             return PunishStepState.DISABLED
 
         if (
-            aplayer.lvl <= self.config.immuned_level_up_to
-            or aplayer.role in self.config.immuned_roles
+                aplayer.lvl <= self.config.immuned_level_up_to
+                or aplayer.role in self.config.immuned_roles
         ):
             self.logger.info("%s is immune to warnings", aplayer.short_repr())
             return PunishStepState.IMMUNED
@@ -244,8 +245,8 @@ class NoLeaderAutomod:
             return PunishStepState.WAIT
 
         if (
-            len(warnings) < self.config.number_of_warning
-            or self.config.number_of_warning == -1
+                len(warnings) < self.config.number_of_warning
+                or self.config.number_of_warning == -1
         ):
             self.logger.info(
                 "%s Will be warned (%s/%s)",
@@ -265,19 +266,19 @@ class NoLeaderAutomod:
         return PunishStepState.GO_TO_NEXT_STEP
 
     def should_punish_player(
-        self,
-        watch_status: WatchStatus,
-        team_view,
-        squad_name: str,
-        squad,
-        aplayer: PunishPlayer,
+            self,
+            watch_status: WatchStatus,
+            team_view,
+            squad_name: str,
+            squad,
+            aplayer: PunishPlayer,
     ):
         if self.config.number_of_punish == 0:
             self.logger.debug("Punish is disabled")
             return PunishStepState.DISABLED
 
         if (
-            get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
+                get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
         ) < self.config.disable_punish_below_server_player_count:
             self.logger.debug("Server below min player count for punish")
             return PunishStepState.WAIT
@@ -287,8 +288,8 @@ class NoLeaderAutomod:
             return PunishStepState.WAIT
 
         if (
-            aplayer.lvl <= self.config.immuned_level_up_to
-            or aplayer.role in self.config.immuned_roles
+                aplayer.lvl <= self.config.immuned_level_up_to
+                or aplayer.role in self.config.immuned_roles
         ):
             self.logger.info("%s is immune to punishment", aplayer.short_repr())
             return PunishStepState.IMMUNED
@@ -300,8 +301,8 @@ class NoLeaderAutomod:
             return PunishStepState.WAIT
 
         if (
-            len(punishes) < self.config.number_of_punish
-            or self.config.number_of_punish == -1
+                len(punishes) < self.config.number_of_punish
+                or self.config.number_of_punish == -1
         ):
             self.logger.info(
                 "%s Will be punished (%s/%s)",
@@ -321,19 +322,19 @@ class NoLeaderAutomod:
         return PunishStepState.GO_TO_NEXT_STEP
 
     def should_kick_player(
-        self,
-        watch_status: WatchStatus,
-        team_view,
-        squad_name: str,
-        squad,
-        aplayer: PunishPlayer,
+            self,
+            watch_status: WatchStatus,
+            team_view,
+            squad_name: str,
+            squad,
+            aplayer: PunishPlayer,
     ):
         if not self.config.kick_after_max_punish:
             self.logger.debug("Kick is disabled")
             return PunishStepState.DISABLED
 
         if (
-            get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
+                get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
         ) < self.config.disable_kick_below_server_player_count:
             self.logger.debug("Server below min player count for punish")
             return PunishStepState.WAIT
@@ -343,8 +344,8 @@ class NoLeaderAutomod:
             return PunishStepState.WAIT
 
         if (
-            aplayer.lvl <= self.config.immuned_level_up_to
-            or aplayer.role in self.config.immuned_roles
+                aplayer.lvl <= self.config.immuned_level_up_to
+                or aplayer.role in self.config.immuned_roles
         ):
             self.logger.info("%s is immune to kick", aplayer.short_repr())
             return PunishStepState.IMMUNED
@@ -356,7 +357,7 @@ class NoLeaderAutomod:
             return PunishStepState.DISABLED
 
         if datetime.now() - last_time < timedelta(
-            seconds=self.config.kick_grace_period_seconds
+                seconds=self.config.kick_grace_period_seconds
         ):
             return PunishStepState.WAIT
 

--- a/rcon/automods/seeding_rules.py
+++ b/rcon/automods/seeding_rules.py
@@ -273,16 +273,19 @@ class SeedingRulesAutomod:
                             drc.message.format(role=drc.roles.get(aplayer.role))
                         )
 
+                if "offensive" in game_state['current_map'] or game_state['current_map'].startswith("stmariedumont_off"):
+                    self._disable_for_round("enforce_cap_fight")
+
                 if not self._is_seeding_rule_disabled("enforce_cap_fight") and \
                         (team == "axis" and game_state["axis_score"]) >= ecf.max_caps or \
                         (team == "allies" and game_state["allied_score"] >= ecf.max_caps):
                     self.logger.debug("Player is on " + team + " side and winning")
                     op = player['offense']
-                    oop = watch_status.offensive_points.setdefault(aplayer.name, 0)
+                    oop = watch_status.offensive_points.setdefault(aplayer.name, -1)
 
                     self.logger.debug(
                         "Player had " + str(oop) + " offensive points last and now " + str(op))
-                    if oop != 0 and oop < op:
+                    if oop != -1 and oop < op:
                         violations.append(ecf.message)
 
                         if ecf.skip_warning:


### PR DESCRIPTION
A new seeding rule that, when configured, warns/punishes players who gain offensive points when their team is "winning" (has the amount of caps configured in the config), which is considered "attacking the enemy sector".