### PR TITLE
No solo tank automod

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -91,8 +91,8 @@ NAME_KICKS:
   reason: "Your nickname is invalid"
   # If left unset, the webhook default to your audit log webhook
   discord_webhook_url: ""
-  whitelist_flags:
-    - ✅
+  whitelist_flags: []
+    # - ✅
 
 BAN_TK_ON_CONNECT:
   enabled: no
@@ -114,8 +114,8 @@ BAN_TK_ON_CONNECT:
 
   # If any of the conditions below are true the player won't be inspected upon TK
   whitelist_players:
-    has_flag:
-      - ✅
+    has_flag: []
+      # - ✅
     is_vip: yes
     # Set to 0 for infinite
     has_at_least_n_sessions: 10
@@ -476,6 +476,84 @@ LEVEL_AUTO_MOD:
   # The following variables are available to fill into the text
   #  {player_name}, {squad_name}, {kick_grace_period} and {violation}
   kick_message: "You violated level thresholds rules on this server: {violation}.\nYour grace period of {kick_grace_period}s has passed.\nYou failed to comply with the previous warnings."
+
+NOSOLOTANK_AUTO_MOD:
+  # This auto-moderator has 4 steps, 1. internally noting (X times), 2. warning via direct message (Y times), 3. punish (Z times) 4. kick
+  # Note that the state cycle for a given squad only resets once it finally has more than one member. So for example if you
+  # disabled the kick and have 3 punishes configured, once the 3 punishes are
+  # through that's it, nothing will happen anymore for that solotaker, even if he's still alone in his squad.
+  #
+  # Note 2: notes, warnings, punishes and kicks are tracked individual per player, not at the squad level.
+  # Set to true to enable the auto moderation of solo tankers squads.
+  enabled: false
+  # If this is set to true no warning / punish / kick will be applied for real
+  # It turns the code into a "simulation" mode and only send what it would do to your discord audit log webhook
+  dry_run: true
+  # This is either an empty list [] or a list of flags to exempt a player
+  # from the automod feature (could be useful for admins that open locked armor squads to be able to use camera).
+  # To use, add a flag or multiple flags to the list, and then flag
+  # the players you want to exempt in the CRCON UI
+  whitelist_flags: []
+    # - 🚨
+  # Discord Webhook URL where audit logs should be sent. If not specified, the environment variable DISCORD_WEBHOOK_AUDIT_LOG
+  # will be used, instead.
+  discord_webhook_url: ""
+
+  # Step number 1
+  # If a player is solo in a tank squad, he will be noted internally but no action is taken
+  # Since we sometimes receive wrong data from the game server we note those players
+  # and see if these squads still are solo the next time we check
+  # set to 0 to disable (this means it will move to warn directly)
+  # set to 1 to X to note the squad X times before we move to the warn step
+  # (we recommend 2 : that should give enough time for mates to join)
+  number_of_notes: 2
+  # This is the number of seconds this auto-mod will wait until moving to
+  # the next note or to warnings if the number_of_notes is reached
+  notes_interval_seconds: 60
+
+  # Step number 2
+  # Send a direct warning message to the solo tank player
+  # set to 0 to disable (this means it will move to punish directly), -1 for infinite warnings (will never go to punishes)
+  # set to 1 or Y to warn him Y times before we move on to the punish step
+  number_of_warning: 2
+  # This is the number of seconds this auto-mod will wait until moving to
+  # the next warning or to the punish if the number_of_warning's is reached
+  warning_interval_seconds: 60
+  # This is the text that will be displayed to warn players.
+  # The following variables are available to fill into the text
+  #  {player_name}, {squad_name}, {received_warnings}, {max_warnings} and {next_check_seconds}
+  warning_message: "Attention, {player_name} !\n\nYou can't play solo in the armor squad {squad_name}.\n\n(Warning {received_warnings} of {max_warnings} before punition)\n\nNext check in {next_check_seconds}s."
+
+  # Step number 3
+  # If the player is still solo in his tank after
+  # the N warnings and the last warning_interval_seconds has elapsed, automod starts punishing
+  # If the server has less players than the number you set below, not punish / kicks will be applied
+  disable_punish_below_server_player_count: 40
+  # Set to 0 to disable to punish entirely. I would advise setting warnings to infinity (-1) if you do that
+  # Set to -1 for infinite punish (will never go to kicks)
+  # Set to 1 or Z to apply Z punishes before we move to the next step (the kicks)
+  number_of_punish: 2
+  # This is the number of seconds to wait between punishes (if the player is still solo tank
+  # I wouldn't recommend setting a high value here (unless you chose infinite punishes) as once the player has died he has the opportunity to leave
+  # the squad, so no excuse. Also it's even more frustrating to respawn, run 300m and die again ;)
+  punish_interval_seconds: 60
+  # This is the message that will be used in the punish
+  # The following variables are available to fill into the text
+  # {player_name}, {squad_name}, {received_punishes}, {max_punishes} and {next_check_seconds}
+  punish_message: "\n\nYou've been punished by a bot,\nbecause you're playing solo in the armor squad {squad_name}.\n\n(Punition {received_punishes} of {max_punishes} before kick)\n\nNext check in {next_check_seconds}s.\n\n"
+
+  # Step number 4
+  # Set the below value to false if you don't want to kick players after they reached the max amount of punishes
+  # note that if you disable punishes it will never go to that step. no matter if it's set to true
+  kick_after_max_punish: true
+  # If the server has less players than the number below, the auto-moderator will wait and not kick yet
+  disable_kick_below_server_player_count: 0
+  # After the Step 2 has reached it's max punishes, this is the amount of time in seconds the auto-mod will wait before kicking
+  kick_grace_period_seconds: 60
+  # This is the message that will be used in the kick
+  # The following variables are available to fill into the text
+  #  {player_name}, {squad_name} and {kick_grace_period}
+  kick_message: "You've been kicked by a bot.\n\nYou were still playing solo in the armor squad {squad_name},\n{kick_grace_period}s after being punished."
 
 # Set your custom text or transalation for each of the below keys. Logo urls and prefered stats and such
 # If you have more that 3 server copy the whole SERVER_1 section

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -14,6 +14,10 @@ class SquadHasLeader(Exception):
     pass
 
 
+class NoSoloTanker(Exception):
+    pass
+
+
 class SquadCycleOver(Exception):
     pass
 
@@ -362,3 +366,42 @@ class LevelThresholdsConfig:
     max_level_message: str = "Access to this server is not allowed over level {level}"
 
     level_thresholds: LevelByRoleConfig = field(default_factory=LevelByRoleConfig)
+
+
+@dataclass
+class NoSoloTankConfig:
+    enabled: bool = False
+    dry_run: bool = True
+    whitelist_flags: List = field(default_factory=lambda: ['🚨'])
+    discord_webhook_url: str = ""
+
+    number_of_notes: int = 2  # Let's give the mates some time to arrive
+    notes_interval_seconds: int = 60
+
+    number_of_warning: int = 2
+    warning_interval_seconds: int = 60
+    warning_message: str = (
+        "Warning, {player_name} !\n\n"
+        "You can't play solo tank on this server !\n\n"
+        "You will be punished after {max_warnings} warnings\n"
+        "(you already received {received_warnings})\n\n"
+        "Next check will happen automatically in {next_check_seconds}s."
+    )
+
+    disable_punish_below_server_player_count: int = 40
+    number_of_punish: int = 2
+    punish_interval_seconds: int = 60
+    punish_message: str = (
+        "You violated solo tank rule on this server.\n"
+        "You're being punished by a bot ({received_punishes}/{max_punishes}).\n"
+        "Next check in {next_check_seconds}s."
+    )
+
+    disable_kick_below_server_player_count: int = 40
+    kick_after_max_punish: bool = False
+    kick_grace_period_seconds: int = 60
+    kick_message: str = (
+        "You violated solo tank rule on this server.\n"
+        "Your grace period of {kick_grace_period}s has passed.\n"
+        "You failed to comply with the previous warnings."
+    )

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -372,7 +372,7 @@ class LevelThresholdsConfig:
 class NoSoloTankConfig:
     enabled: bool = False
     dry_run: bool = True
-    whitelist_flags: List = field(default_factory=lambda: ['🚨'])
+    whitelist_flags: List = field(default_factory=list)
     discord_webhook_url: str = ""
 
     number_of_notes: int = 2  # Let's give the mates some time to arrive

--- a/rcon/automods/no_solotank.py
+++ b/rcon/automods/no_solotank.py
@@ -1,0 +1,359 @@
+import logging
+import pickle
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Literal
+
+import redis
+
+from rcon.automods.get_team_count import get_team_count
+from rcon.automods.is_time import is_time
+from rcon.automods.models import (
+    ActionMethod,
+    NoSoloTankConfig,
+    PunishDetails,
+    PunishPlayer,
+    PunishStepState,
+    PunitionsToApply,
+    NoSoloTanker,
+    WatchStatus,
+)
+from rcon.automods.num_or_inf import num_or_inf
+from rcon.types import GameState
+
+SOLO_TANK_RESET_SECS = 120
+AUTOMOD_USERNAME = "NoSoloTank"
+
+
+class NoSoloTankAutomod:
+    logger: logging.Logger
+    red: redis.StrictRedis
+    config: NoSoloTankConfig
+
+    def __init__(self, config: NoSoloTankConfig, red: redis.StrictRedis or None):
+        self.logger = logging.getLogger(__name__)
+        self.red = red
+        self.config = config
+
+    def enabled(self):
+        return self.config.enabled
+
+    def get_message(
+        self, watch_status: WatchStatus, aplayer: PunishPlayer, method: ActionMethod
+    ):
+        data = {}
+
+        if method == ActionMethod.MESSAGE:
+            data["received_warnings"] = len(watch_status.warned.get(aplayer.name))
+            data["max_warnings"] = self.config.number_of_warning
+            data["next_check_seconds"] = self.config.warning_interval_seconds
+        if method == ActionMethod.PUNISH:
+            data["received_punishes"] = len(watch_status.punished.get(aplayer.name))
+            data["max_punishes"] = self.config.number_of_punish
+            data["next_check_seconds"] = self.config.punish_interval_seconds
+        if method == ActionMethod.KICK:
+            data["kick_grace_period"] = self.config.kick_grace_period_seconds
+
+        data["player_name"] = aplayer.name
+        data["squad_name"] = aplayer.squad
+
+        base_message = {
+            ActionMethod.MESSAGE: self.config.warning_message,
+            ActionMethod.PUNISH: self.config.punish_message,
+            ActionMethod.KICK: self.config.kick_message,
+        }
+
+        message = base_message[method]
+        try:
+            return message.format(**data)
+        except KeyError:
+            self.logger.warning(
+                f"The automod message of {repr(method)} ({message}) contains an invalid key"
+            )
+            return message
+
+    def player_punish_failed(self, aplayer):
+        with self.watch_state(aplayer.team, aplayer.squad) as watch_status:
+            try:
+                if punishes := watch_status.punished.get(aplayer.name):
+                    del punishes[-1]
+            except Exception:
+                self.logger.exception("tried to cleanup punished time but failed")
+
+    @contextmanager
+    def watch_state(self, team: str, squad_name: str):
+        redis_key = f"no_solo_tank{team.lower()}{str(squad_name).lower()}"
+        watch_status = self.red.get(redis_key)
+        if watch_status:
+            watch_status = pickle.loads(watch_status)
+        else:  # No punishments so far, starting a fresh one
+            watch_status = WatchStatus()
+
+        try:
+            yield watch_status
+        except (NoSoloTanker):
+            self.logger.debug(
+                "Squad %s - %s is no more solo tank, clearing state", team, squad_name
+            )
+            self.red.delete(redis_key)
+        else:
+            self.red.setex(
+                redis_key, SOLO_TANK_RESET_SECS, pickle.dumps(watch_status)
+            )
+
+    def punitions_to_apply(
+        self,
+        team_view,
+        squad_name: str,
+        team: Literal["axis", "allies"],
+        squad: dict,
+        game_state: GameState,
+    ) -> PunitionsToApply:
+        punitions_to_apply = PunitionsToApply()
+        if squad_name == "Commander":
+            self.logger.debug("Skipping commander")
+            return punitions_to_apply
+        if not squad_name:
+            # Deactivated (spams the logs)
+            # self.logger.info("Skipping None or empty squad %s %s", squad_name, squad)
+            return punitions_to_apply
+
+        with self.watch_state(team, squad_name) as watch_status:
+
+            if squad_name is None or squad is None:
+                raise NoSoloTanker()
+
+            if squad["type"] != "armor":
+                raise NoSoloTanker()
+
+            if len(squad["players"]) > 1:
+                raise NoSoloTanker()
+
+            # The squad has no leader
+            # -> clearing punishments plan
+            # -> the "noleader" automod will catch him
+            if not squad["has_leader"]:
+                raise NoSoloTanker()
+
+            for flagnb in squad["players"][0]["profile"]["flags"]:
+                if flagnb["flag"] in self.config.whitelist_flags:
+                    raise NoSoloTanker()
+
+            self.logger.info("Squad %s - %s is solo tank", team, squad_name)
+            author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
+
+            for player in squad["players"]:
+                aplayer = PunishPlayer(
+                    steam_id_64=player["steam_id_64"],
+                    name=player["name"],
+                    team=team,
+                    squad=squad_name,
+                    role=player.get("role"),
+                    lvl=int(player.get("level")),
+                    details=PunishDetails(
+                        author=author,
+                        dry_run=self.config.dry_run,
+                        discord_audit_url=self.config.discord_webhook_url,
+                    ),
+                )
+
+                state = self.should_note_player(watch_status, squad_name, aplayer)
+                if state == PunishStepState.APPLY:
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+                if not state in [
+                    PunishStepState.DISABLED,
+                    PunishStepState.GO_TO_NEXT_STEP,
+                ]:
+                    continue
+
+                state = self.should_warn_player(watch_status, squad_name, aplayer)
+
+                if state == PunishStepState.APPLY:
+                    aplayer.details.message = self.get_message(
+                        watch_status, aplayer, ActionMethod.MESSAGE
+                    )
+                    punitions_to_apply.warning.append(aplayer)
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+                if (
+                    state == PunishStepState.WAIT
+                ):  # only here to make the tests pass, otherwise useless
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+
+                if not state in [
+                    PunishStepState.DISABLED,
+                    PunishStepState.GO_TO_NEXT_STEP,
+                ]:
+                    continue
+
+                state = self.should_punish_player(
+                    watch_status, team_view, squad_name, squad, aplayer
+                )
+
+                if state == PunishStepState.APPLY:
+                    aplayer.details.message = self.get_message(
+                        watch_status, aplayer, ActionMethod.PUNISH
+                    )
+                    punitions_to_apply.punish.append(aplayer)
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+                if not state in [
+                    PunishStepState.DISABLED,
+                    PunishStepState.GO_TO_NEXT_STEP,
+                ]:
+                    continue
+
+                state = self.should_kick_player(
+                    watch_status, team_view, squad_name, squad, aplayer
+                )
+                if state == PunishStepState.APPLY:
+                    aplayer.details.message = self.get_message(
+                        watch_status, aplayer, ActionMethod.KICK
+                    )
+                    punitions_to_apply.kick.append(aplayer)
+                    punitions_to_apply.add_squad_state(team, squad_name, squad)
+
+        return punitions_to_apply
+
+    def should_note_player(
+        self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
+    ):
+        if self.config.number_of_notes == 0:
+            self.logger.debug("Notes are disabled. number_of_notes is set to 0")
+            return PunishStepState.DISABLED
+
+        notes = watch_status.noted.setdefault(aplayer.name, [])
+
+        if not is_time(notes, self.config.notes_interval_seconds):
+            self.logger.debug(
+                "Waiting to note: %s in %s", aplayer.short_repr(), squad_name
+            )
+            return PunishStepState.WAIT
+
+        if len(notes) < self.config.number_of_notes:
+            self.logger.info(
+                "%s Will be noted (%s/%s)",
+                aplayer.short_repr(),
+                len(notes),
+                num_or_inf(self.config.number_of_notes),
+            )
+            notes.append(datetime.now())
+            return PunishStepState.APPLY
+
+        self.logger.info(
+            "%s Max notes reached (%s/%s). Moving on to warn.",
+            aplayer.short_repr(),
+            len(notes),
+            self.config.number_of_notes,
+        )
+        return PunishStepState.GO_TO_NEXT_STEP
+
+    def should_warn_player(
+        self, watch_status: WatchStatus, squad_name: str, aplayer: PunishPlayer
+    ):
+        if self.config.number_of_warning == 0:
+            self.logger.debug("Warnings are disabled. number_of_warning is set to 0")
+            return PunishStepState.DISABLED
+
+        warnings = watch_status.warned.setdefault(aplayer.name, [])
+
+        if not is_time(warnings, self.config.warning_interval_seconds):
+            self.logger.debug(
+                "Waiting to warn: %s in %s", aplayer.short_repr(), squad_name
+            )
+            return PunishStepState.WAIT
+
+        if (
+            len(warnings) < self.config.number_of_warning
+            or self.config.number_of_warning == -1
+        ):
+            self.logger.info(
+                "%s Will be warned (%s/%s)",
+                aplayer.short_repr(),
+                len(warnings),
+                num_or_inf(self.config.number_of_warning),
+            )
+            warnings.append(datetime.now())
+            return PunishStepState.APPLY
+
+        self.logger.info(
+            "%s Max warnings reached (%s/%s). Moving on to punish.",
+            aplayer.short_repr(),
+            len(warnings),
+            self.config.number_of_warning,
+        )
+        return PunishStepState.GO_TO_NEXT_STEP
+
+    def should_punish_player(
+        self,
+        watch_status: WatchStatus,
+        team_view,
+        squad_name: str,
+        squad,
+        aplayer: PunishPlayer,
+    ):
+        if self.config.number_of_punish == 0:
+            self.logger.debug("Punish is disabled")
+            return PunishStepState.DISABLED
+
+        if (
+            get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
+        ) < self.config.disable_punish_below_server_player_count:
+            self.logger.debug("Server below min player count for punish")
+            return PunishStepState.WAIT
+
+        punishes = watch_status.punished.setdefault(aplayer.name, [])
+
+        if not is_time(punishes, self.config.punish_interval_seconds):
+            self.logger.debug("Waiting to punish %s", squad_name)
+            return PunishStepState.WAIT
+
+        if (
+            len(punishes) < self.config.number_of_punish
+            or self.config.number_of_punish == -1
+        ):
+            self.logger.info(
+                "%s Will be punished (%s/%s)",
+                aplayer.short_repr(),
+                len(punishes),
+                num_or_inf(self.config.number_of_punish),
+            )
+            punishes.append(datetime.now())
+            return PunishStepState.APPLY
+
+        self.logger.info(
+            "%s Max punish reached (%s/%s)",
+            aplayer.short_repr(),
+            len(punishes),
+            self.config.number_of_punish,
+        )
+        return PunishStepState.GO_TO_NEXT_STEP
+
+    def should_kick_player(
+        self,
+        watch_status: WatchStatus,
+        team_view,
+        squad_name: str,
+        squad,
+        aplayer: PunishPlayer,
+    ):
+        if not self.config.kick_after_max_punish:
+            self.logger.debug("Kick is disabled")
+            return PunishStepState.DISABLED
+
+        if (
+            get_team_count(team_view, "allies") + get_team_count(team_view, "axis")
+        ) < self.config.disable_kick_below_server_player_count:
+            self.logger.debug("Server below min player count for kick")
+            return PunishStepState.WAIT
+
+        try:
+            last_time = watch_status.punished.get(aplayer.name, [])[-1]
+        except IndexError:
+            self.logger.error("Trying to kick player without prior punishes")
+            return PunishStepState.DISABLED
+
+        if datetime.now() - last_time < timedelta(
+            seconds=self.config.kick_grace_period_seconds
+        ):
+            return PunishStepState.WAIT
+
+        return PunishStepState.APPLY

--- a/rcon/automods/no_solotank.py
+++ b/rcon/automods/no_solotank.py
@@ -135,9 +135,10 @@ class NoSoloTankAutomod:
             if not squad["has_leader"]:
                 raise NoSoloTanker()
 
-            for flagnb in squad["players"][0]["profile"]["flags"]:
-                if flagnb["flag"] in self.config.whitelist_flags:
-                    raise NoSoloTanker()
+            if squad["players"][0]["profile"]["flags"] is not None:
+                for flagnb in squad["players"][0]["profile"]["flags"]:
+                    if flagnb["flag"] in self.config.whitelist_flags:
+                        raise NoSoloTanker()
 
             self.logger.info("Squad %s - %s is solo tank", team, squad_name)
             author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")

--- a/tests/test_no_solo_tank_automod.py
+++ b/tests/test_no_solo_tank_automod.py
@@ -1,0 +1,704 @@
+import time
+from datetime import datetime, timedelta
+
+from pytest import fixture
+
+from rcon.automods.models import (
+    PunishPlayer,
+    PunishStepState,
+    WatchStatus,
+    NoSoloTankConfig,
+)
+from rcon.automods.no_solotank import NoSoloTankAutomod
+from rcon.config import get_config
+from rcon.types import GameState
+
+
+@fixture
+def team_view():
+    return {
+        "allies": {
+            "combat": 1353,
+            "commander": {
+                "combat": 17,
+                "country": "",
+                "deaths": 1,
+                "defense": 340,
+                "is_vip": False,
+                "kills": 1,
+                "level": 109,
+                "loadout": "veteran",
+                "name": "Bio",
+                "offense": 20,
+                "profile": None,
+                "role": "armycommander",
+                "steam_bans": None,
+                "steam_id_64": "76561198192586863",
+                "support": 792,
+                "team": "allies",
+                "unit_id": -1,
+                "unit_name": "Commander",
+            },
+            "count": 46,
+            "deaths": 154,
+            "defense": 7920,
+            "kills": 143,
+            "offense": 2520,
+            "squads": {
+                "able": {
+                    "combat": 563,
+                    "deaths": 61,
+                    "defense": 2740,
+                    "has_leader": True,
+                    "kills": 53,
+                    "offense": 620,
+                    "players": [
+                        {
+                            "combat": 136,
+                            "country": "US",
+                            "deaths": 14,
+                            "defense": 600,
+                            "is_vip": False,
+                            "kills": 7,
+                            "level": 20,
+                            "loadout": "mechanic",
+                            "name": "xRONINx6",
+                            "offense": 100,
+                            "profile": None,
+                            "role": "tankcommander",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198041932445",
+                            "steaminfo": None,
+                            "support": 1539,
+                            "team": "allies",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 137,
+                            "country": "",
+                            "deaths": 12,
+                            "defense": 420,
+                            "is_vip": False,
+                            "kills": 16,
+                            "level": 218,
+                            "loadout": "mechanic",
+                            "name": "-SHAKA-",
+                            "offense": 260,
+                            "profile": None,
+                            "role": "crewman",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198033248786",
+                            "steaminfo": None,
+                            "support": 135,
+                            "team": "allies",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 68,
+                            "country": "",
+                            "deaths": 13,
+                            "defense": 740,
+                            "is_vip": False,
+                            "kills": 8,
+                            "level": 70,
+                            "loadout": "mechanic",
+                            "name": "ByteSized",
+                            "offense": 80,
+                            "profile": None,
+                            "role": "crewman",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198109929335",
+                            "steaminfo": None,
+                            "support": 1992,
+                            "team": "allies",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                    ],
+                    "support": 4827,
+                    "type": "armor",
+                },
+                "baker": {
+                    "combat": 85,
+                    "deaths": 22,
+                    "defense": 1400,
+                    "has_leader": True,
+                    "kills": 11,
+                    "offense": 220,
+                    "players": [
+                        {
+                            "combat": 21,
+                            "country": "",
+                            "deaths": 9,
+                            "defense": 560,
+                            "is_vip": False,
+                            "kills": 3,
+                            "level": 88,
+                            "loadout": "mechanic",
+                            "name": "Lawless",
+                            "offense": 40,
+                            "profile": None,
+                            "role": "tankcommander",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198055458575",
+                            "steaminfo": None,
+                            "support": 270,
+                            "team": "allies",
+                            "unit_id": 1,
+                            "unit_name": "baker",
+                        },
+                    ],
+                    "support": 1114,
+                    "type": "armor",
+                },
+            },
+            "support": 8217,
+        },
+        "axis": {
+            "combat": 1361,
+            "commander": {
+                "combat": 94,
+                "country": "",
+                "deaths": 10,
+                "defense": 440,
+                "is_vip": False,
+                "kills": 12,
+                "level": 102,
+                "loadout": "veteran",
+                "name": "Chevron",
+                "offense": 60,
+                "profile": {},
+                "role": "armycommander",
+                "steam_bans": {
+                    "CommunityBanned": False,
+                    "DaysSinceLastBan": 0,
+                    "EconomyBan": "none",
+                    "NumberOfGameBans": 0,
+                    "NumberOfVACBans": 0,
+                    "VACBanned": False,
+                    "has_bans": False,
+                },
+                "steam_id_64": "76561199229309017",
+                "support": 874,
+                "team": "axis",
+                "unit_id": 0,
+                "unit_name": None,
+            },
+            "count": 48,
+            "deaths": 204,
+            "defense": 6420,
+            "kills": 151,
+            "offense": 5800,
+            "squads": {
+                "able": {
+                    "combat": 304,
+                    "deaths": 60,
+                    "defense": 1780,
+                    "has_leader": False,
+                    "kills": 33,
+                    "offense": 780,
+                    "players": [
+                        {
+                            "combat": 63,
+                            "country": "US",
+                            "deaths": 18,
+                            "defense": 380,
+                            "is_vip": False,
+                            "kills": 9,
+                            "level": 110,
+                            "loadout": "veteran",
+                            "name": "emfoor",
+                            "offense": 220,
+                            "profile": None,
+                            "role": "assault",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198979089668",
+                            "support": 125,
+                            "team": "axis",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 68,
+                            "country": "NL",
+                            "deaths": 14,
+                            "defense": 800,
+                            "is_vip": True,
+                            "kills": 5,
+                            "level": 43,
+                            "loadout": "standard issue",
+                            "name": "Makaj",
+                            "offense": 140,
+                            "profile": None,
+                            "role": "officer",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198041823654",
+                            "support": 2181,
+                            "team": "axis",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 64,
+                            "country": "",
+                            "deaths": 12,
+                            "defense": 140,
+                            "is_vip": False,
+                            "kills": 4,
+                            "level": 170,
+                            "loadout": "pionier",
+                            "name": "tinner2115",
+                            "offense": 300,
+                            "profile": None,
+                            "role": "engineer",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198892700816",
+                            "support": 0,
+                            "team": "axis",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 58,
+                            "country": "",
+                            "deaths": 4,
+                            "defense": 220,
+                            "is_vip": False,
+                            "kills": 6,
+                            "level": 129,
+                            "loadout": "ambusher",
+                            "name": "Cuervo",
+                            "offense": 40,
+                            "profile": None,
+                            "role": "antitank",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198354354474",
+                            "support": 0,
+                            "team": "axis",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 27,
+                            "country": "",
+                            "deaths": 6,
+                            "defense": 200,
+                            "is_vip": False,
+                            "kills": 5,
+                            "level": 67,
+                            "loadout": "veteran",
+                            "name": "capitanodrew",
+                            "offense": 40,
+                            "profile": None,
+                            "role": "heavymachinegunner",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198046677517",
+                            "support": 0,
+                            "team": "axis",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                        {
+                            "combat": 24,
+                            "country": "",
+                            "deaths": 6,
+                            "defense": 40,
+                            "is_vip": False,
+                            "kills": 4,
+                            "level": 10,
+                            "loadout": "standard issue",
+                            "name": "Dr.FishShitz",
+                            "offense": 40,
+                            "profile": None,
+                            "role": "automaticrifleman",
+                            "steam_bans": None,
+                            "steam_id_64": "76561199027409370",
+                            "support": 0,
+                            "team": "axis",
+                            "unit_id": 0,
+                            "unit_name": "able",
+                        },
+                    ],
+                    "support": 2306,
+                    "type": "infantry",
+                },
+                "baker": {
+                    "combat": 135,
+                    "deaths": 10,
+                    "defense": 600,
+                    "has_leader": False,
+                    "kills": 12,
+                    "offense": 960,
+                    "players": [
+                        {
+                            "combat": 50,
+                            "country": "",
+                            "deaths": 6,
+                            "defense": 500,
+                            "is_vip": False,
+                            "kills": 6,
+                            "level": 123,
+                            "loadout": "ammo carrier",
+                            "name": "WilliePeter",
+                            "offense": 480,
+                            "profile": None,
+                            "role": "spotter",
+                            "steam_bans": None,
+                            "steam_id_64": "76561198206929555",
+                            "support": 264,
+                            "team": "axis",
+                            "unit_id": 1,
+                            "unit_name": "baker",
+                        },
+                        {
+                            "combat": 85,
+                            "country": "US",
+                            "deaths": 4,
+                            "defense": 100,
+                            "is_vip": True,
+                            "kills": 6,
+                            "level": 184,
+                            "loadout": "veteran",
+                            "name": "DarkVisionary",
+                            "offense": 480,
+                            "profile": None,
+                            "role": "sniper",
+                            "steam_bans": None,
+                            "steam_id_64": "76561199166765040",
+                            "support": 0,
+                            "team": "axis",
+                            "unit_id": 1,
+                            "unit_name": "baker",
+                        },
+                    ],
+                    "support": 264,
+                    "type": "recon",
+                },
+            },
+            "support": 7323,
+        },
+    }
+
+
+game_state: GameState = {
+    "allied_score": 3,
+    "axis_score": 2,
+    "current_map": "",
+    "next_map": "",
+    "num_allied_players": 30,
+    "num_axis_players": 30,
+    "time_remaining": timedelta(10),
+}
+
+
+def construct_aplayer(
+    player_dict: dict, team_name: str = "allies", squad_name: str = "able"
+):
+    return PunishPlayer(
+        steam_id_64=player_dict["steam_id_64"],
+        name=player_dict["name"],
+        team=team_name,
+        squad=squad_name,
+        role=player_dict.get("role"),
+        lvl=int(player_dict.get("level")),
+    )
+
+
+# TODO: when should it note?
+
+
+def test_should_not_warn(team_view):
+    config = NoSoloTankConfig(number_of_warning=0)
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # able squad is a full tank squad
+    player = team_view["allies"]["squads"]["able"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.DISABLED == mod.should_warn_player(
+        watch_status, "able", aplayer
+    )
+
+    assert WatchStatus() == watch_status
+
+
+def test_should_warn_twice(team_view):
+    config = NoSoloTankConfig(
+        number_of_warning=2,
+        warning_interval_seconds=1,
+    )
+    mod = NoSoloTankAutomod(config, None)
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.APPLY == mod.should_warn_player(
+        watch_status, "baker", aplayer
+    )
+    assert PunishStepState.WAIT == mod.should_warn_player(
+        watch_status, "baker", aplayer
+    )
+    time.sleep(config.warning_interval_seconds)
+    assert PunishStepState.APPLY == mod.should_warn_player(
+        watch_status, "baker", aplayer
+    )
+    assert PunishStepState.WAIT == mod.should_warn_player(
+        watch_status, "baker", aplayer
+    )
+    time.sleep(config.warning_interval_seconds)
+    assert PunishStepState.GO_TO_NEXT_STEP == mod.should_warn_player(
+        watch_status, "baker", aplayer
+    )
+
+
+def test_should_warn_infinite(team_view):
+    config = NoSoloTankConfig(number_of_warning=-1, warning_interval_seconds=0)
+    mod = NoSoloTankAutomod(config, None)
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    for _ in range(100):
+        assert PunishStepState.APPLY == mod.should_warn_player(
+            watch_status, "able", aplayer
+        )
+
+
+def test_should_punish(team_view):
+    config = NoSoloTankConfig(
+        number_of_punish=2,
+        disable_punish_below_server_player_count=10,
+    )
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.APPLY == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_punish_wait(team_view):
+    config = NoSoloTankConfig(
+        number_of_punish=2,
+        punish_interval_seconds=60,
+        disable_punish_below_server_player_count=0,
+    )
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.APPLY == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    assert PunishStepState.WAIT == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_punish_twice(team_view):
+    config = NoSoloTankConfig(
+        number_of_punish=2,
+        punish_interval_seconds=1,
+        disable_punish_below_server_player_count=0,
+    )
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.APPLY == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    assert PunishStepState.WAIT == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    time.sleep(config.punish_interval_seconds)
+    assert PunishStepState.APPLY == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    time.sleep(config.punish_interval_seconds)
+    assert PunishStepState.GO_TO_NEXT_STEP == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_punish_too_little_players(team_view):
+    config = NoSoloTankConfig(
+        number_of_punish=2,
+        punish_interval_seconds=60,
+        disable_punish_below_server_player_count=60,
+    )
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.WAIT == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_punish_disabled(team_view):
+    config = NoSoloTankConfig(
+        number_of_punish=0,
+        punish_interval_seconds=0,
+        disable_punish_below_server_player_count=0,
+    )
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.DISABLED == mod.should_punish_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_shouldnt_kick_without_punish(team_view):
+    config = NoSoloTankConfig(
+        kick_after_max_punish=True,
+        kick_grace_period_seconds=0,
+        disable_kick_below_server_player_count=0,
+    )
+    mod = NoSoloTankAutomod(config, None)
+
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+
+    assert PunishStepState.DISABLED == mod.should_kick_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    watch_status.punished.setdefault(player["name"], []).append(datetime.now())
+    assert PunishStepState.APPLY == mod.should_kick_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_shouldnt_kick_disabled(team_view):
+    config = NoSoloTankConfig(
+        kick_after_max_punish=False,
+        kick_grace_period_seconds=0,
+        disable_kick_below_server_player_count=0,
+    )
+    mod = NoSoloTankAutomod(config, None)
+    # baker squad is a solo tank squad, w/ SL
+    watch_status = WatchStatus()
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+    watch_status.punished.setdefault(player["name"], []).append(datetime.now())
+
+    assert PunishStepState.DISABLED == mod.should_kick_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_should_wait_kick(team_view):
+    config = NoSoloTankConfig(
+        kick_after_max_punish=True,
+        kick_grace_period_seconds=1,
+        disable_kick_below_server_player_count=0,
+    )
+    mod = NoSoloTankAutomod(config, None)
+    watch_status = WatchStatus()
+    # baker squad is a solo tank squad, w/ SL
+    player = team_view["allies"]["squads"]["baker"]["players"][0]
+    aplayer = construct_aplayer(player)
+    watch_status.punished.setdefault(player["name"], []).append(datetime.now())
+
+    assert PunishStepState.WAIT == mod.should_kick_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    assert PunishStepState.WAIT == mod.should_kick_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+    time.sleep(1)
+    assert PunishStepState.APPLY == mod.should_kick_player(
+        watch_status,
+        team_view,
+        "baker",
+        team_view["allies"]["squads"]["baker"],
+        aplayer,
+    )
+
+
+def test_default_config():
+    config = get_config()
+    config = NoSoloTankConfig(**config["NOSOLOTANK_AUTO_MOD"])
+
+    assert config.enabled == False


### PR DESCRIPTION
Watches and warns/punishes/kicks the solo tankers SLs
(non-SLs are already managed by "no leader watch").

The armor squads usually come in crew.
But a player may open an armor squad and wait for his mates to enter.
So the automod won't do anything during the X first minutes ("note").
Then, based on configuration, it will begin a standard automod cycle (warn X times, punish X times, kick).

Based on the "no leader watch" automod.