### PR TITLE
Require only the change map permission to change maps

### DIFF
--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -810,11 +810,7 @@ ENDPOINT_PERMISSIONS: dict[Callable, list[str] | set[str] | str] = {
     ctl.set_broadcast: "api.can_change_broadcast_message",
     ctl.set_idle_autokick_time: "api.can_change_idle_autokick_time",
     ctl.set_map_shuffle_enabled: "api.can_change_map_shuffle_enabled",
-    ctl.set_map: {
-        "api.can_change_current_map",
-        "api.can_add_map_to_rotation",
-        "api.can_remove_map_from_rotation",
-    },
+    ctl.set_map:  "api.can_change_current_map",
     ctl.set_maprotation: {
         "api.can_add_map_to_rotation",
         "api.can_remove_map_from_rotation",


### PR DESCRIPTION
I am not sure what I was thinking when I originally wrote this.

Only require the actual change map permission to let users change the current map.

It is just a one line change but I did build it, make a test user and verify that it works.