### PR TITLE
Add missing player cache invalidator

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -135,6 +135,9 @@ class Rcon(ServerCtl):
         else:
             self.pool_size = self.advanced_settings.thread_pool_size
 
+    def invalidate_player_list_cache(self):
+        super().get_players.cache_clear()
+
     @cached_property
     def thread_pool(self):
         return ThreadPoolExecutor(self.pool_size)


### PR DESCRIPTION
Missed this when merging extended/recorded RCONs