### PR TITLE
Log automod less verbose

### DIFF
--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -131,7 +131,7 @@ def _do_punitions(
 
 def do_punitions(rcon: Rcon, punitions_to_apply: PunitionsToApply):
     if punitions_to_apply:
-        logger.info(
+        logger.debug(
             "Automod will apply the following punitions %s",
             repr(punitions_to_apply),
         )

--- a/rcon/automods/seeding_rules.py
+++ b/rcon/automods/seeding_rules.py
@@ -232,7 +232,7 @@ class SeedingRulesAutomod:
         squad: dict,
         game_state: GameState,
     ) -> PunitionsToApply:
-        self.logger.info("Squad %s %s", squad_name, squad)
+        self.logger.debug("Squad %s %s", squad_name, squad)
         punitions_to_apply = PunitionsToApply()
         if not squad_name:
             self.logger.debug("Skipping None or empty squad %s %s", squad_name, squad)


### PR DESCRIPTION
**Prevents the automod.log file size to skyrocket**
By default, **automod includes in its log ALL the messages** the involved players have received **since they entered CRCON's base**. This behavior can rapidly generate a multi GB logfile if you're using a lot of automatic messages (votemaps, automods, custom scripts that send games stats, etc) on your server.

Most of the CRCON users won't notice this problem, as the log rotation caps the file size limit to 10MB.