### PR TITLE
Fix last session recording when no session

### DIFF
--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -395,6 +395,13 @@ def save_end_player_session(steam_id_64, timestamp):
             .first()
         )
 
+        if last_session is None:
+            logger.warning(
+                "Can't record player session for %s, last session not found",
+                steam_id_64,
+            )
+            return
+
         if last_session.end:
             logger.warning(
                 "Last session was already ended for %s. Creating a new one instead",


### PR DESCRIPTION
* Don't attempt to record the end of a session that doesn't exist

If a player disconnects, but CRCON was not running when they joined to have a session created in the first place, it throws an exception.