### PR TITLE
Properly fix cache invalidation when players connect

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -308,12 +308,9 @@ def inject_player_ids(func):
 
 @on_connected
 @inject_player_ids
-def handle_on_connect(rcon, struct_log, name, steam_id_64):
+def handle_on_connect(rcon: Rcon, struct_log, name, steam_id_64):
     try:
-        if type(rcon) == Rcon:
-            rcon.invalidate_player_list_cache()
-        else:
-            rcon.get_player.cache_clear()
+        rcon.get_players.cache_clear()
         rcon.get_player_info.clear_for(struct_log["player"])
         rcon.get_player_info.clear_for(player=struct_log["player"])
     except Exception:

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -135,9 +135,6 @@ class Rcon(ServerCtl):
         else:
             self.pool_size = self.advanced_settings.thread_pool_size
 
-    def invalidate_player_list_cache(self):
-        super().get_players.cache_clear()
-
     @cached_property
     def thread_pool(self):
         return ThreadPoolExecutor(self.pool_size)


### PR DESCRIPTION
Fixed correctly this time, built and pointed it at our server and verified that it does not throw errors when players connect.

`handle_on_connect` in `hooks.py` was checking if it was an instance of `RecordedRcon` and then using that method to clear the cache, if it was `Rcon` (`extended_rcon.py`) then it was trying to call `rcon.get_player.cache_clear`, but that doesn't (and didn't exist as far as I can tell) exist lol, so that method and that check don't need to exist now that the two classes are merged.

All we have to do is nuke `invalidates_player_list_cache` and just directly clear the cache in `hooks.py`.