### PR TITLE
Update logrotate.conf

### DIFF
--- a/config/logrotate.conf
+++ b/config/logrotate.conf
@@ -1,6 +1,6 @@
 /logs/*.log {
-  size 100M
-  rotate 5
+  size 10M
+  rotate 2
   copytruncate
   compress
   create 0666 root root


### PR DESCRIPTION
Reduce the amount and size of log files we retain, I don't think most people use them beyond looking at the tail of them for errors.

20 megabytes per type of log file (2 * 10MB) should be plenty of historical data for anyone who needs it and users can easily adjust this to anything they want locally.