### PR TITLE
Fix key errors when authorization headers are missing

### DIFF
--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -141,7 +141,7 @@ def login_required():
                 )
                 if not header_name.upper() == BEARER:
                     raw_api_key = None
-            except ValueError:
+            except (KeyError, ValueError):
                 raw_api_key = None
 
             try:

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -24,7 +24,7 @@ from .models import DjangoAPIKey, SteamPlayer
 logger = logging.getLogger("rconweb")
 
 AUTHORIZATION_HEADER = "HTTP_AUTHORIZATION"
-BEARER = "BEARER"
+BEARER = ("BEARER", "BEARER:")
 
 
 def update_mods(sender, instance, **kwargs):
@@ -137,9 +137,9 @@ def login_required():
             # requiring the user to be logged in
             try:
                 header_name, raw_api_key = request.META[AUTHORIZATION_HEADER].split(
-                    ": ", maxsplit=1
+                    maxsplit=1
                 )
-                if not header_name.upper() == BEARER:
+                if not header_name.upper().strip() in BEARER:
                     raw_api_key = None
             except (KeyError, ValueError):
                 raw_api_key = None

--- a/rconweb/api/models.py
+++ b/rconweb/api/models.py
@@ -16,6 +16,7 @@ class DjangoAPIKey(models.Model):
 
     class Meta:
         ordering = ("date_modified",)
+        verbose_name = "Django API Key"
 
 
 class SteamPlayer(models.Model):


### PR DESCRIPTION
Whoops. Didn't account for `KeyError`s when the authorization headers are missing.

Noticed this while keeping my UI settings branch up to date, this fixes it.