### PR TITLE
Start auto-settings by default

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -38,7 +38,7 @@ command=/code/manage.py auto_settings
 environment=LOGGING_FILENAME=auto_settings_%(ENV_SERVER_NUMBER)s.log
 startretries=100
 startsecs=1
-autostart=false
+autostart=true
 
 [program:routines]
 command=/code/manage.py routines


### PR DESCRIPTION
Every other service starts by default, I don't think there's a downside to starting auto-settings by default also.

Individual installs can easily override their supervisord.conf if they want