### PR TITLE
Add server number to get_status endpoint

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -1050,6 +1050,7 @@ class Rcon(ServerCtl):
             "nb_players": slots,
             "short_name": os.getenv("SERVER_SHORT_NAME", None) or "HLL Rcon",
             "player_count": slots.split("/")[0],
+            "server_number": int(get_server_number()),
         }
 
     @ttl_cache(ttl=60 * 60 * 24)


### PR DESCRIPTION
* Add the server number to the `get_status` endpoint

`get_status` is locked behind a permission and you have to be logged in and I don't think the server number is sensitive information.

Output looks like:

```json
{
  "result": {
    "name": "Saucymuffin's [BEER] Haus & Squidd Cafe Part Deux",
    "map": "elalamein_warfare",
    "nb_players": "0/100",
    "short_name": "MyServer",
    "player_count": "0",
    "server_number": 1
  },
  "command": "get_status",
  "arguments": {},
  "failed": false,
  "error": "",
  "forward_results": null
}
```