### PR TITLE
Always use local time zone in frontend

### DIFF
--- a/rcongui/src/components/AuditLog/index.jsx
+++ b/rcongui/src/components/AuditLog/index.jsx
@@ -33,7 +33,7 @@ const AuditLogsTable = ({ auditLogs }) => {
       label: "Time",
       options: {
         customBodyRenderLite: (dataIndex) =>
-          moment(auditLogs.get(dataIndex)?.get("creation_time")).format(
+          moment.utc(auditLogs.get(dataIndex)?.get("creation_time")).local().format(
             "ddd Do MMM HH:mm:ss"
           ),
       },

--- a/rcongui/src/components/LogsHistory/logTable.js
+++ b/rcongui/src/components/LogsHistory/logTable.js
@@ -19,7 +19,7 @@ export default function LogsTable({ logs, downloadCSV }) {
       label: "Time",
       options: {
         customBodyRenderLite: (dataIndex) =>
-          moment.unix(logs[dataIndex].event_time).format("ddd Do MMM HH:mm:ss"),
+          moment.unix(logs[dataIndex].event_time).local().format("ddd Do MMM HH:mm:ss"),
       },
     },
     { name: "type", label: "Type" },

--- a/rcongui/src/components/LogsHistory/logsHistory.js
+++ b/rcongui/src/components/LogsHistory/logsHistory.js
@@ -228,6 +228,7 @@ class LogsHistory extends React.Component {
         customBodyRenderLite: (dataIndex) =>
           moment
             .unix(this.state.logs[dataIndex]?.event_time)
+            .local()
             .format("ddd Do MMM HH:mm:ss"),
       },
     },

--- a/rcongui/src/components/PlayerInfo/PlayerInfo.js
+++ b/rcongui/src/components/PlayerInfo/PlayerInfo.js
@@ -98,7 +98,7 @@ const Punishment = ({ punishments }) => {
       label: "Time",
       options: {
         customBodyRenderLite: (dataIndex) =>
-          moment(punishments[dataIndex].time).format("ddd Do MMM HH:mm:ss"),
+          moment.utc(punishments[dataIndex].time).local().format("ddd Do MMM HH:mm:ss"),
       },
     },
   ];

--- a/rcongui/src/components/PlayerView/playerList.js
+++ b/rcongui/src/components/PlayerView/playerList.js
@@ -34,6 +34,7 @@ import {
   ListItemAvatar,
 } from "@material-ui/core";
 import makeSteamProfileUrl from "../../utils/makeSteamProfileUrl";
+import moment from "moment";
 
 const zeroPad = (num, places) => String(num).padStart(places, "0");
 
@@ -169,7 +170,7 @@ const Flag = ({ data, onDeleteFlag }) => (
 );
 
 const formatPunitions = (profile) => {
-  const formatTime = (item) => item.get("time");
+  const formatTime = (item) => moment.utc(item.get("time")).local().format("ddd Do MMM HH:mm:ss");
   return profile
     .get("received_actions", [])
     .map((item) => (

--- a/rcongui/src/components/PlayersHistory/PlayerTile/PlayerPenalties.js
+++ b/rcongui/src/components/PlayersHistory/PlayerTile/PlayerPenalties.js
@@ -18,8 +18,8 @@ export const Penalites = ({ player }) => (
   <div>
     {player.get("received_actions", new List()).size < 1 ? "Clean record" : ""}
     {player.get("received_actions", new List()).map((action) => (
-      <p>{`${action.get("action_type")} ${moment(action.get("time")).format(
-        "LLL"
+      <p>{`${action.get("action_type")} ${moment.utc(action.get("time")).local().format(
+        "ddd Do MMM HH:mm:ss"
       )}: ${truncateString(action.get("reason"), 50)} by ${action.get(
         "by"
       )}`}</p>


### PR DESCRIPTION
Instead of using mixed UTC and local times, the frontend should use one timezone consistently. As local seems to be the more natural thing, I choosed to change all time usages I could find to the local timezone.
This includes the log view, which might be the most visible change with this commit (the time in the log view was UTC so far).