### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+db_data/
 .env
 broadcasts.txt
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
Add `db_data/` to `.gitignore`, I can't think of a compelling reason why we would want this in source control.

If anyone is a power user and is messing with their configuration, they'll know enough to remove this from gitignore.

Prevents anyone from stashing giant files, cluttering up `git status` output.