### PR TITLE
Add previous map endpoint

### DIFF
--- a/rconweb/api/history.py
+++ b/rconweb/api/history.py
@@ -30,6 +30,27 @@ logger = logging.getLogger("rconweb")
 
 @csrf_exempt
 @stats_login_required
+def get_previous_map(request):
+    command_name = "get_previous_map"
+    try:
+        prev_map = MapsHistory()[-1]
+        res = {
+            "name": prev_map['name'],
+            "start": datetime.datetime.fromtimestamp(prev_map['start']).isoformat() if prev_map['start'] else None,
+            "end": datetime.datetime.fromtimestamp(prev_map['end']).isoformat() if prev_map['end'] else None,
+        }
+
+        return api_response(result=res, command=command_name, failed=False)
+    except IndexError:
+        return api_response(result=None,command=command_name, failed=False)
+    except Exception as e:
+        logger.exception(e)
+        return api_response(result=None, command=command_name, failed=True, error=str(e))
+
+
+
+@csrf_exempt
+@stats_login_required
 def get_map_history(request):
     data = _get_data(request)
     res = MapsHistory()[:]

--- a/rconweb/api/urls.py
+++ b/rconweb/api/urls.py
@@ -88,6 +88,7 @@ endpoints: list[tuple[str, Callable]] = [
     ("flag_player", history.flag_player),
     ("unflag_player", history.unflag_player),
     ("player", history.get_player),
+    ("get_previous_map", history.get_previous_map),
     ("get_map_history", history.get_map_history),
     ("do_add_map_to_whitelist", votemap.do_add_map_to_whitelist),
     ("do_add_maps_to_whitelist", votemap.do_add_maps_to_whitelist),


### PR DESCRIPTION
* Add `get_previous_map` endpoint to show the last recorded map end.

No permission for it, except it's locked behind the public stats thing, and anyone with public stats already exposes their match history.

This was user requested to support a tool.

Output looks like (will return `None` if there is no map history):

```json
{
  "result": {
    "name": "stmariedumont_warfare",
    "start": "2023-10-23T14:45:34",
    "end": "2023-10-23T14:46:50"
  },
  "command": "get_previous_map",
  "arguments": null,
  "failed": true,
  "error": null,
  "forwards_results": null
```