### PR TITLE
Cleanup model typing, remove redundancies

### DIFF
--- a/rcon/types.py
+++ b/rcon/types.py
@@ -68,14 +68,15 @@ class DBLogLineType(TypedDict):
     raw: str
     content: str
     server: str
-    weapon: str
+    weapon: Optional[str]
 
 
 class PlayerStatsType(TypedDict):
     id: int
-    player_id: str
+    player_id: int
+    steam_id_64: str
     player: Optional[str]
-    steaminfo: SteamInfoType
+    steaminfo: Optional[SteamInfoType]
     map_id: int
     kills: Optional[int]
     kills_streak: Optional[int]
@@ -122,7 +123,7 @@ class MapInfo(TypedDict):
 class MapsType(TypedDict):
     id: int
     creation_time: datetime.datetime
-    star: datetime.datetime
+    start: datetime.datetime
     end: Optional[datetime.datetime]
     server_number: Optional[int]
     map_name: str
@@ -148,7 +149,7 @@ class ServerCountType(TypedDict):
     minute: datetime.datetime
     count: int
     players: List[PlayerAtCountType]
-    map: MapsType
+    map: str
     vip_count: int
 
 
@@ -192,6 +193,7 @@ class WatchListType(TypedDict):
     count: int
 
 
+# TODO: Remove? Not used anywhere
 class UserConfigType(TypedDict):
     key: str
     value: str
@@ -202,7 +204,7 @@ class PlayerProfileType(TypedDict):
     steam_id_64: str
     created: datetime.datetime
     names: List[PlayerNameType]
-    session: List[PlayerSessionType]
+    sessions: List[PlayerSessionType]
     sessions_count: int
     total_playtime_seconds: int
     current_playtime_seconds: int


### PR DESCRIPTION
Fixes almost all of the typing issues we had in `rcon/models.py` and removes some redundant explicit things we no longer need now that we're on sqlalchemy 2.x