### PR TITLE
Pass allowed mentions as a dict not list due to discord API changes

### DIFF
--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -201,7 +201,7 @@ def send_log_line_webhook_message(
 
     wh.content = content
     wh.add_embed(embed)
-    wh.allowed_mentions = allowed_mentions["user"] + allowed_mentions["roles"]
+    wh.allowed_mentions = allowed_mentions
     wh.execute()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ simplejson==3.19.2
 psycopg2-binary
 sentry-sdk[django]==1.39.1
 python-dateutil==2.8.2
-git+https://github.com/cemathey/python-discord-webhook.git@4d79ab09526b96a2cc86c50ca1c609d7b644c6c7
+discord-webhook
 requests==2.31.0
 steam==1.4.4
 # Alembic does not use semantic versioning, so be careful with the version numbers https://alembic.sqlalchemy.org/en/latest/front.html#versioning-scheme


### PR DESCRIPTION
At some point in the last day or so Discord stopped accepting allowed mentions as a list and now requires them to be passed as a dict.

https://discord.com/developers/docs/resources/channel#allowed-mentions-object

We're also not using any of the modifications I made on the fork of `discord_webhook` so I've reverted it to the upstream version.

Tested this and it works just fine now.