### PR TITLE
Revert unfinished typing change; vip status/profile was missing

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -236,14 +236,8 @@ class Rcon(ServerCtl):
         for player in players_by_id.values():
             steam_id_64 = player[STEAMID]
             profile = steam_profiles.get(player.get("steam_id_64"), {}) or {}
-            enriched_player: EnrichedGetPlayersType = {
-                "name": "",
-                "steam_id_64": steam_id_64,
-                "country": "",
-                "steam_bans": None,
-                "profile": profile,
-                "is_vip": steam_id_64 in vips,
-            }
+            player["profile"] = profile
+            player["is_vip"] = steam_id_64 in vips
 
             teams.setdefault(player.get("team"), {}).setdefault(
                 player.get("unit_name"), {}


### PR DESCRIPTION
I was in the middle of trying to type stuff so I could understand stuff better/use pylance more while merging extended/recorded Rcons, forgot to finish.  Reverts to the previous working version that was in `v7.2.1`