### PR TITLE
Fix forwarding with API keys

### DIFF
--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -25,7 +25,8 @@ from .models import DjangoAPIKey, SteamPlayer
 
 logger = logging.getLogger("rconweb")
 
-AUTHORIZATION_HEADER = "HTTP_AUTHORIZATION"
+HTTP_AUTHORIZATION_HEADER = "HTTP_AUTHORIZATION"
+AUTHORIZATION = "AUTHORIZATION"
 BEARER = ("BEARER", "BEARER:")
 
 
@@ -145,9 +146,9 @@ def login_required():
             # Extract the header and bearer key if present, otherwise fall back on
             # requiring the user to be logged in
             try:
-                header_name, raw_api_key = request.META[AUTHORIZATION_HEADER].split(
-                    maxsplit=1
-                )
+                header_name, raw_api_key = request.META[
+                    HTTP_AUTHORIZATION_HEADER
+                ].split(maxsplit=1)
                 if not header_name.upper().strip() in BEARER:
                     raw_api_key = None
             except (KeyError, ValueError):
@@ -156,7 +157,9 @@ def login_required():
             try:
                 # If we don't include the salt, the hasher generates its own
                 # and it will generate different hashed values every time
-                hashed_api_key = make_password(raw_api_key, salt=SECRET_KEY.replace('$', ''))
+                hashed_api_key = make_password(
+                    raw_api_key, salt=SECRET_KEY.replace("$", "")
+                )
                 api_key_model = DjangoAPIKey.objects.get(api_key=hashed_api_key)
 
                 # Retrieve the user to use the normal authentication system

--- a/rconweb/api/multi_servers.py
+++ b/rconweb/api/multi_servers.py
@@ -1,15 +1,17 @@
 import json
 import logging
 from copy import deepcopy
+from typing import Any
 
 import requests
 from django.contrib.auth.decorators import permission_required
+from django.http import QueryDict
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from rcon.utils import ApiKey
 
-from .auth import api_response, login_required
+from .auth import AUTHORIZATION, api_response, login_required
 
 logger = logging.getLogger("rcon")
 
@@ -47,6 +49,11 @@ def forward_request(request):
     keys = api_key.get_all_keys()
     my_key = api_key.get_key()
 
+    sessionid: str | None = request.COOKIES.get("sessionid")
+    auth_header: str | None = request.headers.get(AUTHORIZATION)
+    cookies = {"sessionid": sessionid} if sessionid else {}
+    headers = {"AUTHORIZATION": auth_header} if auth_header else {}
+
     results = []
     for host, key in keys.items():
         if key == my_key:
@@ -67,7 +74,8 @@ def forward_request(request):
                 params=params,
                 json=data,
                 timeout=5,
-                cookies=dict(sessionid=request.COOKIES.get("sessionid")),
+                cookies=cookies,
+                headers=headers,
             )
 
             # Automatically retry HttpResponseNotAllowed errors as GET requests
@@ -77,7 +85,8 @@ def forward_request(request):
                     params=params,
                     json=data,
                     timeout=5,
-                    cookies=dict(sessionid=request.COOKIES.get("sessionid")),
+                    cookies=cookies,
+                    headers=headers,
                 )
 
             if res.ok:
@@ -93,12 +102,20 @@ def forward_request(request):
     return results
 
 
-def forward_command(path, params=None, json=None, sessionid=None):
-    api_key = ApiKey()
-    keys = api_key.get_all_keys()
-    my_key = api_key.get_key()
+def forward_command(
+    path: str,
+    sessionid: str | None,
+    auth_header: str | None,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | QueryDict | None = None,
+):
+    server_api_key = ApiKey()
+    keys = server_api_key.get_all_keys()
+    my_key = server_api_key.get_key()
     params = deepcopy(params) or {}
     data = deepcopy(json) or {}
+    cookies = {"sessionid": sessionid} if sessionid else {}
+    headers = {"AUTHORIZATION": auth_header} if auth_header else {}
     results = []
 
     if "forwarded" in params or "forwarded" in data:
@@ -118,13 +135,25 @@ def forward_command(path, params=None, json=None, sessionid=None):
             url = f"http://{host}{path}"
 
             logger.info("Forwarding request: %s %s %s", url, params, data)
-            res = requests.get(
+            res = requests.post(
                 url,
                 params=params,
                 json=data,
                 timeout=5,
-                cookies=dict(sessionid=sessionid),
+                cookies=cookies,
+                headers=headers,
             )
+            # Automatically retry HttpResponseNotAllowed errors as GET requests
+            if res.status_code == 405:
+                res = requests.get(
+                    url,
+                    params=params,
+                    json=data,
+                    timeout=5,
+                    cookies=cookies,
+                    headers=headers,
+                )
+
             if res.ok:
                 r = {"host": host, "response": res.json()}
                 results.append(r)


### PR DESCRIPTION
Forwarding when authenticating via an API key was broken.
`forward_command` was also still using `GET` requests by default and not `POST`

Built and tested this via our 2 servers, verified it would forward correctly when using both the UI and API calls when authenticating via API key.