### PR TITLE
Adds "No solo tank" automod

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -477,6 +477,76 @@ LEVEL_AUTO_MOD:
   #  {player_name}, {squad_name}, {kick_grace_period} and {violation}
   kick_message: "You violated level thresholds rules on this server: {violation}.\nYour grace period of {kick_grace_period}s has passed.\nYou failed to comply with the previous warnings."
 
+NOSOLOTANK_AUTO_MOD:
+  # This auto-moderator has 4 steps, 1. internally noting (X times), 2. warning via direct message (Y times), 3. punish (Z times) 4. kick
+  # Note that the state cycle for a given squad only resets once it finally has more than one member. So for example if you
+  # disabled the kick and have 3 punishes configured, once the 3 punishes are
+  # through that's it, nothing will happen anymore for that solotaker, even if he's still alone in his squad.
+  #
+  # Note 2: notes, warnings, punishes and kicks are tracked individual per player, not at the squad level.
+  # Set to true to enable the auto moderation of solo tankers squads.
+  enabled: false
+  # If this is set to true no warning / punish / kick will be applied for real
+  # It turns the code into a "simulation" mode and only send what it would do to your discord audit log webhook
+  dry_run: true
+  # Discord Webhook URL where audit logs should be sent. If not specified, the environment variable DISCORD_WEBHOOK_AUDIT_LOG
+  # will be used, instead.
+  discord_webhook_url: ""
+
+  # Step number 1
+  # If a player is solo in a tank squad, he will be noted internally but no action is taken
+  # Since we sometimes receive wrong data from the game server we note those players
+  # and see if these squads still are solo the next time we check
+  # set to 0 to disable (this means it will move to warn directly)
+  # set to 1 to X to note the squad X times before we move to the warn step
+  # (we recommend 2 : that should give enough time for mates to join)
+  number_of_notes: 2
+  # This is the number of seconds this auto-mod will wait until moving to
+  # the next note or to warnings if the number_of_notes is reached
+  notes_interval_seconds: 60
+
+  # Step number 2
+  # Send a direct warning message to the solo tank player
+  # set to 0 to disable (this means it will move to punish directly), -1 for infinite warnings (will never go to punishes)
+  # set to 1 or Y to warn him Y times before we move on to the punish step
+  number_of_warning: 2
+  # This is the number of seconds this auto-mod will wait until moving to
+  # the next warning or to the punish if the number_of_warning's is reached
+  warning_interval_seconds: 60
+  # This is the text that will be displayed to warn players.
+  # The following variables are available to fill into the text
+  #  {player_name}, {squad_name}, {received_warnings}, {max_warnings} and {next_check_seconds}
+  warning_message: "Attention, {player_name} !\n\nYou can't play solo in the armor squad {squad_name}.\n\n(Warning {received_warnings} of {max_warnings} before punition)\n\nNext check in {next_check_seconds}s."
+
+  # Step number 3
+  # If the player is still solo in his tank after
+  # the N warnings and the last warning_interval_seconds has elapsed, automod starts punishing
+  # Set to 0 to disable to punish entirely. I would advise setting warnings to infinity (-1) if you do that
+  # Set to -1 for infinite punish (will never go to kicks)
+  # Set to 1 or Z to apply Z punishes before we move to the next step (the kicks)
+  number_of_punish: 2
+  # This is the number of seconds to wait between punishes (if the player is still solo tank
+  # I wouldn't recommend setting a high value here (unless you chose infinite punishes) as once the player has died he has the opportunity to leave
+  # the squad, so no excuse. Also it's even more frustrating to respawn, run 300m and die again ;)
+  punish_interval_seconds: 60
+  # This is the message that will be used in the punish
+  # The following variables are available to fill into the text
+  # {player_name}, {squad_name}, {received_punishes}, {max_punishes} and {next_check_seconds}
+  punish_message: "\n\nYou've been punished by a bot,\nbecause you're playing solo in the armor squad {squad_name}.\n\n(Punition {received_punishes} of {max_punishes} before kick)\n\nNext check in {next_check_seconds}s.\n\n"
+
+  # Step number 4
+  # Set the below value to false if you don't want to kick players after they reached the max amount of punishes
+  # note that if you disable punishes it will never go to that step. no matter if it's set to true
+  kick_after_max_punish: true
+  # If the server has less players than the number below, the auto-moderator will wait and not kick yet
+  disable_kick_below_server_player_count: 0
+  # After the Step 2 has reached it's max punishes, this is the amount of time in seconds the auto-mod will wait before kicking
+  kick_grace_period_seconds: 60
+  # This is the message that will be used in the kick
+  # The following variables are available to fill into the text
+  #  {player_name}, {squad_name} and {kick_grace_period}
+  kick_message: "You've been kicked by a bot.\n\nYou were still playing solo in the armor squad {squad_name},\n{kick_grace_period}s after being punished."
+
 # Set your custom text or transalation for each of the below keys. Logo urls and prefered stats and such
 # If you have more that 3 server copy the whole SERVER_1 section
 SCOREBOT:

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -14,6 +14,10 @@ class SquadHasLeader(Exception):
     pass
 
 
+class NoSoloTanker(Exception):
+    pass
+
+
 class SquadCycleOver(Exception):
     pass
 
@@ -362,3 +366,40 @@ class LevelThresholdsConfig:
     max_level_message: str = "Access to this server is not allowed over level {level}"
 
     level_thresholds: LevelByRoleConfig = field(default_factory=LevelByRoleConfig)
+
+
+@dataclass
+class NoSoloTankConfig:
+    enabled: bool = False
+    dry_run: bool = True
+    discord_webhook_url: str = ""
+
+    number_of_notes: int = 2  # Let's give the mates some time to arrive
+    notes_interval_seconds: int = 60
+
+    number_of_warning: int = 2
+    warning_interval_seconds: int = 60
+    warning_message: str = (
+        "Warning, {player_name} !\n\n"
+        "You can't play solo tank on this server !\n\n"
+        "You will be punished after {max_warnings} warnings\n"
+        "(you already received {received_warnings})\n\n"
+        "Next check will happen automatically in {next_check_seconds}s."
+    )
+
+    number_of_punish: int = 2
+    punish_interval_seconds: int = 60
+    punish_message: str = (
+        "You violated solo tank rule on this server.\n"
+        "You're being punished by a bot ({received_punishes}/{max_punishes}).\n"
+        "Next check in {next_check_seconds}s."
+    )
+
+    disable_kick_below_server_player_count: int = 40
+    kick_after_max_punish: bool = False
+    kick_grace_period_seconds: int = 60
+    kick_message: str = (
+        "You violated solo tank rule on this server.\n"
+        "Your grace period of {kick_grace_period}s has passed.\n"
+        "You failed to comply with the previous warnings."
+    )

--- a/rcon/automods/no_solotank.py
+++ b/rcon/automods/no_solotank.py
@@ -1,0 +1,349 @@
+import logging
+import pickle
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Literal
+
+import redis
+
+from rcon.automods.get_team_count import get_team_count
+from rcon.automods.is_time import is_time
+from rcon.automods.models import (
+    ActionMethod,
+    NoSoloTankConfig,
+    PunishDetails,
+    PunishPlayer,
+    PunishStepState,
+    PunitionsToApply,
+    NoSoloTanker,
+    WatchStatus,
+)
+from rcon.automods.num_or_inf import num_or_inf
+from rcon.types import GameState
+
+SOLO_TANK_RESET_SECS = 120
+AUTOMOD_USERNAME = "NoSoloTank"
+
+
+class NoSoloTankAutomod:
+    logger: logging.Logger
+    red: redis.StrictRedis
+    config: NoSoloTankConfig
+
+    def __init__(self, config: NoSoloTankConfig, red: redis.StrictRedis or None):
+        self.logger = logging.getLogger(__name__)
+        self.red = red
+        self.config = config
+
+    def enabled(self):
+        return self.config.enabled
+
+    def get_message(
+        self, watch_status: WatchStatus, aplayer: PunishPlayer, method: ActionMethod
+    ):
+        data = {}
+
+        if method == ActionMethod.MESSAGE:
+            data["received_warnings"] = len(watch_status.warned.get(aplayer.name))
+            data["max_warnings"] = self.config.number_of_warning
+            data["next_check_seconds"] = self.config.warning_interval_seconds
+        if method == ActionMethod.PUNISH:
+            data["received_punishes"] = len(watch_status.punished.get(aplayer.name))
+            data["max_punishes"] = self.config.number_of_punish
+            data["next_check_seconds"] = self.config.punish_interval_seconds
+        if method == ActionMethod.KICK:
+            data["kick_grace_period"] = self.config.kick_grace_period_seconds
+
+        data["player_name"] = aplayer.name
+        data["squad_name"] = aplayer.squad
+
+        base_message = {
+            ActionMethod.MESSAGE: self.config.warning_message,
+            ActionMethod.PUNISH: self.config.punish_message,
+            ActionMethod.KICK: self.config.kick_message,
+        }
+
+        message = base_message[method]
+        try:
+            return message.format(**data)
+        except KeyError:
+            self.logger.warning(
+                f"The automod message of {repr(method)} ({message}) contains an invalid key"
+            )
+            return message
+
+    def player_punish_failed(self, aplayer):
+        with self.watch_state(aplayer.team, aplayer.squad) as watch_status:
+            try:
+                if punishes := watch_status.punished.get(aplayer.name):
+                    del punishes[-1]
+            except Exception:
+                self.logger.exception("tried to cleanup punished time but failed")
+
+    @contextmanager
+    def watch_state(self, team: str, squad_name: str):
+        redis_key = f"no_solo_tank{team.lower()}{str(squad_name).lower()}"
+        watch_status = self.red.get(redis_key)
+        if watch_status:
+            watch_status = pickle.loads(watch_status)
+        else:  # No punishments so far, starting a fresh one
+            watch_status = WatchStatus()
+
+        try:
+            yield watch_status
+        except (NoSoloTanker):
+            self.logger.debug(
+                "Squad %s - %s is no more solo tank, clearing state", team, squad_name
+            )
+            self.red.delete(redis_key)
+        else:
+            self.red.setex(
+                redis_key, SOLO_TANK_RESET_SECS, pickle.dumps(watch_status)
+            )
+
+    def punitions_to_apply(
+        self,
+        team_view,
+        squad_name: str,
+        team: Literal["axis", "allies"],
+        squad: dict,
+        game_state: GameState,
+    ) -> PunitionsToApply:
+        punitions_to_apply = PunitionsToApply()
+        if squad_name == "Commander":
+            self.logger.debug("Skipping commander")
+            return punitions_to_apply
+        if not squad_name:
+            # Deactivated (spams the logs)
+            # self.logger.info("Skipping None or empty squad %s %s", squad_name, squad)
+            return punitions_to_apply
+
+        with self.watch_state(team, squad_name) as watch_status:
+
+            if squad_name is None or squad is None:
+                raise NoSoloTanker()
+
+            if squad["type"] != "armor":
+                raise NoSoloTanker()
+
+            if len(squad["players"]) > 1:
+                raise NoSoloTanker()
+
+            # The squad has no leader
+            # -> clearing punishments plan
+            # -> the "noleader" automod will catch him
+            if not squad["has_leader"]:
+                raise NoSoloTanker()
+
+            self.logger.info("Squad %s - %s is solo tank", team, squad_name)
+            author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
+
+            for player in squad["players"]:
+                aplayer = PunishPlayer(
+                    steam_id_64=player["steam_id_64"],
+                    name=player["name"],
+                    team=team,
+                    squad=squad_name,
+                    role=player.get("role"),
+                    lvl=int(player.get("level")),
+                    details=PunishDetails(
+                        author=author,
+                        dry_run=self.config.dry_run,
+                        discord_audit_url=self.config.discord_webhook_url,
+                    ),
+                )
+
+                state = self.should_note_player(watch_status, squad_name, aplayer)
+                if state == PunishStepState.APPLY:
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+                if not state in [
+                    PunishStepState.DISABLED,
+                    PunishStepState.GO_TO_NEXT_STEP,
+                ]:
+                    continue
+
+                state = self.should_warn_player(watch_status, squad_name, aplayer)
+
+                if state == PunishStepState.APPLY:
+                    aplayer.details.message = self.get_message(
+                        watch_status, aplayer, ActionMethod.MESSAGE
+                    )
+                    punitions_to_apply.warning.append(aplayer)
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+                if (
+                    state == PunishStepState.WAIT
+                ):  # only here to make the tests pass, otherwise useless
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+
+                if not state in [
+                    PunishStepState.DISABLED,
+                    PunishStepState.GO_TO_NEXT_STEP,
+                ]:
+                    continue
+
+                state = self.should_punish_player(
+                    watch_status, team_view, squad_name, squad, aplayer
+                )
+
+                if state == PunishStepState.APPLY:
+                    aplayer.details.message = self.get_message(
+                        watch_status, aplayer, ActionMethod.PUNISH
+                    )
+                    punitions_to_apply.punish.append(aplayer)
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+                if not state in [
+                    PunishStepState.DISABLED,
+                    PunishStepState.GO_TO_NEXT_STEP,
+                ]:
+                    continue
+
+                state = self.should_kick_player(
+                    watch_status, team_view, squad_name, squad, aplayer
+                )
+                if state == PunishStepState.APPLY:
+                    aplayer.details.message = self.get_message(
+                        watch_status, aplayer, ActionMethod.KICK
+                    )
+                    punitions_to_apply.kick.append(aplayer)
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+
+        return punitions_to_apply
+
+    def should_note_player(
+        self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
+    ):
+        if self.config.number_of_notes == 0:
+            self.logger.debug("Notes are disabled. number_of_notes is set to 0")
+            return PunishStepState.DISABLED
+
+        notes = watch_status.noted.setdefault(aplayer.name, [])
+
+        if not is_time(notes, self.config.notes_interval_seconds):
+            self.logger.debug(
+                "Waiting to note: %s in %s", aplayer.short_repr(), squad_name
+            )
+            return PunishStepState.WAIT
+
+        if len(notes) < self.config.number_of_notes:
+            self.logger.info(
+                "%s Will be noted (%s/%s)",
+                aplayer.short_repr(),
+                len(notes),
+                num_or_inf(self.config.number_of_notes),
+            )
+            notes.append(datetime.now())
+            return PunishStepState.APPLY
+
+        self.logger.info(
+            "%s Max notes reached (%s/%s). Moving on to warn.",
+            aplayer.short_repr(),
+            len(notes),
+            self.config.number_of_notes,
+        )
+        return PunishStepState.GO_TO_NEXT_STEP
+
+    def should_warn_player(
+        self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
+    ):
+        if self.config.number_of_warning == 0:
+            self.logger.debug("Warnings are disabled. number_of_warning is set to 0")
+            return PunishStepState.DISABLED
+
+        warnings = watch_status.warned.setdefault(aplayer.name, [])
+
+        if not is_time(warnings, self.config.warning_interval_seconds):
+            self.logger.debug(
+                "Waiting to warn: %s in %s", aplayer.short_repr(), squad_name
+            )
+            return PunishStepState.WAIT
+
+        if (
+            len(warnings) < self.config.number_of_warning
+            or self.config.number_of_warning == -1
+        ):
+            self.logger.info(
+                "%s Will be warned (%s/%s)",
+                aplayer.short_repr(),
+                len(warnings),
+                num_or_inf(self.config.number_of_warning),
+            )
+            warnings.append(datetime.now())
+            return PunishStepState.APPLY
+
+        self.logger.info(
+            "%s Max warnings reached (%s/%s). Moving on to punish.",
+            aplayer.short_repr(),
+            len(warnings),
+            self.config.number_of_warning,
+        )
+        return PunishStepState.GO_TO_NEXT_STEP
+
+    def should_punish_player(
+        self,
+        watch_status: WatchStatus,
+        team_view,
+        squad_name: str,
+        squad,
+        aplayer: PunishPlayer,
+    ):
+        if self.config.number_of_punish == 0:
+            self.logger.debug("Punish is disabled")
+            return PunishStepState.DISABLED
+
+        punishes = watch_status.punished.setdefault(aplayer.name, [])
+
+        if not is_time(punishes, self.config.punish_interval_seconds):
+            self.logger.debug("Waiting to punish %s", squad_name)
+            return PunishStepState.WAIT
+
+        if (
+            len(punishes) < self.config.number_of_punish
+            or self.config.number_of_punish == -1
+        ):
+            self.logger.info(
+                "%s Will be punished (%s/%s)",
+                aplayer.short_repr(),
+                len(punishes),
+                num_or_inf(self.config.number_of_punish),
+            )
+            punishes.append(datetime.now())
+            return PunishStepState.APPLY
+
+        self.logger.info(
+            "%s Max punish reached (%s/%s)",
+            aplayer.short_repr(),
+            len(punishes),
+            self.config.number_of_punish,
+        )
+        return PunishStepState.GO_TO_NEXT_STEP
+
+    def should_kick_player(
+        self,
+        watch_status: WatchStatus,
+        team_view,
+        squad_name: str,
+        squad,
+        aplayer: PunishPlayer,
+    ):
+        if not self.config.kick_after_max_punish:
+            self.logger.debug("Kick is disabled")
+            return PunishStepState.DISABLED
+
+        if (
+            get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
+        ) < self.config.disable_kick_below_server_player_count:
+            self.logger.debug("Server below min player count for kick")
+            return PunishStepState.WAIT
+
+        try:
+            last_time = watch_status.punished.get(aplayer.name, [])[-1]
+        except IndexError:
+            self.logger.error("Trying to kick player without prior punishes")
+            return PunishStepState.DISABLED
+
+        if datetime.now() - last_time < timedelta(
+            seconds=self.config.kick_grace_period_seconds
+        ):
+            return PunishStepState.WAIT
+
+        return PunishStepState.APPLY


### PR DESCRIPTION
Watches and warns/punishes/kicks the solo tankers SLs
(non-SLs are already managed by "no leader watch").

The armor squads usually come in crew.
But a player may open an armor squad and wait for his mates to enter.
So the automod won't do anything during the X first minutes ("note").
Then, based on configuration, it will begin a standard automod cycle (warn X times, punish X times, kick).

Based on the "no leader watch" automod.