### PR TITLE
Fix mock patching class name

### DIFF
--- a/tests/test_ban_tk_connect.py
+++ b/tests/test_ban_tk_connect.py
@@ -57,7 +57,7 @@ def test_ban_excluded_weapon(*args):
         },
     ]
 
-    with mock.patch("rcon.game_logs.RecordedRcon") as rcon, mock.patch(
+    with mock.patch("rcon.game_logs.Rcon") as rcon, mock.patch(
         "rcon.game_logs.get_recent_logs", return_value={"logs": logs}
     ) as get:
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
@@ -119,7 +119,7 @@ def test_ban_success(*args):
         },
     ]
 
-    with mock.patch("rcon.game_logs.RecordedRcon") as rcon, mock.patch(
+    with mock.patch("rcon.game_logs.Rcon") as rcon, mock.patch(
         "rcon.game_logs.get_recent_logs", return_value={"logs": logs}
     ) as get:
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
@@ -193,7 +193,7 @@ def test_ban_ignored_kill(*args):
         },
     ]
 
-    with mock.patch("rcon.game_logs.RecordedRcon") as rcon, mock.patch(
+    with mock.patch("rcon.game_logs.Rcon") as rcon, mock.patch(
         "rcon.game_logs.get_recent_logs", return_value={"logs": logs}
     ) as get:
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
@@ -267,7 +267,7 @@ def test_ban_count_one_death(*args):
         },
     ]
 
-    with mock.patch("rcon.game_logs.RecordedRcon") as rcon, mock.patch(
+    with mock.patch("rcon.game_logs.Rcon") as rcon, mock.patch(
         "rcon.game_logs.get_recent_logs", return_value={"logs": logs}
     ) as get:
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
@@ -353,7 +353,7 @@ def test_ban_ignored_2_death(*args):
         },
     ]
 
-    with mock.patch("rcon.game_logs.RecordedRcon") as rcon, mock.patch(
+    with mock.patch("rcon.game_logs.Rcon") as rcon, mock.patch(
         "rcon.game_logs.get_recent_logs", return_value={"logs": logs}
     ) as get:
         rcon.get_vips_ids = mock.MagicMock(return_value=[])


### PR DESCRIPTION
I forgot to update this when we merged extended/recorded Rcons into a single class.