### PR TITLE
Add server number to get_connection_info endpoint

### DIFF
--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -481,7 +481,7 @@ class ApiKey:
         }
 
 
-def get_server_number() -> int:
+def get_server_number() -> str:
     """Get the CRCON server number"""
     server_number = os.getenv("SERVER_NUMBER")
     if not server_number:

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -683,7 +683,7 @@ def get_connection_info(request):
             "name": ctl.get_name(),
             "port": os.getenv("RCONWEB_PORT"),
             "link": os.getenv("RCONWEB_SERVER_URL"),
-            "server_number": get_server_number(),
+            "server_number": int(get_server_number()),
         },
         failed=False,
         command="get_connection_info",

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -5,6 +5,7 @@ import traceback
 from functools import wraps
 from subprocess import PIPE, run
 from typing import Callable, List
+from rcon.utils import get_server_number
 
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse, JsonResponse
@@ -682,6 +683,7 @@ def get_connection_info(request):
             "name": ctl.get_name(),
             "port": os.getenv("RCONWEB_PORT"),
             "link": os.getenv("RCONWEB_SERVER_URL"),
+            "server_number": get_server_number(),
         },
         failed=False,
         command="get_connection_info",


### PR DESCRIPTION
* Add server number to get_connection_info endpoint
* Login is already required, and the server number doesn't seem like particularly privileged information
* Had a user request this

Output would look like:

```json
{
  "result": {
    "name": "Saucymuffin's [BEER] Haus & Squidd Cafe Part Deux",
    "port": "8010",
    "link": "http://localhost:8010",
    "server_number": "1"
  },
  "command": "get_connection_info",
  "arguments": null,
  "failed": false,
  "error": null,
  "forwards_results": null
}
```