### PR TITLE
Refactor steam API usage to try to reduce rate limiting

### DIFF
--- a/rcon/auto_kick.py
+++ b/rcon/auto_kick.py
@@ -14,7 +14,7 @@ from rcon.user_config.name_kicks import NameKickUserConfig
 logger = logging.getLogger(__name__)
 
 
-@on_connected
+@on_connected()
 @inject_player_ids
 def auto_kick(rcon, struct_log, name, steam_id_64):
     config = NameKickUserConfig.load_from_db()

--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -6,6 +6,7 @@ from typing import List
 from pydantic import HttpUrl
 from redis.client import Redis
 
+import rcon.game_logs
 from rcon.automods.level_thresholds import LevelThresholdsAutomod
 from rcon.automods.models import ActionMethod, PunishPlayer, PunitionsToApply
 from rcon.automods.no_leader import NoLeaderAutomod
@@ -14,7 +15,6 @@ from rcon.automods.seeding_rules import SeedingRulesAutomod
 from rcon.cache_utils import get_redis_client
 from rcon.commands import CommandFailedError, HLLServerError
 from rcon.discord import send_to_discord_audit
-from rcon.game_logs import on_connected, on_kill
 from rcon.hooks import inject_player_ids
 from rcon.rcon import Rcon, get_rcon
 from rcon.types import StructuredLogLineType
@@ -190,7 +190,7 @@ def audit(discord_webhook_url: HttpUrl | None, msg: str, author: str):
         )
 
 
-@on_kill
+@rcon.game_logs.on_kill
 def on_kill(rcon: Rcon, log: StructuredLogLineType):
     red = get_redis_client()
     if not is_first_run_done(red):
@@ -216,7 +216,7 @@ def on_kill(rcon: Rcon, log: StructuredLogLineType):
 pendingTimers = {}
 
 
-@on_connected
+@rcon.game_logs.on_connected()
 @inject_player_ids
 def on_connected(rcon: Rcon, _, name: str, steam_id_64: str):
     red = get_redis_client()

--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -120,7 +120,7 @@ def on_connected(insert_at: int | None = None):
     """Insert the given hook at `insert_at` position, or the end"""
 
     def wrapper(func):
-        if insert_at:
+        if isinstance(insert_at, int):
             HOOKS[AllLogTypes.connected.value].insert(insert_at, func)
         else:
             HOOKS[AllLogTypes.connected.value].append(func)

--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -120,7 +120,7 @@ def on_connected(insert_at: int | None = None):
     """Insert the given hook at `insert_at` position, or the end"""
 
     def wrapper(func):
-        if insert_at and isinstance(insert_at, int):
+        if insert_at:
             HOOKS[AllLogTypes.connected.value].insert(insert_at, func)
         else:
             HOOKS[AllLogTypes.connected.value].append(func)

--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -116,9 +116,18 @@ def on_chat_allies(func):
     return func
 
 
-def on_connected(func):
-    HOOKS[AllLogTypes.connected.value].append(func)
-    return func
+def on_connected(insert_at: int | None = None):
+    """Insert the given hook at `insert_at` position, or the end"""
+
+    def wrapper(func):
+        if insert_at and isinstance(insert_at, int):
+            HOOKS[AllLogTypes.connected.value].insert(insert_at, func)
+        else:
+            HOOKS[AllLogTypes.connected.value].append(func)
+
+        return func
+
+    return wrapper
 
 
 def on_disconnected(func):

--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -111,7 +111,12 @@ def get_profiles(steam_ids, nb_sessions=1):
         return [p.to_dict(limit_sessions=nb_sessions) for p in players]
 
 
-def _get_set_player(sess, player_name, steam_id_64, timestamp=None):
+def _get_set_player(
+    sess,
+    steam_id_64: str,
+    player_name: str | None = None,
+    timestamp: float | None = None,
+):
     player = get_player(sess, steam_id_64)
     if player is None:
         player = _save_steam_id(sess, steam_id_64)
@@ -312,7 +317,9 @@ def save_player_action(
             steam_id_64
             or rcon.get_player_info(player_name, can_fail=True)["steam_id_64"]
         )
-        player = _get_set_player(sess, player_name, _steam_id_64, timestamp=timestamp)
+        player = _get_set_player(
+            sess, player_name=player_name, steam_id_64=_steam_id_64, timestamp=timestamp
+        )
         sess.add(
             PlayersAction(
                 action_type=action_type.upper(), steamid=player, reason=reason, by=by

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -290,9 +290,16 @@ def update_db_player_info(
 
         country_code = _get_player_country_code(player_prof)
         if player.steaminfo:
-            player.steaminfo.profile = player_prof
-            player.steaminfo.bans = player_ban
-            player.steaminfo.country = country_code
+            # Don't overwrite existing info if there are errors making
+            # the steam API calls
+            if player_prof:
+                player.steaminfo.profile = player_prof
+
+            if player_ban:
+                player.steaminfo.bans = player_ban
+
+            if country_code:
+                player.steaminfo.country = country_code
         else:
             player.steaminfo = SteamInfo(
                 profile=player_prof, bans=player_ban, country=country_code

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -68,7 +68,7 @@ def filter_steam_ids():
             steam_id_64s = sorted(
                 set([id_ for id_ in steam_id_64s if is_steam_id_64(id_)])
             )
-            return f(*args, steam_id_64s=steam_id_64s, **kwargs)
+            return f(steam_id_64s=steam_id_64s, *args, **kwargs)
 
         return wrapper
 

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -144,7 +144,7 @@ def fetch_steam_player_summary_mult_players(
         chunk_steam_ids = ",".join(chunk)
         try:
             logger.info(
-                f"Fetching player summaries for {len(chunk_steam_ids)} steam IDs"
+                "Fetching player summaries for %s steam IDs", len(chunk_steam_ids)
             )
             raw_result = api.ISteamUser.GetPlayerSummaries(steamids=chunk_steam_ids)
             chunk_profiles: list[SteamPlayerSummaryType] = raw_result["response"][
@@ -186,7 +186,7 @@ def fetch_steam_bans_mult_players(
     try:
         for chunk in batched(steam_id_64s, page_size):
             chunk_steam_ids = ",".join(chunk)
-            logger.info(f"Fetching player bans for {len(chunk_steam_ids)} steam IDs")
+            logger.info("Fetching player bans for %s steam IDs", len(chunk_steam_ids))
             raw_result = api.ISteamUser.GetPlayerBans(  # type: ignore
                 steamids=chunk_steam_ids
             )
@@ -378,7 +378,8 @@ def enrich_db_users(chunk_size=100, update_from_days_old=30):
         for page in range(pages):
             player_chunks = query.limit(chunk_size).all()
             logger.info(
-                f"Updating steam profile/bans for {[player.steam_id_64 for player in player_chunks]}"
+                "Updating steam profile/bans for %s",
+                [player.steam_id_64 for player in player_chunks],
             )
             num_profs, num_bans = update_db_player_info(sess, players=player_chunks)
 

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -2,35 +2,72 @@ import datetime
 import logging
 import math
 import time
+from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Mapping
+from typing import Any, Iterable, Sequence
 
 import steam.exceptions
+from sqlalchemy import or_, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Session, joinedload
 from steam.webapi import WebAPI
-from dataclasses import dataclass
 
 from rcon.cache_utils import ttl_cache
-from rcon.models import PlayerSteamID, SteamInfo
-from rcon.types import SteamBanResultType, SteamBansType
+from rcon.models import PlayerSteamID, SteamInfo, enter_session
+from rcon.types import SteamBansType, SteamInfoType, SteamPlayerSummaryType
 from rcon.user_config.steam import SteamUserConfig
+from rcon.utils import batched
 
 logger = logging.getLogger(__name__)
-
 last_steam_api_key_warning = datetime.datetime.now()
+
+STEAM_API: WebAPI | None = None
+
+
+def get_steam_api() -> WebAPI:
+    """Maintain a single initialized instance of the Steam WebAPI"""
+    global STEAM_API
+    if STEAM_API is None:
+        api_key = get_steam_api_key()
+        STEAM_API = WebAPI(key=api_key)
+
+    return STEAM_API
+
+
+def get_steam_api_key() -> str | None:
+    """Return the servers steam API key if configured"""
+    global last_steam_api_key_warning
+
+    config = SteamUserConfig.load_from_db()
+    if config.api_key is None or config.api_key == "":
+        timestamp = datetime.datetime.now()
+        # Only log once every 5 minutes or it is super spammy
+        if (timestamp - last_steam_api_key_warning).total_seconds() > 300:
+            logger.warning("Steam API key is not set some features will be disabled.")
+            last_steam_api_key_warning = timestamp
+
+    return config.api_key
 
 
 def is_steam_id_64(steam_id_64: str) -> bool:
+    """Test if an ID is a steam_id_64 or a windows store ID"""
     if len(steam_id_64) == 17 and steam_id_64.isdigit():
         return True
     return False
 
 
 def filter_steam_ids():
+    """Remove any non steam ID player IDs from `steam_id_64s`"""
+
     def decorator(f):
         @wraps(f)
-        def wrapper(steamd_ids: list[str], *args, **kwargs):
-            steamd_ids = [id_ for id_ in steamd_ids if is_steam_id_64(id_)]
-            return f(*args, steamd_ids=steamd_ids, **kwargs)
+        def wrapper(steam_id_64s: Iterable[str], *args, **kwargs):
+            # Remove any duplicates and sort to force redis cache hits even if the
+            # originating call has steam IDs in different orders
+            steam_id_64s = sorted(
+                set([id_ for id_ in steam_id_64s if is_steam_id_64(id_)])
+            )
+            return f(*args, steam_id_64s=steam_id_64s, **kwargs)
 
         return wrapper
 
@@ -39,7 +76,7 @@ def filter_steam_ids():
 
 @dataclass
 class ReturnValue:
-    """Used to return a cacheable/callable object for the redis cache
+    """Used to return a pickleable/callable object for the redis cache
 
     This avoids errors like:
         AttributeError: Can't pickle local object 'filter_steam_id.<locals>.decorator.<locals>.wrapper.<locals>.<lambda>'
@@ -54,11 +91,13 @@ class ReturnValue:
 
 
 def filter_steam_id(return_value: Any = None):
+    """Return `return_value` if the wrapped function is called with a non steam ID"""
+
     def decorator(f):
         @wraps(f)
-        def wrapper(steamd_id: str, *args, **kwargs):
-            if is_steam_id_64(steamd_id):
-                return f(steamd_id=steamd_id, *args, **kwargs)
+        def wrapper(steam_id_64: str, *args, **kwargs):
+            if is_steam_id_64(steam_id_64):
+                return f(steam_id_64=steam_id_64, *args, **kwargs)
             else:
                 return ReturnValue(value=return_value)()
 
@@ -67,234 +106,296 @@ def filter_steam_id(return_value: Any = None):
     return decorator
 
 
-def get_steam_api_key() -> str | None:
-    global last_steam_api_key_warning
-
-    config = SteamUserConfig.load_from_db()
-    if config.api_key is None or config.api_key == "":
-        timestamp = datetime.datetime.now()
-        # Only log once every 5 minutes or it is super spammy
-        if (timestamp - last_steam_api_key_warning).total_seconds() > 300:
-            logger.warning("Steam API key is not set some features will be disabled.")
-            last_steam_api_key_warning = timestamp
-
-    return config.api_key
-
-
-@ttl_cache(60 * 60 * 24, cache_falsy=False, is_method=False)
+@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_id()
-def get_steam_profile(steamd_id) -> Any | None:
-    profiles = get_steam_profiles([steamd_id])
-    if not profiles or len(profiles) == 0:
-        return None
-    return profiles[0]
+def fetch_steam_player_summary_player(
+    steam_id_64: str,
+) -> SteamPlayerSummaryType | None:
+    """Fetch a single players steam profile
+
+    This should never be used in any context where you know more than one steam ID
+    in advance, instead use `fetch_steam_player_summary_mult_players` and pass all
+    the steam IDs at once to reduce API calls
+    """
+    player_prof = fetch_steam_player_summary_mult_players(steam_id_64s=[steam_id_64])
+    if player_prof:
+        return player_prof.get(steam_id_64)
 
 
-@ttl_cache(60 * 60 * 24, cache_falsy=False, is_method=False)
+@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_ids()
-def get_steam_profiles(steamd_ids: list[str]):
-    steam_key = get_steam_api_key()
+def fetch_steam_player_summary_mult_players(
+    steam_id_64s: Iterable[str], page_size=100
+) -> dict[str, SteamPlayerSummaryType]:
+    """Fetch steam API profile info for each player
 
-    if not steam_key:
-        return None
+    https://partner.steamgames.com/doc/webapi/isteamuser
 
+    This should be used in any context where we're querying more than a single
+    player at a time because we can batch API calls for up to 100 steam IDs at a time
+    """
+    api = get_steam_api()
+
+    # The steam API limits requests to 100 steam IDs at a time, process multiple
+    # requests for any list larger than 100, but fit as many steam IDs into the
+    # same API request as possible to help with rate limiting
+    raw_profiles: list[SteamPlayerSummaryType] = []
+    for chunk in batched(steam_id_64s, page_size):
+        chunk_steam_ids = ",".join(chunk)
+        try:
+            logger.info(
+                f"Fetching player summaries for {len(chunk_steam_ids)} steam IDs"
+            )
+            raw_result = api.ISteamUser.GetPlayerSummaries(steamids=chunk_steam_ids)
+            chunk_profiles: list[SteamPlayerSummaryType] = raw_result["response"][
+                "players"
+            ]
+            raw_profiles.extend(chunk_profiles)
+        except steam.exceptions.SteamError as e:
+            logger.error(e)
+        except AttributeError:
+            logger.error("Steam API key is invalid, can't fetch steam profile")
+            break
+        except IndexError:
+            logger.error("Steam: no player(s) found")
+        except Exception as e:
+            logger.exception(e)
+            logger.error("Unexpected error while fetching steam profile")
+
+    return {raw["steamid"]: raw for raw in raw_profiles}
+
+
+@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
+@filter_steam_ids()
+def fetch_steam_bans_mult_players(
+    steam_id_64s: Sequence[str], page_size=100
+) -> dict[str, SteamBansType]:
+    """Fetch steam API ban info for each player
+
+    https://partner.steamgames.com/doc/webapi/isteamuser
+
+    This should be used in any context where we're querying more than a single
+    player at a time because we can batch API calls for up to 100 steam IDs at a time
+    """
+    api = get_steam_api()
+
+    # The steam API limits requests to 100 steam IDs at a time, process multiple
+    # requests for any list larger than 100, but fit as many steam IDs into the
+    # same API request as possible to help with rate limiting
+    raw_bans: list[SteamBansType] = []
     try:
-        api = WebAPI(key=steam_key)
-        return api.ISteamUser.GetPlayerSummaries(steamids=",".join(steamd_ids))[
-            "response"
-        ]["players"]
+        for chunk in batched(steam_id_64s, page_size):
+            chunk_steam_ids = ",".join(chunk)
+            logger.info(f"Fetching player bans for {len(chunk_steam_ids)} steam IDs")
+            raw_result = api.ISteamUser.GetPlayerBans(  # type: ignore
+                steamids=chunk_steam_ids
+            )
+            chunk_bans: SteamBansType = raw_result["players"]
+            raw_bans.extend(chunk_bans)  # type: ignore
+
     except steam.exceptions.SteamError as e:
         logger.error(e)
-        return None
     except AttributeError:
         logger.error("Steam API key is invalid, can't fetch steam profile")
-        return None
     except IndexError:
-        logger.error("Steam: no player found")
+        logger.error("Steam no player found")
     except:
-        logger.error("Unexpected error while fetching steam profile")
-        return None
+        logger.error("Unexpected error while fetching steam bans")
+
+    return {raw["SteamId"]: raw for raw in raw_bans}
 
 
-@ttl_cache(60 * 60 * 24 * 7, cache_falsy=True, is_method=False)
+@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_id()
-def get_player_country_code(steamd_id) -> Any | None:
-    profile = get_steam_profile(steamd_id)
+def fetch_steam_bans_player(steam_id_64: str) -> SteamBansType | None:
+    """Fetch a single players steam bans
 
+    This should never be used in any context where you know more than one steam ID
+    in advance, instead use `fetch_steam_bans_mult_players` and pass all
+    the steam IDs at once to reduce API calls
+    """
+    player = fetch_steam_bans_mult_players(steam_id_64s=[steam_id_64])
+    if player:
+        return player.get(steam_id_64)
+
+
+@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
+def get_steam_profiles_mult_players(
+    steam_id_64s: Iterable[str], sess: Session | None = None
+) -> dict[str, SteamInfoType | None]:
+    """Query the database for the specified players steam info (profile/country/bans)"""
+    stmt = (
+        select(PlayerSteamID)
+        .options(joinedload(PlayerSteamID.steaminfo))
+        .where(PlayerSteamID.steam_id_64.in_(steam_id_64s))
+    )
+
+    profiles: dict[str, SteamInfoType | None] = dict.fromkeys(steam_id_64s, None)
+    if sess is None:
+        with enter_session() as sess:
+            # Needed to avoid an DetachedInstanceError error
+            sess.expire_on_commit = False
+            players = sess.scalars(stmt).all()
+    else:
+        players = sess.scalars(stmt).all()
+
+    for p in players:
+        profiles[p.steam_id_64] = p.steaminfo.to_dict() if p.steaminfo else None
+
+    return dict(profiles)
+
+
+@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
+def get_steam_profile(
+    steam_id_64: str, sess: Session | None = None
+) -> SteamInfoType | None:
+    """Query the database for a specific players steam info (profile/country/bans)"""
+    return get_steam_profiles_mult_players(steam_id_64s=[steam_id_64], sess=sess).get(
+        steam_id_64
+    )
+
+
+def _get_player_country_code(profile: SteamPlayerSummaryType | None):
+    """Extract a players 2 digit ISO 3166 country code from their steam profile"""
     if not profile:
         return None
 
     is_private = profile.get("communityvisibilitystate", 1) != 3
-    return profile.get("loccountrycode", "private" if is_private else "")
+    return profile.get("loccountrycode", "private" if is_private else None)
 
 
-@ttl_cache(60 * 60, cache_falsy=True, is_method=False)
-@filter_steam_ids()
-def get_players_country_code(steamd_ids: list[str]) -> Mapping:
-    profiles = get_steam_profiles(steamd_ids)
+def update_db_player_info(
+    sess: Session, players: list[PlayerSteamID]
+) -> tuple[int, int]:
+    """Fetch steam API info for each player and update their database record
 
-    result = dict.fromkeys(steamd_ids, {"country": None})
-    if not profiles:
-        return result
+    This should be used in any context where we're updating more than a single
+    player at a time because we can batch API calls for up to 100 steam IDs at a time
 
-    for profile in profiles:
-        is_private = profile.get("communityvisibilitystate", 1) != 3
-        country = profile.get("loccountrycode", "private" if is_private else "")
-        result[profile["steamid"]] = {"country": country}
+    Args:
+        sess: An sqlalchemy session, unused but included to force it to only be
+            called from within an active session so the database records will be updated
+        player: A list of player records
+    """
+    steam_id_64s = [player.steam_id_64 for player in players]
+    profiles = fetch_steam_player_summary_mult_players(steam_id_64s=steam_id_64s)
+    bans = fetch_steam_bans_mult_players(steam_id_64s=steam_id_64s)
 
-    return result
+    for player in players:
+        player_prof = profiles.get(player.steam_id_64)
+        player_ban = bans.get(player.steam_id_64)
 
+        # Don't edit the record and change the updated time if we have no new information
+        if player_prof is None and player_ban is None:
+            continue
 
-@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
-@filter_steam_id()
-def get_player_bans(steamd_id) -> SteamBansType | None:
-    steam_key = get_steam_api_key()
+        country_code = _get_player_country_code(player_prof)
+        if player.steaminfo:
+            player.steaminfo.profile = player_prof
+            player.steaminfo.bans = player_ban
+            player.steaminfo.country = country_code
+        else:
+            player.steaminfo = SteamInfo(
+                profile=player_prof, bans=player_ban, country=country_code
+            )
 
-    if not steam_key:
-        return None
-
-    try:
-        api = WebAPI(key=steam_key)
-        bans = api.ISteamUser.GetPlayerBans(steamids=steamd_id)["players"][0]
-    except steam.exceptions.SteamError as e:
-        logger.error(e)
-        return None
-    except AttributeError:
-        logger.error("Steam API key is invalid, can't fetch steam profile")
-        return None
-    except IndexError:
-        logger.error("Steam no player found")
-        return None
-    except:
-        logger.error("Unexpected error while fetching steam bans")
-        return None
-
-    if not bans:
-        bans = {}
-    return bans
+    return len(profiles), len(bans)
 
 
-@ttl_cache(60 * 60, cache_falsy=False, is_method=False)
-@filter_steam_ids()
-def get_players_ban(steamd_ids: list[str]):
-    steam_key = get_steam_api_key()
+def update_missing_old_steam_info_single_player(
+    sess: Session,
+    player: PlayerSteamID,
+    age_limit: datetime.timedelta = datetime.timedelta(hours=12),
+):
+    """Fetch steam API info if missing or older than age_limit for a single player
 
-    if not steam_key:
-        return None
+    Since this only calls the API for a single steam ID at a time and the requests
+    can include up to 100 steam IDs, this should only be used in the context where we're
+    updating info for a single player at a time, like when they connect to the game server
 
-    try:
-        api = WebAPI(key=steam_key)
-        bans = api.ISteamUser.GetPlayerBans(steamids=",".join(steamd_ids))["players"]
-    except steam.exceptions.SteamError as e:
-        logger.error(e)
-        return None
-    except AttributeError:
-        logger.error("Steam API key is invalid, can't fetch steam profile")
-        return None
-    except IndexError:
-        logger.error("Steam no player found")
-        return None
-    except:
-        logger.error("Unexpected error while fetching steam bans")
-        return None
+    Args:
+        sess: An sqlalchemy session, unused but included to force it to only be
+            called from within an active session so the database records will be updated
+        player: The desired players database record
+        age_limit: timedelta after which a refresh will be attempted from the steam API
+    """
 
-    return bans
-
-
-@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
-@filter_steam_ids()
-def get_players_have_bans(steamd_ids: list[str]) -> Mapping[str, SteamBanResultType]:
-    player_bans = get_players_ban(steamd_ids)
-
-    result = dict.fromkeys(steamd_ids, {"steam_bans": None})
-    if player_bans is None:
-        if steamd_ids:
-            logger.warning("Unable to read bans for %s" % steamd_ids)
-        return result
-
-    for bans in player_bans:
-        bans["has_bans"] = any(
-            bans.get(k)
-            for k in [
-                "VACBanned",
-                "NumberOfVACBans",
-                "DaysSinceLastBan",
-                "NumberOfGameBans",
-            ]
+    if (
+        player.steaminfo is None
+        or player.steaminfo
+        and player.steaminfo.updated
+        and (datetime.datetime.utcnow() - player.steaminfo.updated) >= age_limit
+    ):
+        # Fetch both the profile and bans
+        profile = fetch_steam_player_summary_player(player.steam_id_64)
+        country_code = _get_player_country_code(profile)
+        bans = fetch_steam_bans_player(player.steam_id_64)
+        steam_info = SteamInfo(
+            profile=profile,
+            country=country_code,
+            bans=bans,
         )
-        result[bans["SteamId"]] = {"steam_bans": bans}
-        del bans["SteamId"]
-
-    return result
-
-
-@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
-@filter_steam_id(return_value=dict())
-def get_player_has_bans(steamd_id: str):
-    bans = get_player_bans(steamd_id)
-
-    if bans is None:
-        logger.warning("Unable to read bans for %s" % steamd_id)
-        bans = {}
-
-    bans["has_bans"] = any(
-        bans.get(k)
-        for k in [
-            "VACBanned",
-            "NumberOfVACBans",
-            "DaysSinceLastBan",
-            "NumberOfGameBans",
-        ]
-    )
-    return bans
-
-
-def update_db_player_info(player: PlayerSteamID, steam_profile):
-    if not player.steaminfo:
-        player.steaminfo = SteamInfo()
-    player.steaminfo.profile = steam_profile
-    player.steaminfo.country = steam_profile.get("loccountrycode")
+        player.steaminfo = steam_info
+    elif player.steaminfo and player.steaminfo.bans is None:
+        # Fetch the bans
+        bans = fetch_steam_bans_player(player.steam_id_64)
+        player.steaminfo.bans = bans
+    elif (
+        player.steaminfo
+        and player.steaminfo.profile is None
+        or player.steaminfo.country is None
+    ):
+        # Fetch the profile
+        profile = fetch_steam_player_summary_player(player.steam_id_64)
+        country_code = _get_player_country_code(profile)
+        player.steaminfo.profile = profile
+        player.steaminfo.country = country_code
 
 
 def enrich_db_users(chunk_size=100, update_from_days_old=30):
-    from sqlalchemy import or_
-
-    from rcon.models import PlayerSteamID, SteamInfo, enter_session
-
+    """Use the Steam API to update steam profiles/bans for missing or old records"""
     max_age = datetime.datetime.utcnow() - datetime.timedelta(days=update_from_days_old)
     with enter_session() as sess:
+        # Missing JSONB records are surprisingly difficult to identify depending
+        # on how they've been persisted but JSONB.NULL should cover the different cases
         query = (
             sess.query(PlayerSteamID)
             .outerjoin(SteamInfo)
-            .filter(or_(PlayerSteamID.steaminfo == None, SteamInfo.updated <= max_age))
+            .filter(
+                or_(
+                    PlayerSteamID.steaminfo == None,
+                    SteamInfo.updated <= max_age,
+                    SteamInfo.bans == JSONB.NULL,
+                    SteamInfo.profile == JSONB.NULL,
+                )
+            )
         )
 
         pages = math.ceil(query.count() / chunk_size)
+        logger.info(
+            "Updating steam profiles/bans for %s missing/old users", query.count()
+        )
         for page in range(pages):
-            by_ids = {p.steam_id_64: p for p in query.limit(chunk_size).all()}
-            if not by_ids:
+            player_chunks = query.limit(chunk_size).all()
+            logger.info(
+                f"Updating steam profile/bans for {[player.steam_id_64 for player in player_chunks]}"
+            )
+            num_profs, num_bans = update_db_player_info(sess, players=player_chunks)
+
+            if not player_chunks:
                 logger.warning("Empty query results")
                 continue
-            profiles = get_steam_profiles(list(by_ids.keys()))
-            if profiles is None:
-                profiles = []
             logger.info(
-                "Updating steam profiles page %s of %s - result count (query) %s - result count (steam) %s",
+                "Updating steam profiles page %s of %s - %s users fetched from database - %s profiles, %s bans fetched from steam API",
                 page + 1,
                 pages,
-                len(by_ids),
-                len(profiles),
+                len(player_chunks),
+                num_profs,
+                num_bans,
             )
-            for p in profiles:
-                player = by_ids.get(p["steamid"])
-                if not player:
-                    logger.warning("Unable to find player %s", p["steamid"])
-                    continue
-                # logger.debug("Saving info for %s: %s", player.steam_id_64, p)
-                update_db_player_info(player=player, steam_profile=p)
 
             sess.commit()
-            time.sleep(5)
+            time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -109,7 +109,6 @@ def filter_steam_id(return_value: Any = None):
     return decorator
 
 
-@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_id()
 def fetch_steam_player_summary_player(
     steam_id_64: str,
@@ -206,7 +205,6 @@ def fetch_steam_bans_mult_players(
     return {raw["SteamId"]: raw for raw in raw_bans}
 
 
-@ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_id()
 def fetch_steam_bans_player(steam_id_64: str) -> SteamBansType | None:
     """Fetch a single players steam bans

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -44,8 +44,8 @@ def get_steam_api_key() -> str | None:
     config = SteamUserConfig.load_from_db()
     if config.api_key is None or config.api_key == "":
         timestamp = datetime.datetime.now()
-        # Only log once every 5 minutes or it is super spammy
-        if (timestamp - last_steam_api_key_warning).total_seconds() > 300:
+        # Only log once an hour or it is super spammy
+        if (timestamp - last_steam_api_key_warning).total_seconds() > 3600:
             logger.warning("Steam API key is not set some features will be disabled.")
             last_steam_api_key_warning = timestamp
 

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -22,6 +22,8 @@ from rcon.utils import batched
 logger = logging.getLogger(__name__)
 last_steam_api_key_warning = datetime.datetime.now()
 
+STEAM_API_MAX_STEAM_IDS = 100
+
 STEAM_API: WebAPI | None = None
 
 
@@ -126,7 +128,7 @@ def fetch_steam_player_summary_player(
 @ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_ids()
 def fetch_steam_player_summary_mult_players(
-    steam_id_64s: Iterable[str], page_size=100
+    steam_id_64s: Iterable[str],
 ) -> dict[str, SteamPlayerSummaryType]:
     """Fetch steam API profile info for each player
 
@@ -141,7 +143,7 @@ def fetch_steam_player_summary_mult_players(
     # requests for any list larger than 100, but fit as many steam IDs into the
     # same API request as possible to help with rate limiting
     raw_profiles: list[SteamPlayerSummaryType] = []
-    for chunk in batched(steam_id_64s, page_size):
+    for chunk in batched(steam_id_64s, STEAM_API_MAX_STEAM_IDS):
         chunk_steam_ids = ",".join(chunk)
         try:
             logger.info("Fetching player summaries for %s steam IDs", len(chunk))
@@ -167,7 +169,7 @@ def fetch_steam_player_summary_mult_players(
 @ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)
 @filter_steam_ids()
 def fetch_steam_bans_mult_players(
-    steam_id_64s: Sequence[str], page_size=100
+    steam_id_64s: Sequence[str],
 ) -> dict[str, SteamBansType]:
     """Fetch steam API ban info for each player
 
@@ -183,7 +185,7 @@ def fetch_steam_bans_mult_players(
     # same API request as possible to help with rate limiting
     raw_bans: list[SteamBansType] = []
     try:
-        for chunk in batched(steam_id_64s, page_size):
+        for chunk in batched(steam_id_64s, STEAM_API_MAX_STEAM_IDS):
             chunk_steam_ids = ",".join(chunk)
             logger.info("Fetching player bans for %s steam IDs", len(chunk))
             raw_result = api.ISteamUser.GetPlayerBans(  # type: ignore

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -242,7 +242,7 @@ def get_steam_profiles_mult_players(
     for p in players:
         profiles[p.steam_id_64] = p.steaminfo.to_dict() if p.steaminfo else None
 
-    return dict(profiles)
+    return profiles
 
 
 @ttl_cache(60 * 60 * 12, cache_falsy=False, is_method=False)

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -376,22 +376,26 @@ def enrich_db_users(chunk_size=100, update_from_days_old=30):
 
         logger.info("Updating steam profiles/bans for missing/old users")
         for idx, player_chunks in enumerate(sess.scalars(stmt).partitions()):
-            players = list(player_chunks)
-            if not players:
-                logger.warning("Empty query results for page %s", idx)
-                continue
-            logger.info(
-                "Updating page %s steam profile/bans, first steam ID of page: %s",
-                idx + 1,
-                players[0],
-            )
-            num_profs, num_bans = update_db_player_info(sess, players=players)
+            try:
+                players = list(player_chunks)
+                if not players:
+                    logger.warning("Empty query results for page %s", idx)
+                    continue
+                logger.info(
+                    "Updating page %s steam profile/bans, first steam ID of page: %s",
+                    idx + 1,
+                    players[0],
+                )
+                num_profs, num_bans = update_db_player_info(sess, players=players)
 
-            logger.info(
-                "%s profiles, %s bans fetched from steam API",
-                num_profs,
-                num_bans,
-            )
+                logger.info(
+                    "%s profiles, %s bans fetched from steam API",
+                    num_profs,
+                    num_bans,
+                )
+            except Exception as e:
+                logger.exception(e)
+                logger.error("Error while fetching page %s: %s", idx + 1, e)
 
             # Shouldn't really need this with how many API calls we should be able to make
             # but just to be on the safe side

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -1,6 +1,6 @@
 import datetime
 import enum
-from typing import List, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict
 
 
 # Have to inherit from str to allow for JSON serialization w/ pydantic
@@ -113,27 +113,52 @@ class GameServerBanType(TypedDict):
     raw: str
 
 
+class SteamPlayerSummaryType(TypedDict):
+    """Result of steam API ISteamUser.GetPlayerSummaries"""
+
+    avatar: str
+    avatarfull: str
+    avatarhash: str
+    avatarmedium: str
+    # 1 - not visible 3 - visibile
+    communityvisibilitystate: Literal[1] | Literal[3]
+    lastlogoff: int
+    loccityid: int
+    loccountrycode: str
+    locstatecode: str
+    personaname: str
+    personastate: int
+    personastateflags: int
+    primaryclanid: str
+    profilestate: int
+    profileurl: str
+    realname: str
+    steamid: str
+    timecreated: int
+
+
 class SteamBansType(TypedDict):
+    """Result of steam API ISteamUser.GetPlayerBans"""
+
+    SteamId: str
     CommunityBanned: bool
     VACBanned: bool
     NumberOfVACBans: int
     DaysSinceLastBan: int
     NumberOfGameBans: int
     EconomyBan: str
-    has_bans: bool
-
-
-class SteamBanResultType(TypedDict):
-    steam_bans: Optional[SteamBansType]
 
 
 class SteamInfoType(TypedDict):
+    """Dictionary version of SteamInfo model"""
+
     id: int
     created: datetime.datetime
     updated: datetime.datetime
-    profile: dict  # TODO
-    country: str
-    bans: dict  # TODO
+    profile: SteamPlayerSummaryType | None
+    country: str | None
+    bans: SteamBansType | None
+    has_bans: bool
 
 
 class PlayerNameType(TypedDict):
@@ -330,7 +355,7 @@ class PlayerProfileType(TypedDict):
 class GetPlayersType(TypedDict):
     name: str
     steam_id_64: str
-    country: str
+    country: str | None
     steam_bans: Optional[SteamBansType]
 
 

--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -3,7 +3,8 @@ import logging
 import os
 import secrets
 from datetime import datetime, timezone
-from typing import Any, Generic, TypeVar
+from itertools import islice
+from typing import Any, Generic, Iterable, TypeVar
 
 import redis
 
@@ -711,3 +712,12 @@ def parse_raw_player_info(raw: str, player) -> GetDetailedPlayer:
             data[key] = 0
 
     return data
+
+
+# https://docs.python.org/3.12/library/itertools.html#itertools.batched
+def batched(iterable: Iterable[Any], n: int):
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch

--- a/rcon/watchlist.py
+++ b/rcon/watchlist.py
@@ -12,7 +12,7 @@ from rcon.types import PlayerProfileType
 from rcon.user_config.webhooks import WatchlistWebhooksUserConfig
 
 
-@on_connected
+@on_connected()
 @inject_player_ids
 def watchdog(rcon: Rcon, log, name: str, steam_id_64: str):
     watcher = PlayerWatch(steam_id_64)

--- a/tests/test_steam_utils.py
+++ b/tests/test_steam_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rcon.steam_utils import is_steam_id_64
+from rcon.steam_utils import filter_steam_id, filter_steam_ids, is_steam_id_64
 
 
 @pytest.mark.parametrize(
@@ -14,3 +14,39 @@ from rcon.steam_utils import is_steam_id_64
 )
 def test_is_steam_id_64(id_, expected):
     assert is_steam_id_64(id_) == expected
+
+
+@filter_steam_id()
+def should_filter_single_id(steam_id_64: str):
+    return steam_id_64
+
+
+@filter_steam_ids()
+def should_filter_multiple_ids(steam_id_64s: list[str]):
+    return steam_id_64s
+
+
+@pytest.mark.parametrize(
+    "steam_id_64, expected",
+    [
+        ("76561198080212634", "76561198080212634"),
+        ("a21af8b5-59df-5vbr-88gf-ab4239r4g6f4", None),
+    ],
+)
+def test_steam_id_filter(steam_id_64, expected):
+    assert should_filter_single_id(steam_id_64) == expected
+
+
+@pytest.mark.parametrize(
+    "steam_id_64s, expected",
+    [
+        (["76561198080212634"], ["76561198080212634"]),
+        ([], []),
+        (
+            ["76561198080212634", "a21af8b5-59df-5vbr-88gf-ab4239r4g6f4"],
+            ["76561198080212634"],
+        ),
+    ],
+)
+def test_steam_ids_filter(steam_id_64s, expected: list[str]):
+    assert should_filter_multiple_ids(steam_id_64s) == expected


### PR DESCRIPTION
It's hard to say for sure since this involves external services, but I think this should cut down or maybe even eliminate users being rate limited by the Steam API. Previously, clearing the redis cache could also cause CRCON to hammer the steam API a bit since it would call it every time `get_players` was called (very often) until the values were re-cached, this avoids that.

I did build this, let it run, did quite a bit of poking around/manual testing and I don't believe I've changed the API results or broken anything.

This should cut down how often the steam API is called, but if a lot of `on_connected` hooks are processed at once (for instance you reconnect your CRCON to a game server that has been offline and it reprocesses a lot of old log lines at once), and of course rate limits will be shared across a steam API key if it's used for more than one game server, so there is still improvements we could make.

tl;dr stop pulling info from the steam API so much, rely on our local database and update steam info when players connect (critical for VAC/game ban checks) and make `enrich_db_users` work better.

* Update the `on_connected` hook to allow you to specify its order (so we can force the steam API calls to be made when players connected, before we check for VAC bans
* Only call the steam API to fetch profiles/bans when a player connects, or when `enrich_db_users` is called (it's on a `cron` job to run daily)
  * Previously we would make API calls based on `get_players` calls which could happen frequently and result in many overlapping pulls because it was cached based on the steam ID list it was called with which would vary any time players connected/disconnected
* Add some miscellaneous typing
* Add a singleton method (like for the redis pool, sqlalchemy engine, etc.) so per interpreter we only maintain a single initialized connection to the Steam API
* Rename `rcon.steam_util` functions to make it more clear which calls will touch the steam API (`fetch_` functions) and which ones simply query our local database (`get_` functions)
* Rename `rcon.steam_util` functions to make it more clear which ones should be called with a single steam ID and which ones should be called with multiple steam IDs (I found the singular `s` names hard to distinguish at a glance
* Update `enrich_db_users` query to identify more records that are missing information and need to be fetched
* Update `enrich_db_users` logging statements to provide more/clearer information
* Sort/remove duplicate steam IDs for `filter_steam_ids` to cause more cache hits (the redis cache would consider `[1,2,3]` and `[3,2,1]` to be different cache values even though they produce identical API results for our purposes
* Reduce TTL caches to 12 hours, we don't want to make excessive calls but this means each player should only be updated once a day, without skipping multiple days if a player tends to play at the same time each day