### PR TITLE
Fix VIP expiration dates when no player steam ID record exists

### DIFF
--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -295,11 +295,12 @@ def _save_player_alias(sess, steamid, player_name, timestamp=None):
     return name
 
 
-def save_player(player_name, steam_id_64, timestamp=None):
+def save_player(player_name, steam_id_64, timestamp=None) -> None:
+    """Create a PlayerSteamID record if non existent and save the player name alias"""
     with enter_session() as sess:
         steamid = _save_steam_id(sess, steam_id_64)
         _save_player_alias(
-            sess, steamid, player_name, timestamp or datetime.datetime.now()
+            sess, steamid, player_name, timestamp or datetime.datetime.now().timestamp()
         )
 
 


### PR DESCRIPTION
As identified by [KL 彡 Fw.Schultz](https://discord.com/channels/685692524442026020/685695097349734469/1189923485238169743) when a VIP file was uploaded, but the player had never been on the server their expiration date would not be set correctly.

* Create a PlayerSteamID record if `do_add_vip` tries to add VIP to a player without a record
* Simplify setting VIP expirations

I built this, verified it works correctly when uploading a file and when an expiration date is set through the GUI. Expired VIPs are still pruned correctly when the service runs.