### PR TITLE
Don't crash when watch/unwatching a player with no name

### DIFF
--- a/rcongui/src/components/PlayersHistory/index.js
+++ b/rcongui/src/components/PlayersHistory/index.js
@@ -509,17 +509,19 @@ class PlayersHistory extends React.Component {
     return this.deleteVip(player.get("steam_id_64"), forwardVIP);
   }
   onAddToWatchList(player) {
+    const playerName = player.get("names")?.get(0)?.get("name")
     return this.setDoConfirmPlayer({
-      player: player.get("names").get(0).get("name"),
+      player: playerName,
       actionType: "watchlist",
       steam_id_64: player.get("steam_id_64"),
     });
   }
 
   onRemoveFromWatchList(player) {
+    const playerName = player.get("names")?.get(0)?.get("name")
     return this.removeFromWatchList(
       player.get("steam_id_64"),
-      player.get("names").get(0).get("name")
+      playerName
     );
   }
 


### PR DESCRIPTION
* Allow the player history grid to add or remove a watch from a player with no name

You can add a watch to a player with no name from the settings page, but the player history grid would throw an exception when trying to access the players name since they don't exist.

Built/tested it locally and it works fine.