### PR TITLE
Update backend to support windows store player IDs

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -44,7 +44,7 @@ from rcon.utils import (
     ALL_ROLES,
     ALL_ROLES_KEY_INDEX_MAP,
     INDEFINITE_VIP_DATE,
-    _get_default_info_dict,
+    default_player_info_dict,
     get_server_number,
     parse_raw_player_info,
 )
@@ -204,7 +204,7 @@ class Rcon(ServerCtl):
             except Exception:
                 logger.error("Failed to get info for %s", futures[future])
                 fail_count += 1
-                player_data = _get_default_info_dict(futures[future][NAME])
+                player_data = default_player_info_dict(futures[future][NAME])
             player = futures[future]
             player.update(player_data)
             players_by_id[player[STEAMID]] = player

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -67,6 +67,7 @@ def get_steam_api_key() -> str | None:
 
 
 @ttl_cache(60 * 60 * 24, cache_falsy=False, is_method=False)
+@filter_steam_id()
 def get_steam_profile(steamd_id) -> Any | None:
     profiles = get_steam_profiles([steamd_id])
     if not profiles or len(profiles) == 0:

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import math
-import re
 import time
 from functools import wraps
 from typing import Any, Mapping
@@ -17,11 +16,10 @@ from rcon.user_config.steam import SteamUserConfig
 logger = logging.getLogger(__name__)
 
 last_steam_api_key_warning = datetime.datetime.now()
-steam_id_64_pattern = re.compile(r"\d{17}")
 
 
 def is_steam_id_64(steam_id_64: str) -> bool:
-    if re.match(steam_id_64_pattern, steam_id_64):
+    if len(steam_id_64) == 17 and steam_id_64.isdigit():
         return True
     return False
 

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -43,7 +43,7 @@ def filter_steam_id(return_value: Any = None):
         @wraps(f)
         def wrapper(steamd_id: str, *args, **kwargs):
             if is_steam_id_64(steamd_id):
-                return wrapper(steamd_id=steamd_id, *args, **kwargs)
+                return f(steamd_id=steamd_id, *args, **kwargs)
             else:
                 return lambda: return_value
 

--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -609,7 +609,7 @@ def is_invalid_name_pineapple(name: str) -> bool:
     return len(name) == 20 and name.endswith("?")
 
 
-def _get_default_info_dict(player) -> GetDetailedPlayer:
+def default_player_info_dict(player) -> GetDetailedPlayer:
     return {
         "name": player,
         "steam_id_64": "",
@@ -631,7 +631,7 @@ def _get_default_info_dict(player) -> GetDetailedPlayer:
 
 
 def parse_raw_player_info(raw: str, player) -> GetDetailedPlayer:
-    """"""
+    """Parse the result of the playerinfo command from the game server"""
 
     """
         Name: T17 Scott
@@ -646,7 +646,7 @@ def parse_raw_player_info(raw: str, player) -> GetDetailedPlayer:
 
     """
 
-    data = _get_default_info_dict(player)
+    data = default_player_info_dict(player)
     raw_data = {}
 
     for line in raw.split("\n"):

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -13,6 +13,7 @@ from rcon.rcon import Rcon
         (
             """
 [29:55 min (1606340690)] KILL: Karadoc(Axis/76561198080212634) -> Bullitt-FR(Allies/76561198000776367) with G43
+[29:55 min (1606340690)] KILL: Karadoc(Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) -> Bullitt-FR(Allies/76561198000776367) with G43
 [29:42 min (1606340690)] KILL: 湊あくあ(Axis/76561198202984515) -> fguitou(Allies/76561198034763447) with None
 [3:35 min (1675366030)] TEAM KILL: Ð¡Ð°ÑÐºÐ°(Allies/76561198346893462) -> Milk Dick(Allies/76561198044472891) with 155MM HOWITZER [M114]
 [2:07:28 hours (1675358597)] TEAM KILL: Oz(Allies/76561198163789126) -> Sic_Anger(Allies/76561199201574614) with PPSH 41 W/DRUM
@@ -48,6 +49,11 @@ to test something]
                     "[29:55 min (1606340690)]",
                     "1606340690",
                     "KILL: Karadoc(Axis/76561198080212634) -> Bullitt-FR(Allies/76561198000776367) with G43",
+                ),
+                (
+                    "[29:55 min (1606340690)]",
+                    "1606340690",
+                    "KILL: Karadoc(Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) -> Bullitt-FR(Allies/76561198000776367) with G43",
                 ),
                 (
                     "[29:42 min (1606340690)]",
@@ -219,6 +225,45 @@ def test_timestamp_parsing(raw_timestamp, expected):
             },
         ),
         (
+            "KILL: Reduktorius(Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) -> Loch(Allies/76561198086167606) with FG42 x4",
+            {
+                "action": "KILL",
+                "player": "Reduktorius",
+                "steam_id_64_1": "a21af8b5-59df-5vbr-88gf-ab4239r4g6f4",
+                "player2": "Loch",
+                "steam_id_64_2": "76561198086167606",
+                "weapon": "FG42 x4",
+                "message": "Reduktorius(Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) -> Loch(Allies/76561198086167606) with FG42 x4",
+                "sub_content": None,
+            },
+        ),
+        (
+            "KILL: Reduktorius(Axis/76561198136839181) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) with FG42 x4",
+            {
+                "action": "KILL",
+                "player": "Reduktorius",
+                "steam_id_64_1": "76561198136839181",
+                "player2": "Loch",
+                "steam_id_64_2": "a21af8b5-59df-5vbr-88gf-ab4239r4g6f4",
+                "weapon": "FG42 x4",
+                "message": "Reduktorius(Axis/76561198136839181) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) with FG42 x4",
+                "sub_content": None,
+            },
+        ),
+        (
+            "KILL: Reduktorius(Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) with FG42 x4",
+            {
+                "action": "KILL",
+                "player": "Reduktorius",
+                "steam_id_64_1": "a21af8b5-59df-5vbr-88gf-ab4239r4g6fz",
+                "player2": "Loch",
+                "steam_id_64_2": "a21af8b5-59df-5vbr-88gf-ab4239r4g6f4",
+                "weapon": "FG42 x4",
+                "message": "Reduktorius(Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6f4) with FG42 x4",
+                "sub_content": None,
+            },
+        ),
+        (
             "KILL: short(Axis/1234) -> (Axis/76561198136839181) -> Loch(Allies/76561198086167606) with FG42 x4",
             {
                 "action": "KILL",
@@ -228,6 +273,45 @@ def test_timestamp_parsing(raw_timestamp, expected):
                 "steam_id_64_2": "76561198086167606",
                 "weapon": "FG42 x4",
                 "message": "short(Axis/1234) -> (Axis/76561198136839181) -> Loch(Allies/76561198086167606) with FG42 x4",
+                "sub_content": None,
+            },
+        ),
+        (
+            "KILL: short(Axis/1234) -> (Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) -> Loch(Allies/76561198086167606) with FG42 x4",
+            {
+                "action": "KILL",
+                "player": "short(Axis/1234) -> ",
+                "steam_id_64_1": "a21af8b5-59df-5vbr-88gf-ab4239r4g6fz",
+                "player2": "Loch",
+                "steam_id_64_2": "76561198086167606",
+                "weapon": "FG42 x4",
+                "message": "short(Axis/1234) -> (Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) -> Loch(Allies/76561198086167606) with FG42 x4",
+                "sub_content": None,
+            },
+        ),
+        (
+            "KILL: short(Axis/1234) -> (Axis/76561198136839181) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) with FG42 x4",
+            {
+                "action": "KILL",
+                "player": "short(Axis/1234) -> ",
+                "steam_id_64_1": "76561198136839181",
+                "player2": "Loch",
+                "steam_id_64_2": "a21af8b5-59df-5vbr-88gf-ab4239r4g6fz",
+                "weapon": "FG42 x4",
+                "message": "short(Axis/1234) -> (Axis/76561198136839181) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) with FG42 x4",
+                "sub_content": None,
+            },
+        ),
+        (
+            "KILL: short(Axis/1234) -> (Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6fx) with FG42 x4",
+            {
+                "action": "KILL",
+                "player": "short(Axis/1234) -> ",
+                "steam_id_64_1": "a21af8b5-59df-5vbr-88gf-ab4239r4g6fz",
+                "player2": "Loch",
+                "steam_id_64_2": "a21af8b5-59df-5vbr-88gf-ab4239r4g6fx",
+                "weapon": "FG42 x4",
+                "message": "short(Axis/1234) -> (Axis/a21af8b5-59df-5vbr-88gf-ab4239r4g6fz) -> Loch(Allies/a21af8b5-59df-5vbr-88gf-ab4239r4g6fx) with FG42 x4",
                 "sub_content": None,
             },
         ),

--- a/tests/test_steam_utils.py
+++ b/tests/test_steam_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from rcon.steam_utils import is_steam_id_64
+
+
+@pytest.mark.parametrize(
+    "id_, expected",
+    [
+        ("1", False),
+        ("", False),
+        ("a21af8b5-59df-5vbr-88gf-ab4239r4g6f4", False),
+        ("76561198080212634", True),
+    ],
+)
+def test_is_steam_id_64(id_, expected):
+    assert is_steam_id_64(id_) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,12 @@
 import pytest
 
 from rcon.commands import convert_tabs_to_spaces
+from rcon.types import GetDetailedPlayer
 from rcon.utils import (
     exception_in_chain,
     is_invalid_name_pineapple,
     is_invalid_name_whitespace,
+    parse_raw_player_info,
 )
 
 
@@ -91,3 +93,106 @@ def test_is_invalid_name_whitespace(name, expected):
 )
 def test_is_invalid_name_pineapple(name, expected):
     assert is_invalid_name_pineapple(name) == expected
+
+
+def mock_get_detailed_player(
+    name,
+    steam_id_64,
+    team,
+    role,
+    unit_id,
+    unit_name,
+    loadout,
+    kills,
+    deaths,
+    combat,
+    defense,
+    offense,
+    support,
+    level,
+    is_vip=False,
+    profile=None,
+) -> GetDetailedPlayer:
+    return {
+        "name": name,
+        "steam_id_64": steam_id_64,
+        "team": team,
+        "role": role,
+        "unit_id": unit_id,
+        "unit_name": unit_name,
+        "combat": combat,
+        "deaths": deaths,
+        "kills": kills,
+        "defense": defense,
+        "level": level,
+        "loadout": loadout,
+        "offense": offense,
+        "support": support,
+        "is_vip": is_vip,
+        "profile": profile,
+    }
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (
+            """Name: MasterShake
+steamID64: 76561199502921234
+Team: Axis
+Role: Support
+Unit: 9 - JIG
+Loadout: Standard Issue
+Kills: 11 - Deaths: 9
+Score: C 72, O 100, D 220, S 65
+Level: 16
+""",
+            mock_get_detailed_player(
+                name="",
+                steam_id_64="76561199502921234",
+                team="axis",
+                role="support",
+                unit_id=9,
+                unit_name="jig",
+                loadout="standard issue",
+                kills=11,
+                deaths=9,
+                combat=72,
+                offense=100,
+                defense=220,
+                support=65,
+                level=16,
+            ),
+        ),
+        (
+            """Name: MasterShake
+steamID64: a21af8b5-59df-5vbr-88gf-ab4239r4g6f4
+Team: Axis
+Role: Support
+Unit: 9 - JIG
+Loadout: Standard Issue
+Kills: 11 - Deaths: 9
+Score: C 72, O 100, D 220, S 65
+Level: 16
+""",
+            mock_get_detailed_player(
+                name="",
+                steam_id_64="a21af8b5-59df-5vbr-88gf-ab4239r4g6f4",
+                team="axis",
+                role="support",
+                unit_id=9,
+                unit_name="jig",
+                loadout="standard issue",
+                kills=11,
+                deaths=9,
+                combat=72,
+                offense=100,
+                defense=220,
+                support=65,
+                level=16,
+            ),
+        ),
+    ],
+)
+def test_parse_raw_player_info(raw, expected):
+    assert parse_raw_player_info(raw=raw, player="") == expected


### PR DESCRIPTION
* Update the kill/team kill log parsing regex to support windows store IDs
* Refactor the player info command result parsing for easier testing
* Update various steam utilities to only call the steam API if the player ID is an actual steam ID
* Add various tests

I did build this, run the tests (some of the tests fail but it's unrelated to this and should be failing on master as well), assign a steam API key and connect it to a server with actual players on it and let it run a bit and poked around, I believe this works correctly.

I am curious/suspect there might be a better way to do the filtering decorators and I am all ears.

I do have to fix some cache handling errors from #410 but you'll only see that issue if redis is unavailable, and docker desktop (where I almost exclusively do this stuff) likes to have random DNS lookup issues which is how I noticed.