### PR TITLE
Convert get_audit_logs endpoint to GET not POST

### DIFF
--- a/rcongui/src/components/AuditLog/index.jsx
+++ b/rcongui/src/components/AuditLog/index.jsx
@@ -76,12 +76,12 @@ const AuditLog = ({ classes }) => {
   const [timeSort, setTimeSort] = React.useState("desc");
 
   const getAuditLogs = () => {
-    postData(`${process.env.REACT_APP_API_URL}get_audit_logs`, {
+    get("get_audit_logs?" + new URLSearchParams({
       usernames: usernameSearch,
       commands: commandSearch,
       parameters: paramSearch,
       time_sort: timeSort,
-    })
+    }))
       .then((res) => showResponse(res, "get_audit_logs", false))
       .then((res) => {
         setAuditLogs(fromJS(res.result));

--- a/rconweb/api/audit_log.py
+++ b/rconweb/api/audit_log.py
@@ -91,7 +91,7 @@ def get_audit_logs_autocomplete(request):
 @csrf_exempt
 @login_required()
 @permission_required("api.can_view_audit_logs", raise_exception=True)
-@require_http_methods(['POST'])
+@require_http_methods(['GET'])
 @require_content_type()
 def get_audit_logs(request):
     data = _get_data(request)


### PR DESCRIPTION
* Convert the `get_audit_logs` endpoint to require `GET` not `POST`
* Update the GUI to call it correctly

Built it locally and did some quick minimal testing and it filters correctly.