### PR TITLE
Fixes an "AttributeError: 'SeedingRulesAutomod'/'LevelThresholdsAutomod' object has no attribute 'player_punish_failed'"

### DIFF
--- a/rcon/automods/level_thresholds.py
+++ b/rcon/automods/level_thresholds.py
@@ -197,6 +197,14 @@ class LevelThresholdsAutomod:
             )
             return message
 
+    def player_punish_failed(self, aplayer):
+        with self.watch_state(aplayer.team, aplayer.squad) as watch_status:
+            try:
+                if punishes := watch_status.punished.get(aplayer.name):
+                    del punishes[-1]
+            except Exception:
+                self.logger.exception("tried to cleanup punished time but failed")
+
     def punitions_to_apply(
         self,
         team_view,

--- a/rcon/automods/seeding_rules.py
+++ b/rcon/automods/seeding_rules.py
@@ -216,6 +216,14 @@ class SeedingRulesAutomod:
             v = v.decode()
         return v == "1"
 
+    def player_punish_failed(self, aplayer):
+        with self.watch_state(aplayer.team, aplayer.squad) as watch_status:
+            try:
+                if punishes := watch_status.punished.get(aplayer.name):
+                    del punishes[-1]
+            except Exception:
+                self.logger.exception("tried to cleanup punished time but failed")
+
     def punitions_to_apply(
         self,
         team_view,


### PR DESCRIPTION
Seems these attributes were forgotten, causing an automod service restart everytime a player can't be punished.

Fixes :
- "AttributeError: 'SeedingRulesAutomod' object has no attribute 'player_punish_failed'"
- "AttributeError: 'LevelThresholdsAutomod' object has no attribute 'player_punish_failed'"