### PR TITLE
Update ttl_cache

### DIFF
--- a/rcon/cache_utils.py
+++ b/rcon/cache_utils.py
@@ -2,9 +2,12 @@ import functools
 import logging
 import os
 import pickle
+from typing import Callable
 from contextlib import contextmanager
+from cachetools.func import ttl_cache as cachetools_ttl_cache
 
 import redis
+import redis.exceptions
 import simplejson
 
 logger = logging.getLogger(__name__)
@@ -20,13 +23,22 @@ class RedisCached:
         pool,
         ttl_seconds,
         function,
+        function_cache_unavailable: Callable | None = None,
+        red: redis.StrictRedis | None = None,
         is_method=False,
         cache_falsy=True,
         serializer=simplejson.dumps,
         deserializer=simplejson.loads,
     ):
-        self.red = redis.Redis(connection_pool=pool)
+        if pool is None:
+            pool = get_redis_pool()
+
+        if red is None:
+            self.red = redis.Redis(connection_pool=pool)
+        else:
+            self.red = red
         self.function = function
+        self.function_cache_unavailable = function_cache_unavailable
         self.serializer = serializer
         self.deserializer = deserializer
         self.ttl_seconds = ttl_seconds
@@ -65,17 +77,21 @@ class RedisCached:
     def __call__(self, *args, **kwargs):
         val = None
         key = self.key(*args, **kwargs)
+        func = self.function
         try:
             val = self.red.get(key)
-        except redis.exceptions.RedisError:
-            logger.exception("Unable to use cache")
+        except redis.exceptions.RedisError as e:
+            logger.exception("Unable to use cache: %s", e)
+            if self.function_cache_unavailable:
+                func = self.function_cache_unavailable
+                logger.error("Using fallback function due to cache failure: %s", func)
 
         if val is not None:
             # logger.debug("Cache HIT for %s", self.key(*args, **kwargs))
             return self.deserializer(val)
 
         # logger.debug("Cache MISS for %s", self.key(*args, **kwargs))
-        val = self.function(*args, **kwargs)
+        val = func(*args, **kwargs)
 
         if not val and not self.cache_falsy:
             logger.debug("Caching falsy result is disabled for %s", self.__name__)
@@ -140,8 +156,19 @@ def get_redis_client(decode_responses=True):
     return redis.Redis(connection_pool=pool)
 
 
-def ttl_cache(ttl, *args, is_method=True, cache_falsy=True, **kwargs):
+def ttl_cache(
+    ttl,
+    *args,
+    is_method=True,
+    cache_falsy=True,
+    function_cache_unavailable=None,
+    **kwargs,
+):
     pool = get_redis_pool(decode_responses=False)
+    if os.getenv("DEBUG"):
+        # Allow use of in memory cache when running tests
+        logger.warning(f"Unable to connect to Redis, using memory cache")
+        return cachetools_ttl_cache(*args, ttl=ttl, **kwargs)
     if not pool:
         logger.error("Unable to connect to Redis")
         raise ConnectionError("Unable to connect to Redis")
@@ -151,6 +178,7 @@ def ttl_cache(ttl, *args, is_method=True, cache_falsy=True, **kwargs):
             pool,
             ttl,
             function=func,
+            function_cache_unavailable=function_cache_unavailable,
             is_method=is_method,
             cache_falsy=cache_falsy,
             serializer=pickle.dumps,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==23.11.0
 isort==5.13.0
 pytest~=7.4.3
+cachetools==5.3.2

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,69 @@
+from rcon.cache_utils import RedisCached, ttl_cache
+from unittest import mock
+import redis.exceptions
+import redis
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+
+class MockRedis:
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    def get(self, key):
+        raise redis.exceptions.RedisError
+
+    def setex(self, _1, _2, _3):
+        pass
+
+
+def _needs_qual_name():
+    pass
+
+
+def test_cache_unavailable(monkeypatch):
+    cached_func = mock.Mock(spec=_needs_qual_name)
+    uncached_func = mock.Mock(spec=_needs_qual_name)
+
+    c = RedisCached(
+        pool=None,
+        red=MockRedis(),
+        ttl_seconds=1,
+        function=cached_func,
+        function_cache_unavailable=uncached_func,
+        serializer=lambda x: None,
+        deserializer=lambda x: None,
+    )
+
+    c()
+
+    uncached_func.assert_called()
+    cached_func.assert_not_called()
+
+
+def test_cache_available():
+    cached_func = mock.Mock(spec=_needs_qual_name)
+    uncached_func = mock.Mock(spec=_needs_qual_name)
+
+    c = RedisCached(
+        pool=None,
+        ttl_seconds=1,
+        function=cached_func,
+        function_cache_unavailable=uncached_func,
+        serializer=lambda x: str(x),
+        deserializer=lambda x: str(x),
+    )
+
+    c()
+
+    cached_func.assert_called()
+    uncached_func.assert_not_called()
+
+
+def test_mem_cache_used(monkeypatch):
+    monkeypatch.setenv("DEBUG", "True")
+    # This is kind of janky but cachetools returns a decorated function not a class instance
+    # so we can't isinstance check it
+    c = ttl_cache(ttl=1)
+    assert not isinstance(c, RedisCached)


### PR DESCRIPTION
If `redis` is unavailable for any reason after CRCON starts, pulling user configs from the cache will fail and it will persist a new default instance to the database overwriting a users config:

```
[2023-12-14 19:06:32,907][ERROR] rcon.cache_utils cache_utils.py:__call__:71 | Unable to use cache
Traceback (most recent call last):
  File "/code/rcon/cache_utils.py", line 69, in __call__
    val = self.red.get(key)
          ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/commands/core.py", line 1829, in get
    return self.execute_command("GET", name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 536, in execute_command
    return conn.retry.call_with_retry(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/retry.py", line 49, in call_with_retry
    fail(error)
  File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 540, in <lambda>
    lambda error: self._disconnect_raise(conn, error),
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 526, in _disconnect_raise
    raise error
  File "/usr/local/lib/python3.11/site-packages/redis/retry.py", line 46, in call_with_retry
    return do()
           ^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 537, in <lambda>
    lambda: self._send_command_parse_response(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 513, in _send_command_parse_response
    return self.parse_response(conn, command_name, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 553, in parse_response
    response = connection.read_response()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/connection.py", line 500, in read_response
    response = self._parser.read_response(disable_decoding=disable_decoding)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/_parsers/resp2.py", line 15, in read_response
    result = self._read_response(disable_decoding=disable_decoding)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/redis/_parsers/resp2.py", line 38, in _read_response
    raise error
redis.exceptions.BusyLoadingError: Redis is loading the dataset in memory
[2023-12-14 19:06:32,972][WARNING] rcon.user_config.utils utils.py:load_from_db:101 | 1_ScorebotUserConfig not found, creating defaults
```

* Updates `ttl_cache` decorator to allow you to specify an alternate function to use if the cache is unavailable
* Updates cache utils to allow you to use an in memory cache when `DEBUG` is set (this still shouldn't be allowed in production or things like the workers won't function properly)
* Updates `RedisCached` to allow dependency injection for `redis` for easier testing
* Adds some tests

I did build this and connect it to a server, UI configs save and load correctly and I `grep`'d the logs, I don't think I broke anything else with this.