### PR TITLE
Strip `$` characters from the secret key as it's not allowed in the salt

### DIFF
--- a/rconweb/api/admin.py
+++ b/rconweb/api/admin.py
@@ -28,7 +28,7 @@ class DjangoAPIKeyAdminForm(forms.ModelForm):
             raise forms.ValidationError("Minimum API key length is 32 characters")
 
         if DjangoAPIKey.objects.filter(
-            api_key=make_password(self.cleaned_data["api_key"], salt=SECRET_KEY)
+            api_key=make_password(self.cleaned_data["api_key"], salt=SECRET_KEY.replace('$', ""))
         ).exists():
             raise forms.ValidationError("Duplicate API keys are not allowed")
 

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -156,7 +156,7 @@ def login_required():
             try:
                 # If we don't include the salt, the hasher generates its own
                 # and it will generate different hashed values every time
-                hashed_api_key = make_password(raw_api_key, salt=SECRET_KEY)
+                hashed_api_key = make_password(raw_api_key, salt=SECRET_KEY.replace('$', ''))
                 api_key_model = DjangoAPIKey.objects.get(api_key=hashed_api_key)
 
                 # Retrieve the user to use the normal authentication system

--- a/rconweb/api/models.py
+++ b/rconweb/api/models.py
@@ -20,7 +20,7 @@ class DjangoAPIKey(models.Model):
     def save(self, *args, **kwargs):
         """Hash the API key"""
         # If we don't include the salt, the hasher generates its own
-        self.api_key = make_password(self.api_key, salt=SECRET_KEY)
+        self.api_key = make_password(self.api_key, salt=SECRET_KEY.replace('$', ""))
         super().save()
 
     class Meta:


### PR DESCRIPTION
Django doesn't allow the `$` character in salts when hashing passwords, it's acceptable in the `SECRET_KEY` that we're using as our salt value to ensure API keys are hashed/unhashed to the same value.

Strip the `$` key anywhere it's used in the salt, this doesn't affect `SECRET_KEY` in any way and Djangos `SECRET_KEY` rules for length/minimum unique characters mean there should still always be characters left over in the salt no matter what.

I built this and made sure I could add API keys from both the API key management view in the admin site and the individual user page and was able to authenticate against the API with it with a `SECRET_KEY` that included `$`.