### PR TITLE
Capture new kick type, handle future new kick types

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -99,7 +99,7 @@ class Rcon(ServerCtl):
     camera_pattern = re.compile(r"\[(.*)\s{1}\((\d+)\)\] (.*)")
     teamswitch_pattern = re.compile(r"TEAMSWITCH\s(.*)\s\((.*\s>\s.*)\)")
     kick_ban_pattern = re.compile(
-        r"(KICK|BAN): \[(.*)\] (.*\[(KICKED|BANNED|PERMANENTLY|YOU|Host|Anti-Cheat)[^\]]*)(?:\])*"
+        r"(KICK|BAN): \[(.*)\] (.*\[(KICKED|BANNED|PERMANENTLY|YOU|Host|Anti-Cheat|[^\]]*)[^\]]*)(?:\])*"
     )
     vote_pattern = re.compile(
         r"VOTESYS: Player \[(.*)\] voted \[.*\] for VoteID\[\d+\]"
@@ -1372,6 +1372,12 @@ class Rcon(ServerCtl):
                 type_ = ""
             elif type_ == "Anti-Cheat":
                 type_ = "ANTI-CHEAT"
+            elif type_ == "KICKED":
+                type_ = "KICKED"
+            elif type_ == "BANNED":
+                type_ = "BANNED"
+            else:
+                type_ = "MISC"
 
             action = f"ADMIN {type_}".strip()
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -41,7 +41,7 @@ from rcon.rcon import Rcon
 I just need a multiline message in the RCON logs
 to test something]
 [4.56 sec (1675270564)] MESSAGE: player [ð“¼ð“ºð“¾ð“²ð“­ð“­ [KRKN](76561198062837577)], content [Please ignore this just need a message in the RCON logs to test something.]
-
+[3:41 min (1699465895)] KICK: [Elinho] has been kicked. [Kicked for failing auth]
 """,
             [
                 (
@@ -178,6 +178,11 @@ to test something]
                     "[4.56 sec (1675270564)]",
                     "1675270564",
                     "MESSAGE: player [ð“¼ð“ºð“¾ð“²ð“­ð“­ [KRKN](76561198062837577)], content [Please ignore this just need a message in the RCON logs to test something.]",
+                ),
+                (
+                    "[3:41 min (1699465895)]",
+                    "1699465895",
+                    "KICK: [Elinho] has been kicked. [Kicked for failing auth]",
                 ),
             ],
         )
@@ -561,6 +566,32 @@ def test_teamswitch(raw_log_line, expected):
                 "weapon": None,
                 "message": "KICK: [RyanJose] has been kicked. [BANNED FOR 2 HOURS FOR TEAM KILLING!]",
                 "sub_content": "has been kicked. [BANNED FOR 2 HOURS FOR TEAM KILLING!]",
+            },
+        ),
+        (
+            "KICK: [Elinho] has been kicked. [Kicked for failing auth]",
+            {
+                "action": "ADMIN MISC",
+                "player": "Elinho",
+                "steam_id_64_1": None,
+                "player2": None,
+                "steam_id_64_2": None,
+                "weapon": None,
+                "message": "KICK: [Elinho] has been kicked. [Kicked for failing auth]",
+                "sub_content": "has been kicked. [Kicked for failing auth]",
+            },
+        ),
+        (
+            "KICK: [Elinho] has been kicked. [totally new random reason!]",
+            {
+                "action": "ADMIN MISC",
+                "player": "Elinho",
+                "steam_id_64_1": None,
+                "player2": None,
+                "steam_id_64_2": None,
+                "weapon": None,
+                "message": "KICK: [Elinho] has been kicked. [totally new random reason!]",
+                "sub_content": "has been kicked. [totally new random reason!]",
             },
         ),
     ],


### PR DESCRIPTION
* Handle kick types of the variety: `[3:41 min (1699465895)] KICK: [Elinho] has been kicked. [Kicked for failing auth]`
* Parse future kick types that we haven't seen yet
* Both of these are collected under `ADMIN MISC` as the action, I asked T17 what this means, I did not receive a clear answer but it is *probably* an EAC thing.
* Added new log parsing tests, they pass.