### PR TITLE
Ban by steam ID and not name

### DIFF
--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -548,7 +548,7 @@ def auto_ban_if_tks_right_after_connection(
                 )
                 try:
                     rcon.do_perma_ban(
-                        player=player_name,
+                        steam_id_64=player_steam_id,
                         reason=reason,
                         by=author,
                     )


### PR DESCRIPTION
Banning by player name fails (it bans on the game server, but fails on CRCONs side) because it tries to get the steam ID of the player after they've been removed from the server.

Update this to ban by steam ID.

Tested this successfully on a CRCON I host that is using the feature and it works correctly.