### PR TITLE
Increase TCP socket buffer size

### DIFF
--- a/rcon/connection.py
+++ b/rcon/connection.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from threading import Lock, get_ident
 
-MSGLEN = 8196
+MSGLEN = 32_768
 TIMEOUT_SEC = 20
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Increase the buffer size from 8,192 to 32,768 bytes. This aligns on a power of 2 (as the docs recommend) and should reduce the number of incomplete requests we get due to HLLs RCON protocol limitations.