### PR TITLE
Fix URL for server swapping and `get_connection_info` endpoint

### DIFF
--- a/rcongui/src/components/Header/serverStatus.js
+++ b/rcongui/src/components/Header/serverStatus.js
@@ -53,12 +53,13 @@ const Status = ({
             onClose={handleClose}
           >
             {serverList.map((s) => {
-              let link = `${window.location.protocol}//${window.location.hostname
-                }:${s.get("port")}${window.location.pathname}${window.location.hash
-                }`;
+              let link = ""
               if (s.get("link")) {
-                link = `${s.get("link")}${window.location.pathname}${window.location.hash
-                  }`;
+                link = new URL(`${s.get('link')}${window.location.hash}`)
+              } else {
+                // Everyone should be setting their server URL, but for locally hosted instances just swap out the port
+                const regex = /:(\d+)/gm;
+                link = new URL(window.location.href.replace(regex, `:${s.get('port')}`))
               }
               return (
                 <MenuItem onClick={handleClose}>

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -475,7 +475,7 @@ def get_connection_info(request):
         {
             "name": ctl.get_name(),
             "port": os.getenv("RCONWEB_PORT"),
-            "link": str(config.server_url),
+            "link": str(config.server_url) if config.server_url else config.server_url,
             "server_number": int(get_server_number()),
         },
         failed=False,


### PR DESCRIPTION
* Fix the `get_connection_info` which wasn't properly returning `null` when `RconServerSettingsUserConfig.server_url` was `None`
* Fix the GUI which would endlessly add extra `/` characters to the URL when swapping between servers

Manually tested this on a local build connected to two servers, both without `server_url` set and with, seems to work just fine.