### PR TITLE
Use alpine redis/postgres images for smaller file sizes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - server1
       - common
   redis:
-    image: redis:latest
+    image: redis:alpine
     restart: always
     command: redis-server /usr/local/etc/redis/redis.conf
     volumes:
@@ -66,7 +66,7 @@ services:
     networks:
       - common
   postgres:
-    image: postgres:12
+    image: postgres:12-alpine
     restart: always
     environment:
       # If a password is not defined this container will fail to create


### PR DESCRIPTION
Swap the `redis` and `postgres` images to their `alpine` equivalents for reduced file size.  Saves about 275mb which isn't insignificant.

I built this and while I did not exhaustively test it it works like normal as far as I can tell.