### PR TITLE
Add VIP info to PlayerVIP `to_dict`

### DIFF
--- a/rcon/models.py
+++ b/rcon/models.py
@@ -38,6 +38,7 @@ from rcon.types import (
     ServerCountType,
     SteamInfoType,
     WatchListType,
+    PlayerVIPType,
 )
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,7 @@ class PlayerSteamID(Base):
             "flags": [f.to_dict() for f in (self.flags or [])],
             "watchlist": self.watchlist.to_dict() if self.watchlist else None,
             "steaminfo": self.steaminfo.to_dict() if self.steaminfo else None,
+            "vips": [v.to_dict() for v in self.vips],
         }
 
     def __str__(self) -> str:
@@ -681,6 +683,12 @@ class PlayerVIP(Base):
     )
 
     steamid: Mapped[PlayerSteamID] = relationship(back_populates="vips")
+
+    def to_dict(self) -> PlayerVIPType:
+        return {
+            "server_number": self.server_number,
+            "expiration": self.expiration,
+        }
 
 
 class AuditLog(Base):

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -310,6 +310,11 @@ class UserConfigType(TypedDict):
     value: str
 
 
+class PlayerVIPType(TypedDict):
+    server_number: int
+    expiration: datetime.datetime
+
+
 class PlayerProfileType(TypedDict):
     id: int
     steam_id_64: str
@@ -325,6 +330,7 @@ class PlayerProfileType(TypedDict):
     flags: List[PlayerFlagType]
     watchlist: Optional[WatchListType]
     steaminfo: Optional[SteamInfoType]
+    vips: Optional[list[PlayerVIPType]]
 
 
 class GetPlayersType(TypedDict):


### PR DESCRIPTION
VIP status wasn't reflected on the `profile` endpoint (ex: https://example.com/#/player/76561198004895814)

It now shows as a list of the servers they have VIP on and their expiration timestamps. It isn't perfect as it relies on `PlayerVIP` records, so players can have VIP on the game server but without a record. `PlayerVIP` records are created when VIP is added through `rcon.do_add_vip`  or when the expiring VIP service runs (hourly by default)

```json
  "vips": [
      {
        "server_number": 1,
        "expiration": "3000-01-01T00:00:00Z"
      }
    ]
```