### PR TITLE
Hotfix/api keys

### DIFF
--- a/rconweb/api/admin.py
+++ b/rconweb/api/admin.py
@@ -57,11 +57,6 @@ class DjangoAPIKeyAdmin(admin.ModelAdmin):
     list_filter = ("user",)
     search_fields = ("notes",)
 
-    def save_model(self, request, obj, form, change) -> None:
-        # If we don't include the salt, the hasher generates its own
-        obj.api_key = make_password(obj.api_key, salt=SECRET_KEY)
-        return super().save_model(request, obj, form, change)
-
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
         return form

--- a/rconweb/api/admin.py
+++ b/rconweb/api/admin.py
@@ -18,23 +18,6 @@ class SteamPlayerInline(admin.StackedInline):
     verbose_name_plural = "steamid"
 
 
-class DjangoAPIKeyInline(admin.StackedInline):
-    model = DjangoAPIKey
-    can_delete = True
-    verbose_name_plural = "API Keys"
-
-    show_change_link = True
-
-    extra = 0
-    readonly_fields = ["date_created", "date_modified"]
-
-
-# Define a new User admin
-class UserAdmin(BaseUserAdmin):
-    inlines = (SteamPlayerInline, DjangoAPIKeyInline)
-    # inlines = [SteamPlayerInline]
-
-
 class DjangoAPIKeyAdminForm(forms.ModelForm):
     class Meta:
         model = DjangoAPIKey
@@ -50,6 +33,25 @@ class DjangoAPIKeyAdminForm(forms.ModelForm):
             raise forms.ValidationError("Duplicate API keys are not allowed")
 
         return self.cleaned_data["api_key"]
+
+
+class DjangoAPIKeyInline(admin.StackedInline):
+    model = DjangoAPIKey
+    form = DjangoAPIKeyAdminForm
+
+    can_delete = True
+    verbose_name_plural = "API Keys"
+
+    show_change_link = True
+
+    extra = 0
+    readonly_fields = ["date_created", "date_modified"]
+
+
+# Define a new User admin
+class UserAdmin(BaseUserAdmin):
+    inlines = (SteamPlayerInline, DjangoAPIKeyInline)
+    # inlines = [SteamPlayerInline]
 
 
 class DjangoAPIKeyAdmin(admin.ModelAdmin):

--- a/rconweb/api/models.py
+++ b/rconweb/api/models.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.models import User
 from django.db import models
+from django.contrib.auth.hashers import make_password
+from rconweb.settings import SECRET_KEY
 
 
 class DjangoAPIKey(models.Model):
@@ -13,6 +15,12 @@ class DjangoAPIKey(models.Model):
 
     def __str__(self) -> str:
         return f"{self.api_key}"
+
+    def save(self, *args, **kwargs):
+        """Hash the API key"""
+        # If we don't include the salt, the hasher generates its own
+        self.api_key = make_password(self.api_key, salt=SECRET_KEY)
+        super().save()
 
     class Meta:
         ordering = ("date_modified",)


### PR DESCRIPTION
API keys that were created directly on a users page (as opposed to the dedicated form page for API keys) they weren't being hashed.

* Move the hashing action from the model form to the model itself so it's always performed.
* Set the form correctly for the stacked inline instance so it will perform minimum length validation

I did test this to verify that it hashes on both, checks minimum length on both, and that API keys it generates are able to be used to make API calls.