### PR TITLE
Add an endpoint to show a user their permissions

### DIFF
--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -6,6 +6,7 @@ from functools import wraps
 from typing import Any
 
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.models import Permission
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -207,3 +208,22 @@ def get_ingame_mods(request):
         result=ingame_mods(),
         failed=False,
     )
+
+@csrf_exempt
+@login_required()
+def get_own_user_permissions(request):
+    command_name = "get_own_user_permissions"
+
+    permissions = Permission.objects.filter(user=request.user)
+    trimmed_permissions = [
+        {
+            "permission": p['codename'],
+            "description": p['name'],
+        }
+        for p in permissions.values()
+    ]
+
+    return api_response(command=command_name, result={
+        "permissions": trimmed_permissions,
+        "is_superuser": request.user.is_superuser,
+        }, failed=False)

--- a/rconweb/api/urls.py
+++ b/rconweb/api/urls.py
@@ -70,6 +70,7 @@ endpoints: list[tuple[str, Callable]] = [
     ("is_logged_in", auth.is_logged_in),
     ("get_online_mods", auth.get_online_mods),
     ("get_ingame_mods", auth.get_ingame_mods),
+    ("get_own_user_permissions", auth.get_own_user_permissions),
     ("get_services", services.get_services),
     ("do_service", services.do_service),
     ("server_list", multi_servers.get_server_list),


### PR DESCRIPTION
* Add `get_own_user_permissions` endpoint to show a logged in user their user permissions and whether or not they are a super user (allows access to all endpoints regardless of permissions).

Output looks like

```json
{
  "result": {
    "permissions": [
      {
        "permission": "can_add_admin_roles",
        "description": "Can add HLL game server admin roles to players"
      },
      {
        "permission": "can_add_map_to_rotation",
        "description": "Can add a map to the rotation"
      },
      {
        "permission": "can_add_map_to_whitelist",
        "description": "Can add a map to the votemap whitelist"
      },
      {
        "permission": "can_add_maps_to_rotation",
        "description": "Can add maps to the rotation"
      },
      {
        "permission": "can_add_maps_to_whitelist",
        "description": "Can add multiple maps to the votemap whitelist"
      },
      {
        "permission": "can_add_player_comments",
        "description": "Can add comments to a players profile"
      }
    ],
    "is_superuser": true
  },
  "command": "get_own_user_permissions",
  "arguments": null,
  "failed": false,
  "error": null,
  "forwards_results": null
}
```