### PR TITLE
Parse prematurely expired votekicks

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -121,7 +121,7 @@ class Rcon(ServerCtl):
         r"VOTESYS: Player \[(.*)\] Started a vote of type \(.*\) against \[(.*)\]. VoteID: \[\d+\]"
     )
     vote_complete_pattern = re.compile(r"VOTESYS: Vote \[\d+\] completed. Result: (.*)")
-    vote_expired_pattern = re.compile(r"VOTESYS: Vote \[\d+\] expired")
+    vote_expired_pattern = re.compile(r"VOTESYS: Vote \[\d+\] (expired|prematurely)")
     vote_passed_pattern = re.compile(r"VOTESYS: (Vote Kick \{(.*)\} .*\[(.*)\])")
     # Need the DOTALL flag to allow `.` to capture newlines in multi line messages
     message_pattern = re.compile(

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -12,6 +12,7 @@ from rcon.rcon import Rcon
     [
         (
             """
+[2:14:33 hours (1703272319)] VOTESYS: Vote [3] prematurely expired.
 [29:55 min (1606340690)] KILL: Karadoc(Axis/76561198080212634) -> Bullitt-FR(Allies/76561198000776367) with G43
 [29:42 min (1606340690)] KILL: 湊あくあ(Axis/76561198202984515) -> fguitou(Allies/76561198034763447) with None
 [3:35 min (1675366030)] TEAM KILL: Ð¡Ð°ÑÐºÐ°(Allies/76561198346893462) -> Milk Dick(Allies/76561198044472891) with 155MM HOWITZER [M114]
@@ -44,6 +45,11 @@ to test something]
 [3:41 min (1699465895)] KICK: [Elinho] has been kicked. [Kicked for failing auth]
 """,
             [
+                (
+                    "[2:14:33 hours (1703272319)]",
+                    "1703272319",
+                    "VOTESYS: Vote [3] prematurely expired.",
+                ),
                 (
                     "[29:55 min (1606340690)]",
                     "1606340690",
@@ -653,6 +659,19 @@ def test_kicks(raw_log_line, expected):
                 "weapon": None,
                 "message": "Vote [10] expired before completion",
                 "sub_content": "Vote [10] expired before completion",
+            },
+        ),
+        (
+            "VOTESYS: Vote [3] prematurely expired.",
+            {
+                "action": "VOTE EXPIRED",
+                "player": None,
+                "steam_id_64_1": None,
+                "player2": None,
+                "steam_id_64_2": None,
+                "weapon": None,
+                "message": "Vote [3] prematurely expired.",
+                "sub_content": "Vote [3] prematurely expired.",
             },
         ),
         (


### PR DESCRIPTION
* Update log parsing to capture `prematurely` expired vote kicks, whatever the hell those are
* Update tests

Example: 

```
logs/log_event_loop_1.log:[2023-12-22 21:26:33,801][ERROR] rcon.rcon rcon.py:parse_logs:1562 | Unable to parse line: '[2:14:33 hours (1703272319)] 1703272319 VOTESYS: Vote [3] prematurely expired.'
```