### PR TITLE
Show and allow to filter by steam ID on scoreboards

### DIFF
--- a/rcongui/src/components/Scoreboard/Scores.js
+++ b/rcongui/src/components/Scoreboard/Scores.js
@@ -25,6 +25,7 @@ import { pure } from "recompose";
 import { PlayerStatProfile } from "./PlayerStatProfile";
 import MUIDataTable from "mui-datatables";
 import { Button } from "@material-ui/core";
+import { fromJS } from "immutable";
 import { toPairs, sortBy } from "lodash";
 
 export const safeGetSteamProfile = (scoreObj) =>
@@ -220,6 +221,7 @@ const RawScores = pure(({ classes, scores }) => {
             options={{
               filter: false,
               rowsPerPage: rowsPerPage,
+              enableNestedDataAccess: '.',
               selectableRows: "none",
               rowsPerPageOptions: [10, 25, 50, 100, 250, 500, 1000],
               onChangeRowsPerPage: (v) => setRowsPerPage(v),
@@ -240,7 +242,7 @@ const RawScores = pure(({ classes, scores }) => {
             }}
             data={scores ? scores.toJS() : []}
             columns={[
-              { name: "steam_id_64", label: "Steam ID" },
+              { name: "steaminfo.profile.steamid", label: "Steam ID", options: {display: false}, },
               { name: "player", label: "Name" },
               { name: "kills", label: "Kills" },
               { name: "deaths", label: "Deaths" },


### PR DESCRIPTION
This commit alsoc hanges the default visibility of the steam ID column to false. This info is mostly not needed, except people really want to show it. On the other hand, the column is pretty wide and takes huge amount of space in the table, which is already pretty crowded.

Filtering by steam ID is also possible when the column is not displayed, so this should be fine.