### PR TITLE
Handle invalid name none actions properly

### DIFF
--- a/rcon/types.py
+++ b/rcon/types.py
@@ -5,7 +5,6 @@ from typing import List, Optional, TypedDict
 
 # Have to inherit from str to allow for JSON serialization w/ pydantic
 class RconInvalidNameActionType(str, enum.Enum):
-    none = None
     warn = "WARN"
     kick = "KICK"
     ban = "BAN"

--- a/rcon/user_config/rcon_server_settings.py
+++ b/rcon/user_config/rcon_server_settings.py
@@ -58,16 +58,19 @@ class RconServerSettingsType(TypedDict):
     invalid_names: InvalidNameType
 
 
-def upper_case_action(v):
+def upper_case_action(v: str | None):
     """Allow users to enter actions in any case"""
-    return RconInvalidNameActionType(v.upper())
+    if v:
+        return RconInvalidNameActionType(v.upper())
+    else:
+        return v
 
 
 class InvalidName(BaseModel):
     enabled: bool = Field(default=False)
     action: Annotated[
         RconInvalidNameActionType, BeforeValidator(upper_case_action)
-    ] = Field(default=RconInvalidNameActionType.none)
+    ] | None = Field(default=None)
     whitespace_name_player_message: str = Field(default=WHITESPACE_NAME_PLAYER_MESSAGE)
     pineapple_name_player_message: str = Field(default=PINEAPPLE_NAME_PLAYER_MESSAGE)
     audit_message: str = Field(default=INVALID_NAME_AUDIT_MESSAGE)


### PR DESCRIPTION
* Properly handle `None` type actions for invalid names

I originally put the `None` action into the `RconInvalidNameActionType` enum which doesn't work properly because it's serialized to a string in JSON.

This updates the model to either be a `RconInvalidNameActionType` or `None` otherwise it throws errors when trying to save a default model, which is not great.

I built this and tested it against a live server with both whitespace/pineapple names.