### PR TITLE
Don't skip players when they don't have a profile

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -175,7 +175,7 @@ class Rcon(ServerCtl):
                 updated_players.append(
                     {
                         **p,
-                        "profile": profiles[p["steam_id_64"]],
+                        "profile": profiles.get(p.get(STEAMID)),
                         "is_vip": p.get(STEAMID) in vips,
                     }
                 )


### PR DESCRIPTION
Whoops, I messed up when combining extended/recorded RCON and `get_players` would not return any players that did not have a profile.

Tested it against our live server and it works correctly now.