### PR TITLE
Show with what weapon a player was killed

### DIFF
--- a/rcon/models.py
+++ b/rcon/models.py
@@ -513,6 +513,7 @@ class PlayerStats(Base):
     most_killed = Column(JSONB)
     death_by = Column(JSONB)
     weapons = Column(JSONB)
+    death_by_weapons = Column(JSONB)
 
     def to_dict(self) -> PlayerStatsType:
         return dict(
@@ -543,6 +544,7 @@ class PlayerStats(Base):
             most_killed=self.most_killed,
             death_by=self.death_by,
             weapons=self.weapons,
+            death_by_weapons=self.death_by_weapons,
         )
 
 

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -63,6 +63,7 @@ class BaseStats:
                 stats["most_killed"].get(log["player2"], 0) + 1
             )
         if self._is_player_death(player, log):
+            stats["death_by_weapons"][log["weapon"]] = stats["death_by_weapons"].get(log["weapon"], 0) + 1
             stats["death_by"][log["player"]] = (
                 stats["death_by"].get(log["player"], 0) + 1
             )
@@ -168,6 +169,7 @@ class BaseStats:
                 "kills": 0,
                 "kills_streak": 0,
                 "deaths": 0,
+                "death_by_weapons": {},
                 "deaths_without_kill_streak": 0,
                 "teamkills": 0,
                 "teamkills_streak": 0,

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -97,6 +97,7 @@ class PlayerStatsType(TypedDict):
     most_killed: Optional[dict]
     death_by: Optional[dict]
     weapons: Optional[dict]
+    death_by_weapons: Optional[dict]
 
 
 class MapsType(TypedDict):

--- a/rcon/workers.py
+++ b/rcon/workers.py
@@ -178,6 +178,7 @@ def record_stats_from_map(sess, map_):
                 weapons=stats.get("weapons"),
                 most_killed=stats.get("most_killed"),
                 death_by=stats.get("death_by"),
+                death_by_weapons=stats.get("death_by_weapons"),
             )
             logger.debug(f"Saving stats %s", player_stats)
             player_stat_record = PlayerStats(**player_stats)

--- a/rcongui/src/components/Scoreboard/Scores.js
+++ b/rcongui/src/components/Scoreboard/Scores.js
@@ -299,12 +299,14 @@ const RawScores = pure(({ classes, scores }) => {
                 name: "weapons",
                 label: "Weapons",
                 options: {
-                  customBodyRender: (value, tableMeta, updateValue) => {
-                    const pairs = toPairs(value);
-                    return sortBy(pairs, (v) => -v[1])
-                      .map((v) => `${v[0]}: ${v[1]}`)
-                      .join(", ");
-                  },
+                  customBodyRender: commaSeperatedListRenderer,
+                },
+              },
+              {
+                name: "death_by_weapons",
+                label: "Death by Weapons",
+                options: {
+                  customBodyRender: commaSeperatedListRenderer,
                 },
               },
             ]}
@@ -316,6 +318,13 @@ const RawScores = pure(({ classes, scores }) => {
     </Grid>
   );
 });
+
+function commaSeperatedListRenderer(value) {
+  const pairs = toPairs(value);
+  return sortBy(pairs, (v) => -v[1])
+    .map((v) => `${v[0]}: ${v[1]}`)
+    .join(", ");
+}
 
 const Scores = pure(({ classes, scores, durationToHour, type }) => {
   const [highlight, setHighlight] = React.useState(null);

--- a/rconweb/api/scoreboards.py
+++ b/rconweb/api/scoreboards.py
@@ -105,13 +105,11 @@ def get_map_scoreboard(request):
     data = _get_data(request)
     error = None
     failed = False
-    game = None
 
     try:
         map_id = int(data.get("map_id", None))
         with enter_session() as sess:
             game = sess.query(Maps).filter(Maps.id == map_id).one_or_none()
-            # import ipdb; ipdb.set_trace()
             if not game:
                 error = "No map for this ID"
                 failed = True


### PR DESCRIPTION
This was a feature request I recently got multiple times (and found myself as well). Instead of just showing with what weapon a player made their kills, it is also of interest with what weapon they were killed the most (e.g. artillery, MGs, etc).

As this is pretty cheap (from a calculation point of view) to implement, let's simply add it :D