### PR TITLE
Strip tabs from commands accepting end user input that are lists

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -13,6 +13,11 @@ from rcon.utils import exception_in_chain
 logger = logging.getLogger(__name__)
 
 
+def convert_tabs_to_spaces(value: str) -> str:
+    """Convert tabs to a space to not break HLL tab delimited lists"""
+    return value.replace("\t", " ")
+
+
 def escape_string(s):
     """Logic taken from the official rcon client.
     There's probably plenty of nicer and more bulletproof ones
@@ -371,6 +376,7 @@ class ServerCtl:
         return self._get_list("get profanity", can_fail=False)
 
     def do_ban_profanities(self, profanities_csv) -> str:
+        profanities_csv = convert_tabs_to_spaces(profanities_csv)
         return self._str_request(f"BanProfanity {profanities_csv}")
 
     def do_unban_profanities(self, profanities_csv) -> str:
@@ -612,6 +618,7 @@ class ServerCtl:
         reason="",
         admin_name="",
     ) -> str:
+        reason = convert_tabs_to_spaces(reason)
         return self._str_request(
             f'tempban "{steam_id_64 or player_name}" {duration_hours} "{reason}" "{admin_name}"',
             log_info=True,
@@ -621,6 +628,7 @@ class ServerCtl:
     def do_perma_ban(
         self, player_name=None, steam_id_64=None, reason="", admin_name=""
     ) -> str:
+        reason = convert_tabs_to_spaces(reason)
         return self._str_request(
             f'permaban "{steam_id_64 or player_name}" "{reason}" "{admin_name}"',
             log_info=True,
@@ -634,6 +642,7 @@ class ServerCtl:
 
     @_escape_params
     def do_add_admin(self, steam_id_64, role, name) -> str:
+        name = convert_tabs_to_spaces(name)
         return self._str_request(
             f'adminadd "{steam_id_64}" "{role}" "{name}"', log_info=True
         )
@@ -643,6 +652,7 @@ class ServerCtl:
 
     @_escape_params
     def do_add_vip(self, steam_id_64, name) -> str:
+        name = convert_tabs_to_spaces(name)
         return self._str_request(f'vipadd {steam_id_64} "{name}"', log_info=True)
 
     def do_remove_vip(self, steam_id_64) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
+import pytest
+
 from rcon.utils import exception_in_chain
+from rcon.commands import convert_tabs_to_spaces
 
 
 class TestException(Exception):
@@ -51,3 +54,16 @@ def test_deeply_chained_implicit():
     e.__context__.__cause__.__context__ = DeepChainedException()
 
     assert exception_in_chain(e, DeepChainedException)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("some\tcontaining\twords", "some containing words"),
+        ("", ""),
+        ("\t", " "),
+        ("no tabs", "no tabs"),
+    ],
+)
+def test_convert_tabs_to_spaces(value, expected):
+    assert convert_tabs_to_spaces(value) == expected


### PR DESCRIPTION
* Convert tabs to a single whitespace for the commands that accept arbitrary user input that are stored by HLL as tab delimited lists to prevent broken lists/failed get commands
  * do_ban_profanities
  * do_temp_ban
  * do_perma_ban
  * do_add_admin
  * do_add_vip

https://gist.github.com/timraay/5634d85eab552b5dfafb9fd61273dc52#lists