### PR TITLE
Hotfix/UI settings docs

### DIFF
--- a/rcongui/src/components/UserSettings/autoMods.js
+++ b/rcongui/src/components/UserSettings/autoMods.js
@@ -321,127 +321,198 @@ export const SeedingAutoMod = ({
   describeEndpoint,
 }) => {
   const notes = `
-    {
-        /*
-            This auto-moderator has 4 steps, 1. internally noting (X times), 2. warning via direct message (Y times), 3. punish (Z times) 4. kick
-            Note that the state cycle for a given squad only resets once it finally has more than one member. So for example if you
-            disabled the kick and have 3 punishes configured, once the 3 punishes are
-            through that's it, nothing will happen anymore for that solotaker, even if he's still alone in his squad.
+  {
+    /*
+        This auto-moderator has 3 steps, 1. warning via direct message (Y times), 3. punish (Z times) 4. kick
 
-            Note 2: notes, warnings, punishes and kicks are tracked individual per player, not at the squad level.      
-        */
+        Note that the state cycle for a given squad only resets once the rule-violation is fixed. So for example if you
+        disabled the kick and have 3 punishes configured, once the 3 punishes are
+        through that's it, nothing will happen anymore for that player if they still break seeding rules.
+    */
+    "enabled": false,
 
-        /* Set to true to enable the auto moderation of solo tankers squads. */
-        "enabled": false,
+    /* Discord Webhook URL where audit logs should be sent. */
+    "discord_webhook_url": null,
 
-        /*
-            If this is set to true no warning / punish / kick will be applied for real
-            It turns the code into a "simulation" mode and only send what it would do to your discord audit log webhook      
-        */
-        "dry_run": true,
+    /*
+        Announce that the server is currently seeding when at least one seeding rule is enabled. When the player count exceeds
+        the max_player settings of all seeding rules, the announcement is disabled automatically until the next round.
 
-        /* Discord Webhook URL where audit logs should be sent. */
-        "discord_webhook_url": null,
+        This message occurs only when a player connects to a server. If the player count drops beneath the max_player setting of one
+        seeding rule and a new map starts, all connected players will NOT get an announcement.
+    */
+    "announcement_enabled": false,
 
-        /*
-            This is either an empty list [] or a list of flags to exempt a player
-            from the automod feature (could be useful for admins that open locked armor squads to be able to use camera).
-            To use, add a flag or multiple flags to the list, and then flag
-            the players you want to exempt in the CRCON UI      
-        */
-        "whitelist_flags": [],
-
-
-        /*
-            Step number 1
-
-            If a player is solo in a tank squad, he will be noted internally but no action is taken
-            Since we sometimes receive wrong data from the game server we note those players
-            and see if these squads still are solo the next time we check
-            set to 0 to disable (this means it will move to warn directly)
-            set to 1 to X to note the squad X times before we move to the warn step
-            (we recommend 2 : that should give enough time for mates to join)
-        */
-        "number_of_notes": 1,
-
-        /*
-            This is the number of seconds this auto-mod will wait until moving to
-            the next note or to warnings if the number_of_notes is reached
-        */
-        "notes_interval_seconds": 10,
-
-        /*
-            Step number 2
-
-            Send a direct warning message to the solo tank player
-            set to 0 to disable (this means it will move to punish directly), -1 for infinite warnings (will never go to punishes)
-            set to 1 or Y to warn him Y times before we move on to the punish step      
-        */
-        "number_of_warnings": 2,
-
-        /*
-            This is the text that will be displayed to warn players.
-            The following variables are available to fill into the text
-            {player_name}, {squad_name}, {received_warnings}, {max_warnings} and {next_check_seconds}
-        */
-        "warning_message": "Warning, {player_name} !\\n\\nYou can't play solo tank on this server !\\n\\nYou will be punished after {max_warnings} warnings\\n(you already received {received_warnings})\\n\\nNext check will happen automatically in {next_check_seconds}s.",
+    /*
+        {disallowed_roles}, {disallowed_roles_max_players}, {disallowed_weapons} and {disallowed_weapons_max_players}
+        are the allowed message parameters
+    */
+    "announcement_message": "We are trying to populate the server! That means special rules apply.\\n\\n- {disallowed_roles} are not allowed (until {disallowed_roles_max_players} players are online)\\n- {disallowed_weapons} are not allowed (until {disallowed_weapons_max_players} players are online)\\n\\nThanks for understanding and helping us seed!",
+    
+    /*
+        Step number 1
         
+        Send a direct warning message to the players that violate seeding rules
+        set to 0 to disable (this means it will move to punish directly), -1 for infinite warnings (will never go to punishes)
+        set to 1 or Y to warn squad Y times before we move on to the punish step
+    */
+    "number_of_warnings": 2,
 
-        /*
-            This is the number of seconds this auto-mod will wait until moving to
-            the next warning or to the punish if the number_of_warning's is reached      
-        */
-        "warning_interval_seconds": 60,
+    /*
+        {player_name}, {received_warnings}, {max_warnings}, {next_check_seconds} and {violation}
+        are the allowed message parameters
+    */
+    "warning_message": "Warning, {player_name}! You violate seeding rules on this server: {violation}\nYou will be punished after {max_warnings} warnings (you already received {received_warnings}), then kicked.\nNext check will happen automatically in {next_check_seconds}s.",
+    
+    /*
+        This is the number of seconds this auto-mod will wait until moving to
+        the next warning or to the punish stage if the number_of_warning's is reached
+    */
+    "warning_interval_seconds": 60,
+    
+    /*
+        Step number 2
         
+        If the player still violates a seeding rule after
+        the N warnings and the last warning_interval_seconds has elapsed, automod starts punishing
+        
+        Set to 0 to disable to punish entirely. I would advise setting warnings to infinity (-1) if you do that
+        Set to -1 for infinite punish (will never go to kicks)
+        Set to 1 or Z to apply Z punishes before we move to the next step (the kicks)
+    */
+    "number_of_punishments": 2,
 
-        /*
-            Step number 3
+    /*
+        This is the message that will be used in the punish
+        {player_name}, {received_punishes}, {max_punishes}, {next_check_seconds} and {violation}
+        are the allowed message parameters
+    */
+    "punish_message": "You violated seeding rules on this server: {violation}.\nYou're being punished by a bot ({received_punishes}/{max_punishes}).\nNext check in {next_check_seconds} seconds",
+    
+    /*
+        This is the number of seconds to wait between punishes
+        I wouldn't recommend setting a high value here (unless you chose infinite punishes) as once the player has died he has the opportunity to
+        stop violating the seeding rules, so no excuse. Also it's even more frustrating to respawn run 300m and die again ;)
+    */
+    "punish_interval_seconds": 60,
+    
+    /*
+        Step number 4
+        
+        Set the below value to false if you don't want to kick players after they reached the max amount of punishes
+        note that if you disable punishes it will never go to that step. no matter if it's set to true
+    */
+    "kick_after_max_punish": false,
 
-            If the player is still solo in his tank after
-            the N warnings and the last warning_interval_seconds has elapsed, automod starts punishing
-            
-            Set to 0 to disable to punish entirely. I would advise setting warnings to infinity (-1) if you do that
-            Set to -1 for infinite punish (will never go to kicks)
-            Set to 1 or Z to apply Z punishes before we move to the next step (the kicks)
-        */
-        "number_of_punishments": 2,
-        
-        
-        /*
-            This is the message that will be used in the punish
-            The following variables are available to fill into the text
-            {player_name}, {squad_name}, {received_punishes}, {max_punishes} and {next_check_seconds}      
-        */
-        "punish_message": "You violated solo tank rule on this server.\\nYou're being punished by a bot ({received_punishes}/{max_punishes}).\\nNext check in {next_check_seconds}s.",
-        
-        /* This is the number of seconds to wait between punishes (if the player is still solo tanking) */
-        "punish_interval_seconds": 40,
-        
-        
-        /* If the server has less players than the number you set below, not punish / kicks will be applied */
-        "min_server_players_for_punish": 40,
-        
-        /*
-            Step number 4
+    /* After the Step 2 has reached it's max punishes, this is the amount of time in seconds the auto-mod will wait before kicking */
+    "kick_grace_period_seconds": 120,
+    
+    /*
+        This is the message that will be used in the kick
+        {player_name}, {squad_name} and {kick_grace_period}
+        are the allowed message parameters
+    */
+    "kick_message": "You violated seeding rules on this server.\nYour grace period of {kick_grace_period}s has passed.\nYou failed to comply with the previous warnings.",
+    
+    /*
+        The disallowed roles is a seeding rule that ultimately prevents players from taking a role that should generally not
+        be used when a server has a playercount below a certain threshold (seeding).
+    */
+    "disallowed_roles": {
 
-            Set the below value to false if you don't want to kick players after they reached the max amount of punishes
-            note that if you disable punishes it will never go to that step. no matter if it's set to true
-        */
-        "kick_after_max_punish": true,
-        
-        /* If the server has fewer players than the number below, the auto-moderator will wait and not kick yet */
-        "min_server_players_for_kick": 6,
-        
-        /* After the Step 2 has reached it's max punishes, this is the amount of time in seconds the auto-mod will wait before kicking */
-        "kick_grace_period_seconds": 120,
-        
-        /*
-            This is the message that will be used in the kick
-            The following variables are available to fill into the text
-            {player_name}, {squad_name} and {kick_grace_period}      
-        */
-        "kick_message": "You violated solo tank rule on this server.\\nYour grace period of {kick_grace_period}s has passed.\\nYou failed to comply with the previous warnings."
+      /*
+        the player count of the server needed for this rule to be enforced. The number is inclusive, which means, if you use 5
+        this rule will be enforced for players 5 to max_players. If there are only 4 players on the server, the rules will
+        not be enforced.
+      */
+      "min_players": 5,
+
+      /*
+        the player count of the server under which this rule should be enforced. The number is exclusive, which means, if you use 30
+        this rule will be enforced for players 1 to 29, once the 30 player connected, the rule will not be enforced anymore.
+      */
+      "max_players": 30,
+
+      /*
+        a list of roles that should not be taken by players.
+        Available roles are: 'officer', 'antitank', 'automaticrifleman', 'assault', 'heavymachinegunner', 
+            'support', 'sniper', 'spotter', 'rifleman', 'crewman', 'tankcommander', 'engineer', 'medic'
+      */
+      "roles": {
+        "tankcommander": "Tanks",
+        "crewman": "Tanks"
+      },
+
+      /* 
+        Violation message used as a description of the seeding violation when player is messaged, punished and kicked.
+        {role} can be used in the message and will be filled with the players role
+      */
+      "violation_message": "{role} are not allowed when server is seeding"
+    },
+
+    /*
+        The disallowed weapons is a seeding rule that prevents players from using defined weapons to kill other players. Different to the other
+        automods, this rule does not use the escalation path (message -> punish -> kick) as configured in the general seeding automod config.
+        Instead, players using one of the mentioned weapons (and given the server player count are in the bounds as configured) will be
+        punished directly. This automod will also continue to punish players if they continue using disallowed weapons, even if they were punished
+        already. The automod will not escalate to the kick stage, either.
+    */
+    "disallowed_weapons": {
+      /*
+        the player count of the server needed for this rule to be enforced. The number is inclusive, which means, if you use 5
+        this rule will be enforced for players 5 to max_players. If there are only 4 players on the server, the rules will
+        not be enforced.
+      */
+      "min_players": 5,
+
+      /*
+        the player count of the server under which this rule should be enforced. The number is exclusive, which means, if you use 30
+        this rule will be enforced for players 1 to 29, once the 30 player connected, the rule will not be enforced anymore.
+      */
+      "max_players": 30,
+
+      /*
+        map of weapons players should not use. The key of the map is the weapon class as used by the game
+        (https://gist.github.com/timraay/5634d85eab552b5dfafb9fd61273dc52#available-weapons),
+        whereas the value of the map is a human friendly name of the weapon (as it will be passed
+        to the {weapon} variable of the message parameter.
+      */
+      "weapons": {
+            "155MM HOWITZER [M114]": "Artillery"
+      },
+      "violation_message": "{weapon} are not allowed when server is seeding"
+    },
+
+
+    "enforce_cap_fight": {
+      /*
+        the player count of the server needed for this rule to be enforced. The number is inclusive, which means, if you use 5
+        this rule will be enforced for players 5 to max_players. If there are only 4 players on the server, the rules will
+        not be enforced.
+      */
+      "min_players": 5,
+
+      /*
+        the player count of the server under which this rule should be enforced. The number is exclusive, which means, if you use 30
+        this rule will be enforced for players 1 to 29, once the 30 player connected, the rule will not be enforced anymore.
+      */
+      "max_players": 30,
+
+      /*
+        The maximum number of caps a team can have while seeding. When a player gains offensive points while is team has
+        this number of caps capped, they will be warned/punished by this automod.
+      */
+      "max_caps": 3,
+      
+      /*
+        A boolean to indicate if this rule should go straight to punish the player (instead of warn them first). This might be valuable
+        to enable, as the game will only refresh offensive points (which this rule is based upon) every minute. Capping a point takes 2 minutes in warfare mode.
+        A player might get warnings, but the damage capping a point with "just" two warnings might justify directly punishing the player.
+      */
+      "skip_warning": false,
+      "violation_message": "Attacking 4th cap while seeding is not allowed"
     }
+  }
     `;
 
   return (

--- a/rcongui/src/components/UserSettings/index.js
+++ b/rcongui/src/components/UserSettings/index.js
@@ -5,6 +5,7 @@ import { Button } from "@material-ui/core";
 import { withRouter } from "react-router";
 import Grid from "@material-ui/core/Grid";
 import { CopyBlock, dracula } from "react-code-blocks";
+import { toast } from "react-toastify";
 
 const endpointToNames = new Map();
 endpointToNames.set("get_audit_discord_webhooks_config", "Audit Webhooks");
@@ -40,25 +41,22 @@ const UserSetting = ({
   };
 
   const sendData = (endpoint) => {
-    console.log(`sending data=${JSON.stringify(data)}`);
     setErrors([]);
-    postData(`${process.env.REACT_APP_API_URL}${endpoint}`, {
-      ...JSON.parse(data),
-      errors_as_json: true,
-    })
-      .then((res) => showResponse(res, endpoint, true))
-      .then((res) => {
-        console.log(`post res=${JSON.stringify(res)}`);
-        if (res?.error) {
-          console.log(
-            `error len=${JSON.parse(res.error).length} res.error=${res.error}`
-          );
-          setErrors(JSON.parse(res.error));
-        }
-      });
+    try {
+      postData(`${process.env.REACT_APP_API_URL}${endpoint}`, {
+        ...JSON.parse(data),
+        errors_as_json: true,
+      })
+        .then((res) => showResponse(res, endpoint, true))
+        .then((res) => {
+          if (res?.error) {
+            setErrors(JSON.parse(res.error));
+          }
+        });
+    } catch (error) {
+      toast.error("Error parsing your settings JSON: " + error);
+    }
   };
-
-  console.log(`errors=${JSON.stringify(errors)}`);
 
   return (
     <>

--- a/rcongui/src/components/UserSettings/miscellaneous.js
+++ b/rcongui/src/components/UserSettings/miscellaneous.js
@@ -400,10 +400,17 @@ export const NameKicks = ({
   const notes = `
     {
         /*
-            A list of regular expressions player names are tested againstwhen they join,
+            A list of regular expressions player names are tested against when they join,
             any player name that matches any of the regular expressions will be kicked
             
             You can test your regex here: https://regex101.com/ (set the type to "Python")
+        */
+
+        /*
+          You must escape any \ character in your regular expressions
+          For example:
+            ^[\\d]+$ is correct
+            ^[\d]+$ is not correct and will cause JSON parsing errors
         */
         "regular_expressions": [],
 

--- a/rcongui/src/components/UserSettings/webHooks.js
+++ b/rcongui/src/components/UserSettings/webHooks.js
@@ -200,7 +200,7 @@ export const ChatWebhooks = ({
         */
         "hooks": [
             {
-                "url": "https://discord.com/api/webhooks/1156773876626374778/qyXM1nlYRNU-6R6eaL1xCESqMyK2jnfT1L9N_USz9V05JZS7h6EwOkzGu0hHzyVx00QG"
+                "url": "https://discord.com/api/webhooks/.../..."
             }
         ],
 


### PR DESCRIPTION
* Catch and display JSON parsing errors when setting user configurations instead of silently failing
* Fix the documentation on the seeding auto mod page (it was the no leader docs)
* Prevent chat web hooks from @ mentioning when they contain an admin ping word
* Remove an actual web hook I had left in an example