### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.11-buster
+FROM python:3.11-slim
 
 WORKDIR /code
-RUN apt-get update -y && apt-get install -y cron logrotate
+RUN apt-get update -y && apt-get install -y cron logrotate git
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN pip install gunicorn


### PR DESCRIPTION
Use a smaller base docker image for Python to reduce image size. This cuts image size from ~1.4gb to ~700mb.

I did not test extensively but I did build it locally an connected it to our game server and it seemed like it works fine, we do have to install git explicitly.