### PR TITLE
Don't cause IndexError's when current rotation is empty

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -1347,8 +1347,13 @@ class Rcon(ServerCtl):
                 logger.info("Removing from rotation: '%s'", map_without_number)
                 super().do_remove_map_from_rotation(map_without_number)
 
-            last = current[0]
-            map_number = {last: 1}
+            if len(current) > 0:
+                last = current[0]
+                map_number = {last: 1}
+            else:
+                last = rotation[0]
+                map_number = {}
+
             for map_ in rotation:
                 logger.info("Adding to rotation: '%s'", map_)
                 super().do_add_map_to_rotation(map_, last, map_number.get(last, 1))


### PR DESCRIPTION
In some scenario(s) it is possible to end up with an empty map rotation (I haven't investigated that part), which will cause `set_maprotation` to fail:

```
[2024-01-03 16:12:45,899][INFO] rcon.rcon rcon.py:set_maprotation:1346 | Current rotation: []
[2024-01-03 16:12:45,899][ERROR] rcon.auto_settings auto_settings.py:do_run_commands:202 | Unable to apply set_maprotation {'rotation': ['remagen_warfare', 'carentan_warfare', 'stmariedumont_warfare', 'hurtgenforest_warfare_V2', 'foy_warfare', 'utahbeach_warfare', 'stmereeglise_warfare', 'purpleheartlane_warfare', 'hill400_warfare', 'omahabeach_warfare']}
Traceback (most recent call last):
  File "/code/rcon/auto_settings.py", line 200, in do_run_commands
    rcon.__getattribute__(command)(**params)
  File "/code/rcon/rcon.py", line 1357, in set_maprotation
    last = current[0]
           ~~~~~~~^^^
IndexError: list index out of range
```

I tested this change against an RCON I host that ended up with the rotation empty since I wasn't sure how to induce that myself without tweaking more stuff and it fixed the problem.