### PR TITLE
Move death_by_weapons in own sublist and consistent entry sorting

### DIFF
--- a/rcongui/src/components/Scoreboard/PlayerStatProfile.js
+++ b/rcongui/src/components/Scoreboard/PlayerStatProfile.js
@@ -28,6 +28,7 @@ export const PlayerStatProfile = pure(({ playerScore, onClose }) => {
     "most_killed",
     "weapons",
     "death_by",
+    "death_by_weapons",
   ]);
 
   return (
@@ -69,6 +70,12 @@ export const PlayerStatProfile = pure(({ playerScore, onClose }) => {
               />
               <SubList
                 playerScore={playerScore}
+                dataMapKey="death_by_weapons"
+                subtitle="'None' means Tank, Arty, roadkill or some explosives"
+                title="Deaths by weapons"
+              />
+              <SubList
+                playerScore={playerScore}
                 dataMapKey="most_killed"
                 title="Kills by player"
               />
@@ -82,6 +89,7 @@ export const PlayerStatProfile = pure(({ playerScore, onClose }) => {
                   excludedKeys.has(k)
                 )}
                 title="Raw stats"
+                sortByKey
               />
             </List>
           </Paper>

--- a/rcongui/src/components/Scoreboard/SubList.js
+++ b/rcongui/src/components/Scoreboard/SubList.js
@@ -21,12 +21,17 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export const SubList = pure(
-  ({ playerScore, dataMapKey, title, subtitle, openDefault }) => {
-    const data = dataMapKey
+  ({ playerScore, dataMapKey, title, subtitle, openDefault, sortByKey }) => {
+    let data = dataMapKey
       ? playerScore.get(dataMapKey) || new Map()
       : playerScore;
     const styles = useStyles();
     const [open, setOpen] = React.useState(openDefault);
+
+    if (sortByKey)
+      data = data.sortBy((v, k) => k)
+    else
+      data = data.sort().reverse()
 
     return (
       <React.Fragment>
@@ -44,8 +49,6 @@ export const SubList = pure(
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding dense>
             {data
-              .sort()
-              .reverse()
               .entrySeq()
               .map(([key, value]) => (
                 <ListItem className={styles.nested}>


### PR DESCRIPTION
Including the `death_by_weapons` in the raw stats sublist is not a good idea as can be seen in the screenshot.
Move those stats into their own sublist and make the sorting of the entries in the raw stats list consistent (sort by key instead of value)
![image](https://github.com/MarechJ/hll_rcon_tool/assets/51382157/dbe694d6-efa0-4c6e-a056-fd71e81af84c)
