### PR TITLE
Downgrade rq, re-add missing rq-scheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,9 @@ requests==2.31.0
 steam==1.4.4
 # Alembic does not use semantic versioning, so be careful with the version numbers https://alembic.sqlalchemy.org/en/latest/front.html#versioning-scheme
 alembic==1.12.1
-# rq 1.15.* requires a higher redis version
-rq==1.15.1
+# rq-scheduler doesn't work with rq > 1.13.0 right now because of a deprecated `ColorizingStreamHandler` import
+rq==1.13.0
+rq-scheduler==0.13.0
 paramiko==3.3.1
 ftpretty==0.4.0
 pytz>=2023.3


### PR DESCRIPTION
* While merging updated requirements on other branches, I accidentally removed `rq-scheduler`
* Downgrades `rq` because newer versions are incompatible with the version of `rq-scheduler` we're using, it tries to import something that's deprecated