### PR TITLE
Avoid theme name collision with Django admin site

### DIFF
--- a/rcongui/src/App.js
+++ b/rcongui/src/App.js
@@ -357,11 +357,11 @@ const hllNoBg = createMuiTheme({
 function App() {
   const [isEmbed, setIsEmbed] = React.useState(false);
   const [userTheme, setThemeName] = React.useState(
-    localStorage.getItem("theme")
+    localStorage.getItem("crconTheme")
   );
   const setTheme = (name) => {
     setThemeName(name);
-    localStorage.setItem("theme", name);
+    localStorage.setItem("crconTheme", name);
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
Django and React were both using the same theme name, and the Django admin site would reset the theme to `auto` if it didn't recognize a theme name.

This will reset everyones themes to default when they upgrade, but it will stop resetting the themes when people use the admin site and it's trivial to set their theme again.