### PR TITLE
Hotfix/resetting user configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ cp default.env .env
 
 **Note**: if you don't see the `.env` file you need to activate the show hidden files option on Windows. On Linux don't forget the `-a`: `ls -a`
 
-**Note**: If you make _any_ changes to your `.env` you will have to recreate (`docker compose up -d --force-recreate --remove-orphans` your containers before it will take effect), (if you `docker compose restart` it will not take effect)
+**Note**: If you make _any_ changes to your `.env` you will have to recreate (`docker compose up -d --remove-orphans` your containers before it will take effect), (if you `docker compose restart` it will not take effect)
 
 **Note**: The values in `.env` are used by `docker` when it starts the container and they're referenced in your `compose` files, you should only edit (unless you really know what you are doing) values in `.env` and not the `compose` files.
 
@@ -217,21 +217,23 @@ Check out a tagged release (substitute the release you want):
 Get the newest docker images and restart your containers:
 
     docker compose pull
-    docker compose up -d --force-recreate --remove-orphans
+    docker compose up -d --remove-orphans
 
 #### Windows
+
 Substitute the release you want in `git checkout`:
 
     git fetch --tags
     git checkout v7.0.2
-    docker compose pull && docker compose -f docker-compose.yml -f docker-compose.windows.yml up -d --force-recreate --remove-orphans
+    docker compose pull && docker compose -f docker-compose.yml -f docker-compose.windows.yml up -d --remove-orphans
 
 #### Raspberry-Pi or any ARM32v7
+
 Substitute the release you want in `git checkout`:
 
     git fetch --tags
     git checkout v7.0.2
-    docker compose -f docker-compose.yml -f docker-compose.arm32v7.yml up --build -d --force-recreate --remove-orphans
+    docker compose -f docker-compose.yml -f docker-compose.arm32v7.yml up --build -d --remove-orphans
 
 Or download the [latest zip release](https://github.com/MarechJ/hll_rcon_tool/releases/latest)
 
@@ -307,13 +309,13 @@ If you don't have a `.env` you wou must set the following environment variables 
 
 ### Build the images
 
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml build 
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml build
 
 ### Run it!
 
 Once the images are built (which can take a considerable amount of time depending on your hardware specs), and once it's configured properly (see the installation part of this README), then simply use `docker compose` to create the containers:
 
-    docker compose up -d --force-recreate --remove-orphans
+    docker compose up -d --remove-orphans
 
 If you don't want to use `docker compose` (which you really should, it's just easier) then you would have to properly set/create/run the Docker containers yourself, consult Docker's documentation please.
 
@@ -333,7 +335,7 @@ The `backend` is split into two major components, the `rcon` package and the `rc
 
 The `supervisor` container manages starting and restarting all of the optional/non optional (if you want a fully functioning CRCON) services, all of which are implemented in the `rcon` package or are a standalone program like `rq` or `cron`.
 
-The `frontend` is a combination of `nginx` (used as a reverse proxy) and `gunicorn` web servers that handles all of the HTTP requests and serves all of the responses. The flow is `incoming request` -> `nginx` -> `gunicorn` -> `nginx` -> `outgoing response`. `nginx` handles serving all of the static content like HTML/css/images, and `Django` processes all of the API calls that return dynamic content. 
+The `frontend` is a combination of `nginx` (used as a reverse proxy) and `gunicorn` web servers that handles all of the HTTP requests and serves all of the responses. The flow is `incoming request` -> `nginx` -> `gunicorn` -> `nginx` -> `outgoing response`. `nginx` handles serving all of the static content like HTML/css/images, and `Django` processes all of the API calls that return dynamic content.
 
 #### `rcon` package
 
@@ -369,7 +371,7 @@ The services are managed by [supervisord](http://supervisord.org/) and run insid
 
 [Redis](https://redis.io/) is used for two reasons in CRCON, caching and interprocess communication.
 
-Every round trip to the game server can be significantly slow (in computing terms) and induces some amount of overhead on both CRCON and the game server. 
+Every round trip to the game server can be significantly slow (in computing terms) and induces some amount of overhead on both CRCON and the game server.
 
 Some commands are cached even if they have a very low cache time (such as retrieving logs from the game server) to avoid constantly reprocessing info on very short time frames and others are on a longer cache time because they rarely if ever change (such as the list of available maps from the game server).
 
@@ -385,7 +387,7 @@ CRCON uses postgres 12 with a default configuration.
 
 To run a local instance of CRCON without using the Docker images requires you to do some manual set up.
 
-If you have **never** successfully run the complete CRCON environment from this install, you should do so first so that the database is created/initialized properly. (If you only ever plan on running the tests, you can do this without seeding the database).  If you've done this, you can skip the database migrations/user creation below. It's just easier to do it this way, so I recommend it but it is optional.
+If you have **never** successfully run the complete CRCON environment from this install, you should do so first so that the database is created/initialized properly. (If you only ever plan on running the tests, you can do this without seeding the database). If you've done this, you can skip the database migrations/user creation below. It's just easier to do it this way, so I recommend it but it is optional.
 
 Because of some configuration differences and how Docker determines environment variable precedence, I recommend using separate shells to run local instances and to run the full blown production Docker setup.
 
@@ -394,7 +396,7 @@ To avoid polluting your system Python, you should create/activate a [virtual env
 Once the virtual environment is activated in your shell install all of the Python dependencies:
 
     pip install -r requirements.txt
-    pip install -r requirements-dev.txt  
+    pip install -r requirements-dev.txt
 
 #### Set environment variables
 
@@ -423,7 +425,7 @@ The default username and database name is `rcon` if you've seeded the database u
 
 Make sure you set all of the environment variables from the previous section(s).
 
-You can *sort of* run a local instance without a game server to connect to, but so much depends on one that it's pretty pointless to try to do this without one.
+You can _sort of_ run a local instance without a game server to connect to, but so much depends on one that it's pretty pointless to try to do this without one.
 
     export HLL_HOST=<your game server IP>
     export HLL_PORT=<your game server RCON port>
@@ -433,7 +435,7 @@ You can *sort of* run a local instance without a game server to connect to, but 
 
     PYTHONPATH=. alembic upgrade head
     PYTHONPATH=. ./manage.py init_db
-    PYTHONPATH=. ./rconweb/manage.py makemigrations --no-input 
+    PYTHONPATH=. ./rconweb/manage.py makemigrations --no-input
     PYTHONPATH=. ./rconweb/manage.py migrate --noinput
 
 Alembic runs the database migrations which creates the tables, and `init_db` installs a postgres extension and sets default values for auto settings.
@@ -442,7 +444,7 @@ Alembic runs the database migrations which creates the tables, and `init_db` ins
 
 **If you didn't run the production environment first**: Create a `superuser` account and follow the prompts:
 
-    PYTHONPATH=. ./rconweb/manage.py createsuperuser       
+    PYTHONPATH=. ./rconweb/manage.py createsuperuser
 
 Set the redis environment variables:
 
@@ -453,7 +455,7 @@ Set the redis environment variables:
 
 Both the `redis` and `postgres` containers should be running (or you should have a `redis` and `postgres` installed/configured if you don't want to use the Docker images):
 
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate redis postgres
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis postgres
 
 Start the Django (backend) development web server:
 
@@ -520,12 +522,11 @@ Unfortunately at this moment in time the database needs to be running for the te
 
 From the root `hll_rcon_tool` directory:
 
-    PYTHONPATH=. DEBUG=TRUE pytest tests/    
+    PYTHONPATH=. DEBUG=TRUE pytest tests/
 
 If you don't set `PYTHONPATH` you'll see errors similar to ` ModuleNotFoundError: No module named 'rcon'`.
 
 If you don't set `DEBUG` to a truthy value, you'll see errors about not being able to connect to redis.
-
 
 #### To test if your changes will work with the production setup, start the whole stack
 
@@ -534,7 +535,7 @@ This should be done from a **separate** shell without the environment variables 
 Building the frontend if you've made any changes to the javascript files or if the build cache isn't available can take a considerable amount of time.
 
     docker compose -f docker-compose.yml -f docker-compose.dev.yml build
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 Now test on http://localhost:8010
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,10 @@ services:
       service: python
     command: web
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       server1:
         aliases:
@@ -132,7 +134,10 @@ services:
           - supervisor
     command: supervisor
     depends_on:
-      - frontend_1
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   backend_2:
     <<: *backend
     hostname: api_2
@@ -145,7 +150,10 @@ services:
         aliases:
           - backend
     depends_on:
-      - frontend_1
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   frontend_2:
     <<: *frontend
     ports:
@@ -200,7 +208,10 @@ services:
         aliases:
           - supervisor
     depends_on:
-      - frontend_2
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   backend_3:
     <<: *backend
     hostname: api_3
@@ -213,7 +224,10 @@ services:
         aliases:
           - backend
     depends_on:
-      - frontend_2
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   frontend_3:
     <<: *frontend
     ports:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ then
       exit 0
   fi
   alembic upgrade head
-  ./manage.py init_db
+  python -m rcon.user_config.seed_db
   ./manage.py register_api
   cd rconweb 
   ./manage.py makemigrations --no-input

--- a/rcon/audit.py
+++ b/rcon/audit.py
@@ -5,7 +5,7 @@ from typing import List
 from redis import BlockingConnectionPool, Redis
 
 from rcon.cache_utils import get_redis_pool
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 
 logger = logging.getLogger(__name__)
 
@@ -60,15 +60,13 @@ def set_registered_mods(moderators_name_steamids: List[tuple]):
 
 
 def ingame_mods(rcon=None):
-    from rcon.rcon import Rcon
-
     red = _red()
     mods = red.hgetall("moderators") or {}
 
     if not mods:
         return []
 
-    rcon = rcon or Rcon(SERVER_INFO)
+    rcon = rcon or get_rcon()
     players = rcon.get_players()
     mods_ids = set(v.decode() for v in mods.values())
     ig_mods = []

--- a/rcon/auto_settings.py
+++ b/rcon/auto_settings.py
@@ -6,8 +6,7 @@ from datetime import datetime
 import pytz
 
 from rcon.audit import ingame_mods, online_mods
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 from rcon.user_config.auto_settings import AutoSettingsConfig
 from rcon.vote_map import VoteMap
 
@@ -204,7 +203,7 @@ def do_run_commands(rcon, votemap, commands):
 
 
 def run():
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
     votemap = VoteMap()
     config = AutoSettingsConfig().get_settings()
 

--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -16,8 +16,7 @@ from rcon.commands import CommandFailedError, HLLServerError
 from rcon.discord import send_to_discord_audit
 from rcon.game_logs import on_connected, on_kill
 from rcon.hooks import inject_player_ids
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import Rcon, get_rcon
 from rcon.types import StructuredLogLineType
 from rcon.user_config.auto_mod_level import AutoModLevelUserConfig
 from rcon.user_config.auto_mod_no_leader import AutoModNoLeaderUserConfig
@@ -262,7 +261,7 @@ def on_connected(rcon: Rcon, _, name: str, steam_id_64: str):
 
 
 def run():
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
     red = get_redis_client()
 
     while True:

--- a/rcon/broadcast.py
+++ b/rcon/broadcast.py
@@ -249,9 +249,9 @@ def format_message(ctl, msg):
 
 def run():
     # avoid circular import
-    from rcon.rcon import Rcon
+    from rcon.rcon import get_rcon
 
-    ctl = Rcon(SERVER_INFO)
+    ctl = get_rcon()
 
     while True:
         config = AutoBroadcastUserConfig.load_from_db()

--- a/rcon/cli.py
+++ b/rcon/cli.py
@@ -18,7 +18,7 @@ from rcon.cache_utils import RedisCached, get_redis_pool, invalidates
 from rcon.discord_chat import get_handler
 from rcon.game_logs import LogLoop, load_generic_hooks
 from rcon.models import enter_session, install_unaccent
-from rcon.rcon import Rcon
+from rcon.rcon import get_rcon
 from rcon.scoreboard import live_stats_loop
 from rcon.server_stats import (
     save_server_stats_for_last_hours,
@@ -26,7 +26,7 @@ from rcon.server_stats import (
 )
 from rcon.settings import SERVER_INFO
 from rcon.steam_utils import enrich_db_users
-from rcon.user_config.auto_settings import AutoSettingsConfig, seed_default_config
+from rcon.user_config.auto_settings import AutoSettingsConfig
 from rcon.user_config.webhooks import (
     BaseMentionWebhookUserConfig,
     BaseUserConfig,
@@ -39,10 +39,32 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 def cli():
-    pass
+    ctl = get_rcon()
+    # Dynamically register all the methods from ServerCtl
+    # use dir instead of inspect.getmembers to avoid touching cached_property
+    # members that would be initialized even if we want to skip them, like connection_pool
+    for name in dir(ctl):
+        if name in EXCLUDED:
+            continue
 
+        func = getattr(ctl, name)
 
-ctl = Rcon(SERVER_INFO)
+        if (
+            not any(name.startswith(prefix) for prefix in PREFIXES_TO_EXPOSE)
+            or name in EXCLUDED
+        ):
+            continue
+        wrapped = do_print(func)
+
+    # Registering the arguments of the function must be done from last
+    # to first as they are decorators
+    for pname, param in [i for i in inspect.signature(func).parameters.items()][::-1]:
+        if param.default != inspect._empty:
+            wrapped = click.option(f"--{pname}", pname, default=param.default)(wrapped)
+        else:
+            wrapped = click.argument(pname)(wrapped)
+
+    cli.command(name=name)(wrapped)
 
 
 @cli.command(name="live_stats_loop")
@@ -126,7 +148,6 @@ def run_log_recorder(frequency_min, now):
 
 def init(force=False):
     install_unaccent()
-    seed_default_config()
 
 
 @cli.command(name="init_db")
@@ -138,6 +159,7 @@ def do_init(force):
 @cli.command(name="set_maprotation")
 @click.argument("maps", nargs=-1)
 def maprot(maps):
+    ctl = get_rcon()
     ctl.set_maprotation(list(maps))
 
 
@@ -155,6 +177,7 @@ def unregister():
 @click.argument("file", type=click.File("r"))
 @click.option("-p", "--prefix", default="")
 def importvips(file, prefix):
+    ctl = get_rcon()
     for line in file:
         line = line.strip()
         steamid, name = line.split(" ", 1)
@@ -168,6 +191,7 @@ def clear():
 
 @cli.command
 def export_vips():
+    ctl = get_rcon()
     print("/n".join(f"{d['steam_id_64']} {d['name']}" for d in ctl.get_vip_ids()))
 
 
@@ -404,32 +428,6 @@ def reset_user_settings(server: int):
 
 PREFIXES_TO_EXPOSE = ["get_", "set_", "do_"]
 EXCLUDED: Set[str] = {"set_maprotation", "connection_pool"}
-
-# Dynamically register all the methods from ServerCtl
-# use dir instead of inspect.getmembers to avoid touching cached_property
-# members that would be initialized even if we want to skip them, like connection_pool
-for name in dir(ctl):
-    if name in EXCLUDED:
-        continue
-
-    func = getattr(ctl, name)
-
-    if (
-        not any(name.startswith(prefix) for prefix in PREFIXES_TO_EXPOSE)
-        or name in EXCLUDED
-    ):
-        continue
-    wrapped = do_print(func)
-
-    # Registering the arguments of the function must be done from last
-    # to first as they are decorators
-    for pname, param in [i for i in inspect.signature(func).parameters.items()][::-1]:
-        if param.default != inspect._empty:
-            wrapped = click.option(f"--{pname}", pname, default=param.default)(wrapped)
-        else:
-            wrapped = click.argument(pname)(wrapped)
-
-    cli.command(name=name)(wrapped)
 
 if __name__ == "__main__":
     cli()

--- a/rcon/expiring_vips/service.py
+++ b/rcon/expiring_vips/service.py
@@ -7,8 +7,7 @@ from pydantic import HttpUrl
 
 from rcon.discord import send_to_discord_audit
 from rcon.models import PlayerSteamID, PlayerVIP, enter_session
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import Rcon, get_rcon
 from rcon.user_config.expired_vips import ExpiredVipsUserConfig
 from rcon.utils import INDEFINITE_VIP_DATE, get_server_number
 
@@ -121,7 +120,7 @@ def remove_expired_vips(rcon_hook: Rcon, webhook_url: Optional[HttpUrl] = None):
 
 
 def run():
-    rcon_hook = Rcon(SERVER_INFO)
+    rcon_hook = get_rcon()
 
     while True:
         config = ExpiredVipsUserConfig.load_from_db()

--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -22,8 +22,7 @@ from rcon.player_history import (
     get_player_profile,
     player_has_flag,
 )
-from rcon.rcon import LOG_ACTIONS, Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import LOG_ACTIONS, Rcon, get_rcon
 from rcon.types import (
     AllLogTypes,
     GetDetailedPlayer,
@@ -233,7 +232,7 @@ class LogLoop:
     log_history_key = "log_history"
 
     def __init__(self):
-        self.rcon = Rcon(SERVER_INFO)
+        self.rcon = get_rcon()
         self.red = get_redis_client()
         self.duplicate_guard_key = "unique_logs"
         self.log_history = self.get_log_history_list()

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -35,8 +35,8 @@ from rcon.rcon import Rcon, StructuredLogLineType
 from rcon.steam_utils import (
     get_player_bans,
     get_steam_profile,
-    update_db_player_info,
     is_steam_id_64,
+    update_db_player_info,
 )
 from rcon.types import (
     PlayerFlagType,
@@ -692,4 +692,3 @@ if __name__ == "__main__":
         "message": "Dr.WeeD",
         "sub_content": None,
     }
-    real_vips(Rcon(SERVER_INFO), struct_log=log)

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -5,7 +5,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from functools import cached_property
 from time import sleep
-from typing import Any, Iterable, Literal
+from typing import Any, Iterable, Literal, Optional
 
 from dateutil import parser
 
@@ -18,6 +18,7 @@ from rcon.player_history import (
     safe_save_player_action,
     save_player,
 )
+from rcon.settings import SERVER_INFO
 from rcon.steam_utils import (
     get_player_country_code,
     get_player_has_bans,
@@ -34,6 +35,7 @@ from rcon.types import (
     GetPlayersType,
     ParsedLogsType,
     PlayerIdsType,
+    ServerInfoType,
     StatusType,
     StructuredLogLineType,
     StructuredLogLineWithMetaData,
@@ -84,6 +86,30 @@ LOG_ACTIONS = [
     "MESSAGE",
 ]
 logger = logging.getLogger(__name__)
+
+
+CTL: Optional["Rcon"] = None
+
+
+def get_rcon(credentials: ServerInfoType | None = None):
+    """Return a initialized Rcon connection to the game server
+
+    This maintains a single initialized instance across a Python interpreter
+    instance unless someone explicitly chooses to use multiple instances.
+    This also doesn't automatically attempt to connect to the game server on
+    module import.
+
+    Args:
+        credentials: A dict of the game server IP, RCON port and RCON password
+    """
+    global CTL
+
+    if credentials is None:
+        credentials = SERVER_INFO
+
+    if CTL is None:
+        CTL = Rcon(credentials)
+    return CTL
 
 
 class Rcon(ServerCtl):

--- a/rcon/routines.py
+++ b/rcon/routines.py
@@ -3,7 +3,7 @@ import time
 
 from rcon.audit import ingame_mods, online_mods
 from rcon.commands import CommandFailedError
-from rcon.rcon import CommandFailedError, Rcon
+from rcon.rcon import CommandFailedError, Rcon, get_rcon
 from rcon.user_config.auto_kick import AutoVoteKickUserConfig
 from rcon.vote_map import VoteMap
 
@@ -40,9 +40,7 @@ def toggle_votekick(rcon: Rcon):
 
 def run():
     max_fails = 5
-    from rcon.settings import SERVER_INFO
-
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
 
     while True:
         try:

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -10,8 +10,7 @@ from rcon.cache_utils import get_redis_client
 from rcon.game_logs import get_historical_logs_records, get_recent_logs
 from rcon.models import enter_session
 from rcon.player_history import _get_profiles, get_player_profile_by_steam_ids
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 from rcon.types import StructuredLogLineWithMetaData
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
 from rcon.utils import MapsHistory
@@ -29,7 +28,7 @@ class Streaks:
 
 class BaseStats:
     def __init__(self):
-        self.rcon = Rcon(SERVER_INFO)
+        self.rcon = get_rcon()
         self.voted_yes_regex = re.compile(".*PV_Favour.*")
         self.voted_no_regex = re.compile(".*PV_Against.*")
         self.red = get_redis_client()

--- a/rcon/server_stats.py
+++ b/rcon/server_stats.py
@@ -16,8 +16,7 @@ from rcon.models import (
     ServerCount,
     enter_session,
 )
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 
 logger = logging.getLogger(__name__)
 
@@ -244,7 +243,7 @@ def _get_server_stats(
     # Crete a list of minutes for the given time window
     # Bear in mind that a huge window will impact perf a lot
     try:
-        vips = Rcon(SERVER_INFO).get_vip_ids()
+        vips = get_rcon().get_vip_ids()
         vips = {d["steam_id_64"] for d in vips}
     except:
         logger.warning("Unable to get VIP list")

--- a/rcon/stats_loop.py
+++ b/rcon/stats_loop.py
@@ -5,8 +5,7 @@ import redis
 import redis.exceptions
 
 from rcon.cache_utils import get_redis_client
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import Rcon, get_rcon
 
 logger = getLogger(__name__)
 
@@ -111,7 +110,7 @@ class PlayerCount(Series):
 
 
 def run():
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
     red = get_redis_client()
     registered_series = [PlayerCount(red)]
     for series in registered_series:

--- a/rcon/user_config/auto_settings.py
+++ b/rcon/user_config/auto_settings.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from rcon.models import enter_session
 from rcon.user_config.utils import (
     _add_conf,
     _remove_conf,
@@ -158,13 +157,3 @@ DEFAULT_AUTO_SETTINGS = {
         "current_map": {"maps": ["stmariedumont_warfare", "..."], "not": False},
     },
 }
-
-
-def seed_default_config():
-    logger.info("Seeding DB")
-    try:
-        with enter_session() as sess:
-            AutoSettingsConfig().seed_db(sess)
-            sess.commit()
-    except Exception as e:
-        logger.exception("Failed to seed DB")

--- a/rcon/user_config/seed_db.py
+++ b/rcon/user_config/seed_db.py
@@ -1,0 +1,72 @@
+import logging
+
+from rcon.models import enter_session
+from rcon.user_config import auto_settings
+from rcon.user_config.auto_broadcast import AutoBroadcastUserConfig
+from rcon.user_config.auto_kick import AutoVoteKickUserConfig
+from rcon.user_config.auto_mod_level import AutoModLevelUserConfig
+from rcon.user_config.auto_mod_no_leader import AutoModNoLeaderUserConfig
+from rcon.user_config.auto_mod_seeding import AutoModSeedingUserConfig
+from rcon.user_config.auto_mod_solo_tank import AutoModNoSoloTankUserConfig
+from rcon.user_config.ban_tk_on_connect import BanTeamKillOnConnectUserConfig
+from rcon.user_config.camera_notification import CameraNotificationUserConfig
+from rcon.user_config.expired_vips import ExpiredVipsUserConfig
+from rcon.user_config.gtx_server_name import GtxServerNameChangeUserConfig
+from rcon.user_config.log_line_webhooks import LogLineWebhookUserConfig
+from rcon.user_config.name_kicks import NameKickUserConfig
+from rcon.user_config.rcon_connection_settings import RconConnectionSettingsUserConfig
+from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
+from rcon.user_config.real_vip import RealVipUserConfig
+from rcon.user_config.scorebot import ScorebotUserConfig
+from rcon.user_config.standard_messages import StandardBroadcastMessagesUserConfig
+from rcon.user_config.steam import SteamUserConfig
+from rcon.user_config.vac_game_bans import VacGameBansUserConfig
+from rcon.user_config.vote_map import VoteMapUserConfig
+from rcon.user_config.webhooks import (
+    AdminPingWebhooksUserConfig,
+    AuditWebhooksUserConfig,
+    CameraWebhooksUserConfig,
+    ChatWebhooksUserConfig,
+    KillsWebhooksUserConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def seed_default_config():
+    logger.info("Seeding DB")
+    try:
+        with enter_session() as sess:
+            auto_settings.AutoSettingsConfig().seed_db(sess)
+            AdminPingWebhooksUserConfig.seed_db(sess)
+            AuditWebhooksUserConfig.seed_db(sess)
+            AutoBroadcastUserConfig.seed_db(sess)
+            AutoModLevelUserConfig.seed_db(sess)
+            AutoModNoLeaderUserConfig.seed_db(sess)
+            AutoModNoSoloTankUserConfig.seed_db(sess)
+            AutoModSeedingUserConfig.seed_db(sess)
+            AutoVoteKickUserConfig.seed_db(sess)
+            BanTeamKillOnConnectUserConfig.seed_db(sess)
+            CameraNotificationUserConfig.seed_db(sess)
+            CameraWebhooksUserConfig.seed_db(sess)
+            ChatWebhooksUserConfig.seed_db(sess)
+            ExpiredVipsUserConfig.seed_db(sess)
+            GtxServerNameChangeUserConfig.seed_db(sess)
+            KillsWebhooksUserConfig.seed_db(sess)
+            LogLineWebhookUserConfig.seed_db(sess)
+            NameKickUserConfig.seed_db(sess)
+            RconConnectionSettingsUserConfig.seed_db(sess)
+            RconServerSettingsUserConfig.seed_db(sess)
+            RealVipUserConfig.seed_db(sess)
+            ScorebotUserConfig.seed_db(sess)
+            StandardBroadcastMessagesUserConfig.seed_db(sess)
+            SteamUserConfig.seed_db(sess)
+            VacGameBansUserConfig.seed_db(sess)
+            VoteMapUserConfig.seed_db(sess)
+
+    except Exception as e:
+        logger.exception("Failed to seed DB")
+
+
+if __name__ == "__main__":
+    seed_default_config()

--- a/rcon/user_config/seed_db.py
+++ b/rcon/user_config/seed_db.py
@@ -18,7 +18,11 @@ from rcon.user_config.rcon_connection_settings import RconConnectionSettingsUser
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
 from rcon.user_config.real_vip import RealVipUserConfig
 from rcon.user_config.scorebot import ScorebotUserConfig
-from rcon.user_config.standard_messages import StandardBroadcastMessagesUserConfig
+from rcon.user_config.standard_messages import (
+    StandardBroadcastMessagesUserConfig,
+    StandardPunishmentMessagesUserConfig,
+    StandardWelcomeMessagesUserConfig,
+)
 from rcon.user_config.steam import SteamUserConfig
 from rcon.user_config.vac_game_bans import VacGameBansUserConfig
 from rcon.user_config.vote_map import VoteMapUserConfig
@@ -28,6 +32,7 @@ from rcon.user_config.webhooks import (
     CameraWebhooksUserConfig,
     ChatWebhooksUserConfig,
     KillsWebhooksUserConfig,
+    WatchlistWebhooksUserConfig,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,9 +65,12 @@ def seed_default_config():
             RealVipUserConfig.seed_db(sess)
             ScorebotUserConfig.seed_db(sess)
             StandardBroadcastMessagesUserConfig.seed_db(sess)
+            StandardPunishmentMessagesUserConfig.seed_db(sess)
+            StandardWelcomeMessagesUserConfig.seed_db(sess)
             SteamUserConfig.seed_db(sess)
             VacGameBansUserConfig.seed_db(sess)
             VoteMapUserConfig.seed_db(sess)
+            WatchlistWebhooksUserConfig.seed_db(sess)
 
     except Exception as e:
         logger.exception("Failed to seed DB")

--- a/rcon/user_config/utils.py
+++ b/rcon/user_config/utils.py
@@ -1,11 +1,11 @@
 import logging
 import os
-from typing import Any, Iterable, Self, Type
+from typing import Any, Iterable, Self
 
 import pydantic
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm.session import Session
 
-from rcon.cache_utils import invalidates, ttl_cache
 from rcon.models import UserConfig, enter_session
 from rcon.utils import get_server_number
 
@@ -84,7 +84,7 @@ class BaseUserConfig(pydantic.BaseModel):
         )
 
     @classmethod
-    def load_from_db(cls, default_on_error: bool = True) -> Self:
+    def load_from_db(cls, default_on_validation_error: bool = True) -> Self:
         # This should never happen in production, but allows tests to run
         if not os.getenv("HLL_DB_URL"):
             logger.warning(f"HLL_DB_URL not set, returning a default instance")
@@ -92,12 +92,12 @@ class BaseUserConfig(pydantic.BaseModel):
 
         # If the cache is unavailable, it will fall back to creating a default
         # model instance, but will not persist it to the database and overwrite settings
-        conf = get_user_config(cls.KEY(), default=None, cls=cls)
+        conf = get_user_config(cls.KEY(), default=None)
         if conf is not None:
             try:
                 return cls.model_validate(conf)
             except pydantic.ValidationError as e:
-                if default_on_error:
+                if default_on_validation_error:
                     logger.error(
                         f"Error loading {cls.KEY()}, returning defaults, validation errors:"
                     )
@@ -106,15 +106,27 @@ class BaseUserConfig(pydantic.BaseModel):
                 else:
                     raise
         else:
-            logger.warning(f"{cls.KEY()} not found, creating defaults")
-            conf = cls()
-            set_user_config(conf.KEY(), conf.model_dump())
+            # This shouldn't happen because we seed the database on startup if the
+            # records don't exist, if someone has manually edited their database that
+            # is on them, previously we would not seed defaults and create/persist an
+            # instance if `get_user_config` did not find a record for any reason.
+            # This was resetting peoples legitimate configs in some scenarios, particularly
+            # when containers were being created/torn down and a service or the backend queried
+            # a model and postgres was unavailable.
+            # Now models are only persisted to the database when they're either explicitly seeded
+            # during backend startup, or if the `save_to_db` method is explicitly called, for
+            # instance through the API, or CLI
+            logger.error(f"{cls.KEY()} not found, returning defaults")
 
         return cls()
 
     @staticmethod
     def save_to_db() -> None:
         raise NotImplementedError
+
+    @classmethod
+    def seed_db(cls, sess: Session):
+        _set_default(sess, key=cls.KEY(), val=cls().model_dump())
 
 
 def _get_conf(sess, key):
@@ -127,27 +139,7 @@ def _get_conf(sess, key):
         return None
 
 
-def _get_user_config_cache_unavailable(
-    key: str, default=None, cls: Type[BaseUserConfig] | None = None
-) -> dict[str, Any]:
-    """Return a default model as JSON"""
-    logger.info(f"_get_user_config_cache_unavailable {key=} {default=} {cls=}")
-    if cls:
-        return cls().model_dump()
-    else:
-        raise ValueError(f"cls must not be None")
-
-
-@ttl_cache(
-    5 * 60 * 60,
-    is_method=False,
-    function_cache_unavailable=_get_user_config_cache_unavailable,
-)
-def get_user_config(
-    key: str, default=None, cls: Type[BaseUserConfig] | None = None
-) -> dict[str, Any] | Any | None:
-    # cls required as a default parameter so it will be passed through to
-    # _get_user_config_cache_unavailable in the ttl_cache decorator
+def get_user_config(key: str, default=None) -> dict[str, Any] | Any | None:
     logger.debug("Getting user config for %s", key)
     with enter_session() as sess:
         res = _get_conf(sess, key)
@@ -177,16 +169,16 @@ def _remove_conf(sess, key):
 
 def _set_default(sess, key, val):
     if _get_conf(sess, key) is None:
+        logger.info("Seeding default values for %s", key)
         _add_conf(sess, key, val)
     return val
 
 
 def set_user_config(key, object_):
-    with invalidates(get_user_config):
-        logger.debug("Setting user config for %s with %s", key, object_)
-        with enter_session() as sess:
-            conf = _get_conf(sess, key)
-            if conf is None:
-                _add_conf(sess, key, object_)
-            else:
-                conf.value = object_
+    logger.debug("Setting user config for %s with %s", key, object_)
+    with enter_session() as sess:
+        conf = _get_conf(sess, key)
+        if conf is None:
+            _add_conf(sess, key, object_)
+        else:
+            conf.value = object_

--- a/rcon/vote_map.py
+++ b/rcon/vote_map.py
@@ -12,8 +12,7 @@ from sqlalchemy import and_
 from rcon.cache_utils import get_redis_client, get_redis_pool
 from rcon.models import PlayerOptins, PlayerSteamID, enter_session
 from rcon.player_history import get_player
-from rcon.rcon import CommandFailedError, Rcon, StructuredLogLineType
-from rcon.settings import SERVER_INFO
+from rcon.rcon import CommandFailedError, Rcon, StructuredLogLineType, get_rcon
 from rcon.user_config.vote_map import DefaultMethods, VoteMapUserConfig
 from rcon.utils import (
     ALL_MAPS,
@@ -539,7 +538,7 @@ class VoteMap:
         return {k.decode(): v.decode() for k, v in votes.items()}
 
     def get_current_map(self):
-        map_ = Rcon(SERVER_INFO).get_map()
+        map_ = get_rcon().get_map()
         if map_.endswith("_RESTART"):
             map_ = map_.replace("_RESTART", "")
 
@@ -682,7 +681,7 @@ class VoteMap:
                 logger.error(f"{next_map=} is not part of vote selection {selection=}")
             logger.info(f"Winning map {next_map=}")
 
-        rcon = Rcon(SERVER_INFO)
+        rcon = get_rcon()
         # Apply rotation safely
 
         current_rotation = rcon.get_map_rotation()

--- a/rcon/workers.py
+++ b/rcon/workers.py
@@ -5,7 +5,6 @@ from concurrent.futures import as_completed
 from datetime import timedelta
 from typing import Set
 
-from dateutil import relativedelta
 from rq import Queue
 from rq.job import Job
 from sqlalchemy import and_
@@ -14,9 +13,8 @@ from sqlalchemy.orm import Session
 from rcon.cache_utils import get_redis_client
 from rcon.models import Maps, PlayerStats, enter_session
 from rcon.player_history import get_player
-from rcon.rcon import Rcon
+from rcon.rcon import get_rcon
 from rcon.scoreboard import TimeWindowStats
-from rcon.settings import SERVER_INFO
 from rcon.types import MapInfo, PlayerStat
 from rcon.utils import INDEFINITE_VIP_DATE
 
@@ -29,9 +27,7 @@ def get_queue(redis_client=None):
 
 
 def broadcast(msg):
-    from rcon.rcon import Rcon
-
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
     rcon.set_broadcast(msg)
 
 
@@ -42,9 +38,7 @@ def temporary_broadcast(rcon, message, seconds):
 
 
 def welcome(msg):
-    from rcon.rcon import Rcon
-
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
     rcon.set_welcome_message(msg)
 
 
@@ -55,9 +49,7 @@ def temporary_welcome(rcon, message, seconds):
 
 
 def temp_welcome_standalone(msg, seconds):
-    from rcon.rcon import Rcon
-
-    rcon = Rcon(SERVER_INFO)
+    rcon = get_rcon()
     prev = rcon.set_welcome_message(msg, save=False)
     queue = get_queue()
     queue.enqueue_in(timedelta(seconds), welcome, prev)
@@ -281,7 +273,7 @@ def worker_bulk_vip(name_ids, job_key, mode="override"):
 
 def bulk_vip(name_ids, mode="override"):
     errors = []
-    ctl = Rcon(SERVER_INFO)
+    ctl = get_rcon()
     logger.info(f"bulk_vip name_ids {name_ids[0]} type {type(name_ids)}")
     vips = ctl.get_vip_ids()
 

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -22,8 +22,7 @@ from rcon.commands import CommandFailedError
 from rcon.discord import send_to_discord_audit
 from rcon.gtx import GTXFtp
 from rcon.player_history import add_player_to_blacklist, remove_player_from_blacklist
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
 from rcon.utils import LONG_HUMAN_MAP_NAMES, MapsHistory, get_server_number, map_name
 from rcon.watchlist import PlayerWatch
@@ -36,7 +35,8 @@ from .multi_servers import forward_command, forward_request
 from .utils import _get_data
 
 logger = logging.getLogger("rconweb")
-ctl = Rcon(SERVER_INFO)
+
+ctl = get_rcon()
 
 
 @csrf_exempt
@@ -60,6 +60,7 @@ def restart_gunicorn(request):
 
 
 def set_temp_msg(request, func, name):
+    ctl = get_rcon()
     data = _get_data(request)
     failed = False
     error = None

--- a/rconweb/rconweb/settings.py
+++ b/rconweb/rconweb/settings.py
@@ -19,12 +19,11 @@ from sentry_sdk import configure_scope
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 
 try:
     ENVIRONMENT = re.sub(
-        "[^0-9a-zA-Z]+", "", (Rcon(SERVER_INFO).get_name() or "default").strip()
+        "[^0-9a-zA-Z]+", "", (get_rcon().get_name() or "default").strip()
     )[:64]
 except:
     ENVIRONMENT = "undefined"

--- a/tests/test_broadcast_vars.py
+++ b/tests/test_broadcast_vars.py
@@ -1,11 +1,10 @@
 from rcon import broadcast
-from rcon.rcon import Rcon
-from rcon.settings import SERVER_INFO
+from rcon.rcon import get_rcon
 
 
 # This test requires an actual connection to the game server
 def test_smoke_all_variables():
-    ctl = Rcon(SERVER_INFO)
+    ctl = get_rcon()
     var_dict = broadcast._get_vars(ctl)
 
     for k in var_dict.keys():


### PR DESCRIPTION
There is an issue with user configs (not auto settings, since that's still treated separately) occasionally having their default values persisted to the database (resetting peoples configurations, which really sucks).

I thought this issue was isolated to when the cache would fail and that was also causing it, but there's also a separate issue. Whenever a model is requested and it doesn't exist in the database (or the database is not available!) it persists those default instances, which I set up in lieu of explicitly seeding them. I thought we could get by without explicitly seeding, but that causes more issues than it's worth.

We also use these configurations *all over* CRCON, and in many cases we were instantiating an `Rcon` instance (which uses a database loaded config) on module import. 

Docker container creation/tear down order matters for us because anytime `redis` or `postgres` isn't available but any of the `backend` or `supervisor` containers are running, until those containers shut down they will still try to use those and log errors (and in this case save stuff they shouldn't to the database).  Docker creates containers in order of dependency, so with this compose file `redis` and `postgres` will start first, then the `backend` container and then the `supervisor` for each server. The `frontend` will start after the backend has been created, but this is without an explicit health check for the `backend` so the frontend will still likely come up before the backend which isn't a big deal. Health checks for the backend are in a #431 which we haven't decided on yet.

If you do a `docker compose down` Docker respects this order and tears down containers in reverse order, and I believe this is really the crux of of our issue with how most of the configs were occasionally being reset. If you do a `docker compose up -d --force-recreate` with the containers **already running**, Docker *helpfully* follows this container creation order, and restarts `redis` and `postgres` without stopping the other containers that depend on it first. During this window in time trying to fetch a user config would fail, but I think there were some race condition-ish times where `postgres` could be back up and running after failing to return a model, but be ready to save the reset (default) user config.

I think moving forward our advice to users should be (during upgrades, or any other time they want to start their containers) to simply use `docker compose up -d` or `docker compose up -d --remove-orphans` without the `--force-recreate` option because people rarely need to actually force recreate a container to fix an issue. It will still detect image changes doing it this way and `.env` changes are still properly injected into the containers. This will reduce the amount of errors/scary looking exceptions that end up in the logs as well.

I built this locally and let it run for awhile without issue (to include more than one game ending) and I'm going to build this and deploy it as our production RCON, but I haven't found any errors with this, or had it reset any models with these changes.

This PR:
* Moves the database seeding out of `manage.py` into its own module which is run after `alembic` does the migrations, but before anything else because `manage.py` creates an `Rcon` instance so that all the commands are available through the command line interface, but this requires model fetching
* Explicitly seeds the user config models to the database when the backend starts (if we ever add any new models we'll have to seed them here, we could have done it dynamically with introspection but that's harder to debug/people to work on the project because it's not clear)
* Explicitly marks `redis` and `postgres` containers as prerequisites for each `supervisor` and `backend` container so they will wait until redis/postgres are up/ready before starting
* Adds a `get_rcon` method (similar to the way we have a single method to get the sqlalchemy engine, or redis pool, etc.) that manages a single `Rcon` instance (per interpreter) and refactors everything so that these aren't instantiated simply when a module is imported because that would try to fetch certain user configs that may not be ready yet
* Removes redis caching from `get_user_config` because I believe it was causing more problems than it's worth, `postgres` should be more than performant enough to handle fetching records, our bottleneck in almost every case is most likely the network requests between the user, crcon, the game server, and back.
* No longer persists a default instance if `get_user_config` does not successfully return a model from the database, instead it logs the error and returns a default instance (so CRCON won't crash, but we can find/identify any errors)