### PR TITLE
Autosettings: Add "set_map_shuffle_enabled" to default config

### DIFF
--- a/config/auto_settings.default.json
+++ b/config/auto_settings.default.json
@@ -90,6 +90,7 @@
     "do_remove_maps_from_rotation": { "maps": ["stmariedumont_warfare", "kursk_offensive_rus"] },
     "do_randomize_map_rotation": { "maps": ["An optional list of maps", "that will replace the current rotation"] },
     "set_maprotation": { "rotation": ["Overwrites the current rotation", "Yes the spelling is intentional"] },
+    "set_map_shuffle_enabled": {"enabled": false},
     "do_punish": { "player": "12345678901234567", "reason": "Get rekt" },
     "do_kick": { "player": "12345678901234567", "reason": "Get rekt" },
     "do_temp_ban": {

--- a/rcon/user_config.py
+++ b/rcon/user_config.py
@@ -612,6 +612,7 @@ DEFAULT_AUTO_SETTINGS = {
                 "Yes the spelling is intentional",
             ]
         },
+        "set_map_shuffle_enabled": {"enabled": False},
         "do_punish": {"player": "12345678901234567", "reason": "Get rekt"},
         "do_kick": {"player": "12345678901234567", "reason": "Get rekt"},
         "do_temp_ban": {


### PR DESCRIPTION
Hey everyone,

first, thank you for this great software!
I have noticed that the command "set_map_shuffle_enabled" is missing in the standard configuration for autosettings. Since the standard configuration serves as documentation, I think it makes sense to include this command in the file. In this pull request I have done exactly that. This should make it easier for new users (including me) to include it. 

Thank you very much!