### PR TITLE
Hotfix/steam db enrichment

### DIFF
--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -262,7 +262,7 @@ def update_db_player_info(player: PlayerSteamID, steam_profile):
 def enrich_db_users(chunk_size=25, update_from_days_old=30):
     steam_config = SteamUserConfig.load_from_db()
     if steam_config.api_key is None:
-        logger.warning(f"Unable to run database enrichment, steam API key is not set")
+        logger.warning("Unable to run database enrichment, steam API key is not set")
         sys.exit(0)
 
     max_age = datetime.datetime.utcnow() - datetime.timedelta(days=update_from_days_old)

--- a/tests/test_steam_utils.py
+++ b/tests/test_steam_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rcon.steam_utils import is_steam_id_64
+from rcon.steam_utils import filter_steam_id, filter_steam_ids, is_steam_id_64
 
 
 @pytest.mark.parametrize(
@@ -14,3 +14,39 @@ from rcon.steam_utils import is_steam_id_64
 )
 def test_is_steam_id_64(id_, expected):
     assert is_steam_id_64(id_) == expected
+
+
+@filter_steam_id()
+def should_filter_single_id_without_parameter_name(steamd_id: str):
+    return steamd_id
+
+
+@filter_steam_ids()
+def should_filter_multiple_ids_without_parameter_name(steamd_ids: list[str]):
+    return steamd_ids
+
+
+@pytest.mark.parametrize(
+    "steamd_id, expected",
+    [
+        ("76561198080212634", "76561198080212634"),
+        ("a21af8b5-59df-5vbr-88gf-ab4239r4g6f4", None),
+    ],
+)
+def test_steam_id_filter(steamd_id, expected):
+    assert should_filter_single_id_without_parameter_name(steamd_id) == expected
+
+
+@pytest.mark.parametrize(
+    "steamd_ids, expected",
+    [
+        (["76561198080212634"], ["76561198080212634"]),
+        ([], []),
+        (
+            ["76561198080212634", "a21af8b5-59df-5vbr-88gf-ab4239r4g6f4"],
+            ["76561198080212634"],
+        ),
+    ],
+)
+def test_steam_ids_filter(steamd_ids, expected):
+    assert should_filter_multiple_ids_without_parameter_name(steamd_ids) == expected


### PR DESCRIPTION
* Update `enrich_db_users` log messages to be more clear
* Exit if a steam API key is not set as it's mandatory
* Reduce chunk size (number of profiles fetched per steam API request) from `100` to `25` to try to reduce the chance of steam rate limiting
* Don't fetch windows store ID players from the database for enrichment
* Add some tests to make sure the steam API decorators are filtering windows store IDs properly