### PR TITLE
Unescape newlines/tabs for shared messages

### DIFF
--- a/rcongui/src/utils/fetchUtils.js
+++ b/rcongui/src/utils/fetchUtils.js
@@ -148,7 +148,9 @@ async function sendAction(command, parameters) {
 
 async function _checkResult(data) {
   if (data.result) {
-    return data.result.messages;
+    let unescaped = data.result.messages.map(ele => ele.replaceAll(/\\n/g, '\n'))
+    unescaped = unescaped.map(ele => ele.replaceAll(/\\t/g, '\t'))
+    return unescaped
   }
   return [];
 }


### PR DESCRIPTION
I am sure there is a better/smarter way to do this, but properly unescape newline and tab control characters in shared messages.