### PR TITLE
Add support for win-store playerid "profile" links.

### DIFF
--- a/rcongui/src/components/PlayerInfo/PlayerInfo.js
+++ b/rcongui/src/components/PlayerInfo/PlayerInfo.js
@@ -24,7 +24,7 @@ import MessageHistory from "../MessageHistory";
 import { toast } from "react-toastify";
 import { useParams } from "react-router-dom";
 import CollapseCard from "../collapseCard";
-import makeSteamProfileUrl from "../../utils/makeSteamProfileUrl";
+import makePlayerProfileUrl from "../../utils/makePlayerProfileUrl";
 
 // return a label for steam and windows ids types
 const getLinkLabel = (id) => {
@@ -317,7 +317,7 @@ const PlayerInfoFunc = ({ classes }) => {
                 </Grid>
                 <Grid item>
                   <Typography variant="h6">
-                    <Link href={makeSteamProfileUrl(steamId64, names[0]?.name)}>
+                    <Link href={makePlayerProfileUrl(steamId64, names[0]?.name)}>
                       {getLinkLabel(steamId64)} Profile
                     </Link>
                   </Typography>

--- a/rcongui/src/components/PlayerInfo/PlayerInfo.js
+++ b/rcongui/src/components/PlayerInfo/PlayerInfo.js
@@ -304,7 +304,7 @@ const PlayerInfoFunc = ({ classes }) => {
                 </Grid>
                 <Grid item>
                   <Typography variant="h6">
-                    <Link href={makeSteamProfileUrl(steamId64)}>
+                    <Link href={makeSteamProfileUrl(steamId64, names[0]?.name)}>
                       Steam Profile
                     </Link>
                   </Typography>

--- a/rcongui/src/components/PlayerInfo/PlayerInfo.js
+++ b/rcongui/src/components/PlayerInfo/PlayerInfo.js
@@ -26,6 +26,19 @@ import { useParams } from "react-router-dom";
 import CollapseCard from "../collapseCard";
 import makeSteamProfileUrl from "../../utils/makeSteamProfileUrl";
 
+// return a label for steam and windows ids types
+const getLinkLabel = (id) => {
+  if (id.length === 17) {
+    // valid steam id is 17 digits...
+    return "Steam";
+  } else {
+    // xbox gamertags are unique and cost $$ to change...
+    // otherwise assume it's a T17 guid and return
+    // a url to https://xboxgamertag.com/search/ name
+    return "xboxgamertag.com";
+  }
+};
+
 const useStyles = makeStyles((theme) => ({
   padding: {
     padding: theme.spacing(1),
@@ -305,7 +318,7 @@ const PlayerInfoFunc = ({ classes }) => {
                 <Grid item>
                   <Typography variant="h6">
                     <Link href={makeSteamProfileUrl(steamId64, names[0]?.name)}>
-                      Steam Profile
+                      {getLinkLabel(steamId64)} Profile
                     </Link>
                   </Typography>
                 </Grid>

--- a/rcongui/src/components/PlayerView/playerList.js
+++ b/rcongui/src/components/PlayerView/playerList.js
@@ -12,7 +12,7 @@ import {
   faQuestionCircle,
   faStar,
 } from "@fortawesome/free-solid-svg-icons";
-import { faSteam } from "@fortawesome/free-brands-svg-icons";
+import { faSteam, faXbox, faWindows } from "@fortawesome/free-brands-svg-icons";
 import Link from "@material-ui/core/Link";
 import withWidth from "@material-ui/core/withWidth";
 import Icon from "@material-ui/core/Icon";
@@ -368,9 +368,9 @@ const PlayerItem = ({
               className={classes.marginRight}
               target="_blank"
               color="inherit"
-              href={makeSteamProfileUrl(steamID64)}
+              href={makeSteamProfileUrl(steamID64, name)}
             >
-              <FontAwesomeIcon icon={faSteam} />
+              <FontAwesomeIcon icon={(steamID64.length === 17) ? faSteam : faWindows} />
             </Link>
           </React.Fragment>
         }

--- a/rcongui/src/components/PlayerView/playerList.js
+++ b/rcongui/src/components/PlayerView/playerList.js
@@ -33,7 +33,7 @@ import {
   Grid,
   ListItemAvatar,
 } from "@material-ui/core";
-import makeSteamProfileUrl from "../../utils/makeSteamProfileUrl";
+import makePlayerProfileUrl from "../../utils/makePlayerProfileUrl";
 import moment from "moment";
 
 const zeroPad = (num, places) => String(num).padStart(places, "0");
@@ -368,7 +368,7 @@ const PlayerItem = ({
               className={classes.marginRight}
               target="_blank"
               color="inherit"
-              href={makeSteamProfileUrl(steamID64, name)}
+              href={makePlayerProfileUrl(steamID64, name)}
             >
               <FontAwesomeIcon icon={(steamID64.length === 17) ? faSteam : faWindows} />
             </Link>

--- a/rcongui/src/components/PlayersHistory/PlayerTile/PlayerHeader.js
+++ b/rcongui/src/components/PlayersHistory/PlayerTile/PlayerHeader.js
@@ -60,9 +60,10 @@ export const PlayerHeader = pure(({ classes, player }) => {
         <Link
           target="_blank"
           color="inherit"
-          href={makeSteamProfileUrl(player.get(
-            "steam_id_64"
-          ))}
+          href={makeSteamProfileUrl(
+            player.get("steam_id_64"),
+            firstName.get("name")
+          )}
         >
           <Avatar src={avatarUrl}>{firstNameLetter}</Avatar>
         </Link>
@@ -153,9 +154,10 @@ export const PlayerHeader = pure(({ classes, player }) => {
                   .map((n) => n.get("name"))
                   .join(" | ")}\nSteamID: ${player.get(
                   "steam_id_64"
-                )}\nSteam URL: ${makeSteamProfileUrl(player.get(
-                  "steam_id_64"
-                ))}\nType of issue:\nDescription:\nEvidence:`;
+                )}\nSteam URL: ${makeSteamProfileUrl(
+                  player.get("steam_id_64"),
+                  player.get("names").first().get("name")
+                )}\nType of issue:\nDescription:\nEvidence:`;
                 if (navigator.clipboard === undefined) {
                   alert(`This feature only works if your rcon uses HTTPS.`);
                   return;

--- a/rcongui/src/components/PlayersHistory/PlayerTile/PlayerHeader.js
+++ b/rcongui/src/components/PlayersHistory/PlayerTile/PlayerHeader.js
@@ -18,7 +18,7 @@ import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import { pure } from "recompose";
 import { getName } from "country-list";
-import makeSteamProfileUrl from "../../../utils/makeSteamProfileUrl";
+import makePlayerProfileUrl from "../../../utils/makePlayerProfileUrl";
 
 const getCountry = (country) => {
   if (country === "" || country === null) {
@@ -60,7 +60,7 @@ export const PlayerHeader = pure(({ classes, player }) => {
         <Link
           target="_blank"
           color="inherit"
-          href={makeSteamProfileUrl(
+          href={makePlayerProfileUrl(
             player.get("steam_id_64"),
             firstName.get("name")
           )}
@@ -154,7 +154,7 @@ export const PlayerHeader = pure(({ classes, player }) => {
                   .map((n) => n.get("name"))
                   .join(" | ")}\nSteamID: ${player.get(
                   "steam_id_64"
-                )}\nSteam URL: ${makeSteamProfileUrl(
+                )}\nSteam URL: ${makePlayerProfileUrl(
                   player.get("steam_id_64"),
                   player.get("names").first().get("name")
                 )}\nType of issue:\nDescription:\nEvidence:`;

--- a/rcongui/src/components/Scoreboard/PlayerStatProfile.js
+++ b/rcongui/src/components/Scoreboard/PlayerStatProfile.js
@@ -49,7 +49,11 @@ export const PlayerStatProfile = pure(({ playerScore, onClose }) => {
                         color="inherit"
                         href={
                           steamProfile.get("profileurl") ||
-                          makeSteamProfileUrl(playerScore.get("steam_id_64"))
+                          makeSteamProfileUrl(
+                            playerScore.get("steam_id_64"),
+                            playerScore.get("player") ||
+                              steamProfile.get("personaname")
+                          )
                         }
                         target="_blank"
                       >

--- a/rcongui/src/components/Scoreboard/PlayerStatProfile.js
+++ b/rcongui/src/components/Scoreboard/PlayerStatProfile.js
@@ -17,7 +17,7 @@ import CancelIcon from "@material-ui/icons/Cancel";
 import { pure } from "recompose";
 import { safeGetSteamProfile } from "./Scores";
 import { SubList } from "./SubList";
-import makeSteamProfileUrl from "../../utils/makeSteamProfileUrl";
+import makePlayerProfileUrl from "../../utils/makePlayerProfileUrl";
 
 export const PlayerStatProfile = pure(({ playerScore, onClose }) => {
   const steamProfile = safeGetSteamProfile(playerScore);
@@ -49,7 +49,7 @@ export const PlayerStatProfile = pure(({ playerScore, onClose }) => {
                         color="inherit"
                         href={
                           steamProfile.get("profileurl") ||
-                          makeSteamProfileUrl(
+                          makePlayerProfileUrl(
                             playerScore.get("steam_id_64"),
                             playerScore.get("player") ||
                               steamProfile.get("personaname")

--- a/rcongui/src/utils/makePlayerProfileUrl.js
+++ b/rcongui/src/utils/makePlayerProfileUrl.js
@@ -1,6 +1,5 @@
-import { faSteam, faXbox } from "@fortawesome/free-brands-svg-icons";
 
-const makeSteamProfileUrl = (steamId64, name = "") => {
+const makeSteamPlayerUrl = (steamId64, name = "") => {
   if (steamId64.length === 17) {
     // valid steam id is 17 digits...
     return `https://steamcommunity.com/profiles/${steamId64}`;
@@ -12,4 +11,4 @@ const makeSteamProfileUrl = (steamId64, name = "") => {
   }
 };
 
-export default makeSteamProfileUrl;
+export default makePlayerProfileUrl;

--- a/rcongui/src/utils/makePlayerProfileUrl.js
+++ b/rcongui/src/utils/makePlayerProfileUrl.js
@@ -1,5 +1,5 @@
 
-const makeSteamPlayerUrl = (steamId64, name = "") => {
+const makePlayerProfileUrl = (steamId64, name = "") => {
   if (steamId64.length === 17) {
     // valid steam id is 17 digits...
     return `https://steamcommunity.com/profiles/${steamId64}`;

--- a/rcongui/src/utils/makeSteamProfileUrl.js
+++ b/rcongui/src/utils/makeSteamProfileUrl.js
@@ -1,4 +1,15 @@
-const makeSteamProfileUrl = (steamId64) =>
-  `https://steamcommunity.com/profiles/${steamId64}`;
+import { faSteam, faXbox } from "@fortawesome/free-brands-svg-icons";
+
+const makeSteamProfileUrl = (steamId64, name = "") => {
+  if (steamId64.length === 17) {
+    // valid steam id is 17 digits...
+    return `https://steamcommunity.com/profiles/${steamId64}`;
+  } else if (name.length > 0) {
+    // xbox gamertags are unique and cost $$ to change...
+    // otherwise assume it's a T17 guid and return
+    // a url to https://xboxgamertag.com/search/ name
+    return `https://xboxgamertag.com/search/${name}`;
+  }
+};
 
 export default makeSteamProfileUrl;


### PR DESCRIPTION
Add support for win-store playerid "profile" links.

Win-store playerids will link to an xboxgamertag.com search. This is a third-party site, but Microsoft does not have a player lookup web service that can be used. Note that gamertags are unique and cost money to change so gamertags should be more stable than steam player names.
- update `makeSteamProfileLink` to detect steam vs. win-store playerids + return appropriate url
- update live views to use `faWindows` icon for win-store playerids

*`faWindows` icon:*

![Screenshot 2024-01-16 005330-copy](https://github.com/MarechJ/hll_rcon_tool/assets/2712638/996d3b61-6d43-4a29-a623-665a85b94b6a)

*Old screenshot (no win-store players the last few days):*

![Screenshot 2024-01-16 000210-marked-up](https://github.com/MarechJ/hll_rcon_tool/assets/2712638/e57a0ec6-7b69-4eb7-8ddc-2887700de927)
