### PR TITLE
Maint/upgrade django

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Per server settings
     HLL_HOST
     HLL_PORT
     HLL_PASSWORD
+    RCONWEB_SERVER_URL
+
+**You must configure `RCONWEB_SERVER_URL` for each server you're setting up to match the URL you're hosting CRCON on, or you will be unable to access the admin site due to CSRF errors**
+
+For example if you are hosting using `HTTPS` on `example.com` you would set `RCONWEB_SERVER_URL=https://example.com`
+For example if you are hosting using `HTTP` on `127.0.0.1` on port `8010` you would set `RCONWEB_SERVER_URL=http://127.0.0.1:8010`
 
 There are other optional (but beneficial) settings in your `.env` such as Discord integration.
 

--- a/default.env
+++ b/default.env
@@ -106,8 +106,14 @@ SERVER_SHORT_NAME=MyServer
 # access then use: 127.0.0.1:8010
 RCONWEB_PORT=8010
 
-# Only change if you use a reverse proxy setup, set a full url with scheme 
-# (and port if relevant), to this rcon, eg: https://mydomain.com 
+# You must configure this to match the URL you're hosting CRCON on
+# or you will be unable to access the admin site due to CSRF errors
+# you need to match scheme (http/https) hostname (ip, or URL) and port (8010, etc)
+# if you are hosting using a domain name (example.com) you most likely do not need to include the port
+# For example if you are hosting using HTTPS on example.com you would set:
+# RCONWEB_SERVER_URL=https://example.com
+# For example if you are hosting using HTTP on 127.0.0.1 on port 8010 you would set:
+# RCONWEB_SERVER_URL=http://127.0.0.1:8010
 RCONWEB_SERVER_URL=
 
 # Same as above but for https

--- a/rconweb/rconweb/settings.py
+++ b/rconweb/rconweb/settings.py
@@ -118,7 +118,7 @@ ALLOWED_HOSTS = [
     "localhost",
     "localhost:3000",
 ] + os.getenv("DOMAINS", "").split(",")
-CORS_ORIGIN_WHITELIST = ["http://{}".format(h) for h in ALLOWED_HOSTS if h] + [
+CORS_ALLOWED_ORIGINS = ["http://{}".format(h) for h in ALLOWED_HOSTS if h] + [
     "https://{}".format(h) for h in ALLOWED_HOSTS if h
 ]
 CORS_ALLOW_CREDENTIALS = True
@@ -129,6 +129,12 @@ CORS_ORIGIN_ALLOW_ALL = False
 SESSION_COOKIE_HTTPONLY = False
 CSRF_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_SAMESITE = "Lax"
+
+# Required as of Django 4.0 otherwise it causes CSRF issues
+# if we don't include the origin
+CSRF_TRUSTED_ORIGINS = CORS_ALLOWED_ORIGINS.copy()
+if host := os.getenv('RCONWEB_SERVER_URL'):
+    CSRF_TRUSTED_ORIGINS.append(host)
 
 if DEBUG:
     CSRF_COOKIE_SAMESITE = "None"
@@ -230,6 +236,7 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
+# Deprecated in Django 4.0, removed in Django 5.0
 USE_L10N = True
 
 USE_TZ = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click~=8.0.0
 cachetools==4.0.0
-Django~=3.2.0
-django-cors-headers==3.5.0
+Django~=4.2.0
+django-cors-headers==4.2.0
 redis==3.5.3
 simplejson==3.17.0
 sqlalchemy==1.3.19
@@ -24,5 +24,7 @@ pandas>=1.4.1,<2.0.0
 pydantic==1.9.1
 discord.py==1.7.3
 pytest==7.2.0
-django-directory
+# django-directory
+# django-dirctory is currently incompatible with Django 4.0+, PR is pending to fix django-directory upstream
+git+https://github.com/cemathey/django-directory@f51ee1e8dc50edf453fee4a0d9631c0e46fe9433
 pre-commit


### PR DESCRIPTION
We can jump from Django `3.1` to `4.2` with almost no changes, but Django started implementing CSRF origin checking in `4.0`.

This means that (the CRCON frontend works fine) to use the admin site users would have to configure their `RCONWEB_SERVER_URL` environment variable to match their originating host (url, http://<vps ip>:<port>, etc.) or they get a CSRF error on any page on the admin site.

For example: `RCONWEB_SERVER_URL=http://localhost:8010`

`django-directory` was incompatible with Django `4.0`+ but I forked it/patched it (the `url` method was deprecated) and updated `requirements.txt` to point to the working version.

`CORS_ORIGIN_WHITELIST` is renamed to `CORS_ALLOWED_ORIGINS`  to match `django-cors-headers` documentation (the old name is an alias for now, but I changed it in case they deprecate it in the future)

Django `3.1` ends LTS in April 2024 so it's still supported, but prior to Django `4.1` they used `jQuery` to add Javascript to manage formset events on the admin page and I'm working on that on a separate branch and would rather just do it once, in the modern style with the latest version of Django.