### PR TITLE
Make docker repo and version a .env variable for easier downgrades

### DIFF
--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ BACKEND_DOCKER_REPOSITORY=maresh/hll_rcon
 FRONTEND_DOCKER_REPOSITORY=maresh/hll_rcon_frontend
 
 # This is the version of CRCON that will be pulled from Docker hub when you
-# pull images, leave this at `latest` for have the latest version, or 
+# pull images, leave this at `latest` to have the latest version, or 
 # replace with a specific version such as `7.0.2` or your desired version
 # from https://hub.docker.com/r/maresh/hll_rcon/tags
 TAGGED_VERSION=latest

--- a/.env
+++ b/.env
@@ -10,6 +10,21 @@
 # https://docs.docker.com/compose/environment-variables/env-file/
 
 # -----------------------------
+# Docker Repository & Version
+# -----------------------------
+
+# The name of the Docker hub repository, you should never need to change
+# this unless we host images on a different repository
+BACKEND_DOCKER_REPOSITORY=maresh/hll_rcon
+FRONTEND_DOCKER_REPOSITORY=maresh/hll_rcon_frontend
+
+# This is the version of CRCON that will be pulled from Docker hub when you
+# pull images, leave this at `latest` for have the latest version, or 
+# replace with a specific version such as `7.0.2` or your desired version
+# from https://hub.docker.com/r/maresh/hll_rcon/tags
+TAGGED_VERSION=latest
+
+# -----------------------------
 # Database Details
 # -----------------------------
 # This is a database password you have to choose, It does not have to be memorable 

--- a/default.env
+++ b/default.env
@@ -10,6 +10,21 @@
 # https://docs.docker.com/compose/environment-variables/env-file/
 
 # -----------------------------
+# Docker Repository & Version
+# -----------------------------
+
+# The name of the Docker hub repository, you should never need to change
+# this unless we host images on a different repository
+BACKEND_DOCKER_REPOSITORY=maresh/hll_rcon
+FRONTEND_DOCKER_REPOSITORY=maresh/hll_rcon_frontend
+
+# This is the version of CRCON that will be pulled from Docker hub when you
+# pull images, leave this at `latest` to have the latest version, or 
+# replace with a specific version such as `7.0.2` or your desired version
+# from https://hub.docker.com/r/maresh/hll_rcon/tags
+TAGGED_VERSION=latest
+
+# -----------------------------
 # Database Details
 # -----------------------------
 # This is a database password you have to choose, It does not have to be memorable 

--- a/docker-compose-common-components.yml
+++ b/docker-compose-common-components.yml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
     python:
-        image: maresh/hll_rcon:latest
+        image: ${BACKEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
         environment:
             HLL_HOST: ${HLL_HOST}
             HLL_PORT: ${HLL_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
           - backend
       common:
   frontend_1: &frontend
-    image: maresh/hll_rcon_frontend:latest
+    image: ${FRONTEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
     ports:
       - ${RCONWEB_PORT}:80
       - ${RCONWEB_PORT_HTTPS}:443


### PR DESCRIPTION
Turn the Docker hub repository and version into a `.env` environment variable so people don't need to edit the docker-compose files to upgrade or downgrade versions.

I tested it and I was able to pull images just fine with it.

If we want to do this we should hold off on the merge until we're ready to make any other `.env` changes we want, like deprecating the steam stuff if we merge PR 279 for instance.