### PR TITLE
Hotfix/sqlaclhemy relationship

### DIFF
--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -6,7 +6,7 @@ import unicodedata
 from functools import cmp_to_key
 
 from sqlalchemy import func
-from sqlalchemy.orm import contains_eager, defaultload
+from sqlalchemy.orm import contains_eager, selectinload
 from sqlalchemy.sql.functions import ReturnTypeFromArgs
 
 from rcon.commands import CommandFailedError
@@ -58,37 +58,33 @@ def get_player_profile(steam_id_64, nb_sessions):
 
 
 def get_player_profile_by_ids(sess, ids):
-    eager_load = [
-        PlayerSteamID.names,
-        PlayerSteamID.received_actions,
-        PlayerSteamID.blacklist,
-        PlayerSteamID.flags,
-        PlayerSteamID.watchlist,
-        PlayerSteamID.steaminfo,
-    ]
-
     return (
         sess.query(PlayerSteamID)
         .filter(PlayerSteamID.id.in_(ids))
-        .options(defaultload(*eager_load))
+        .options(
+            selectinload(PlayerSteamID.names),
+            selectinload(PlayerSteamID.received_actions),
+            selectinload(PlayerSteamID.blacklist),
+            selectinload(PlayerSteamID.flags),
+            selectinload(PlayerSteamID.watchlist),
+            selectinload(PlayerSteamID.steaminfo),
+        )
         .all()
     )
 
 
 def get_player_profile_by_steam_ids(sess, steam_ids):
-    eager_load = [
-        PlayerSteamID.names,
-        PlayerSteamID.received_actions,
-        PlayerSteamID.blacklist,
-        PlayerSteamID.flags,
-        PlayerSteamID.watchlist,
-        PlayerSteamID.steaminfo,
-    ]
-
     return (
         sess.query(PlayerSteamID)
         .filter(PlayerSteamID.steam_id_64.in_(steam_ids))
-        .options(defaultload(*eager_load))
+        .options(
+            selectinload(PlayerSteamID.names),
+            selectinload(PlayerSteamID.received_actions),
+            selectinload(PlayerSteamID.blacklist),
+            selectinload(PlayerSteamID.flags),
+            selectinload(PlayerSteamID.watchlist),
+            selectinload(PlayerSteamID.steaminfo),
+        )
         .all()
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,9 @@ requests==2.31.0
 steam==1.4.4
 # Alembic does not use semantic versioning, so be careful with the version numbers https://alembic.sqlalchemy.org/en/latest/front.html#versioning-scheme
 alembic==1.12.1
-# rq 1.15.* requires a higher redis version
-rq==1.15.1
+# rq-scheduler doesn't work with rq > 1.13.0 right now because of a deprecated `ColorizingStreamHandler` import
+rq==1.13.0
+rq-scheduler==0.13.0
 paramiko==3.3.1
 ftpretty==0.4.0
 pytz>=2023.3


### PR DESCRIPTION
* Changed all of the `backref` relationships to `back_populates` so relationships are explicit and viewable from both models
* Removed some redundant relationship options that are no longer necessary, they're picked up from the type annotations now
* I had to change the load options for player history because it was no longer able to join like it was when we were on `sqlalchemy 1.3`
* Accidentally commited the rq/rq-scheduler stuff to this branch apparently too whoops.