### PR TITLE
escape markdown sequences in discord audit webhooks...

### DIFF
--- a/rcon/discord.py
+++ b/rcon/discord.py
@@ -6,6 +6,7 @@ from typing import List, Type
 import requests
 from discord_webhook import DiscordWebhook
 from pydantic import HttpUrl
+from discord.utils import escape_markdown
 
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
 from rcon.user_config.webhooks import (
@@ -100,7 +101,7 @@ def send_to_discord_audit(
         dh_webhooks = [
             DiscordWebhook(
                 url=str(url),
-                content="[{}][**{}**] {}".format(server_config.short_name, by, message),
+                content="[{}][**{}**] {}".format(server_config.short_name, escape_markdown(by), escape_markdown(message)),
             )
             for url in webhookurls
             if url

--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -10,6 +10,7 @@ from functools import partial
 from typing import Callable, DefaultDict, Dict, Iterable
 
 import discord_webhook
+from discord.utils import escape_markdown
 from pydantic import HttpUrl
 from sqlalchemy import and_, desc, or_
 from sqlalchemy.exc import IntegrityError
@@ -199,7 +200,7 @@ def send_log_line_webhook_message(
     allowed_mentions = make_allowed_mentions(mentions)
 
     content = " ".join(mentions)
-    description: str = log_line["line_without_time"]
+    description: str = escape_markdown(log_line["line_without_time"])
     embed = discord_webhook.DiscordEmbed(
         description=description,
         timestamp=datetime.datetime.utcfromtimestamp(log_line["timestamp_ms"] / 1000),

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -6,6 +6,7 @@ from functools import wraps
 from threading import Timer
 
 from discord_webhook import DiscordEmbed
+from discord.utils import escape_markdown
 
 import rcon.steam_utils as steam_utils
 from rcon.cache_utils import invalidates
@@ -749,7 +750,7 @@ def notify_camera(rcon: Rcon, struct_log):
     try:
         if hooks := get_prepared_discord_hooks(CameraWebhooksUserConfig):
             embeded = DiscordEmbed(
-                title=f'{struct_log["player"]}  - {struct_log["steam_id_64_1"]}',
+                title=f'{escape_markdown(struct_log["player"])}  - {escape_markdown(struct_log["steam_id_64_1"])}',
                 description=struct_log["sub_content"],
                 color=242424,
             )

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from functools import wraps
 from threading import Timer
+from typing import Final
 
 from discord_webhook import DiscordEmbed
 from discord.utils import escape_markdown
@@ -746,12 +747,13 @@ def undo_real_vips(rcon: Rcon, struct_log):
 @on_camera
 def notify_camera(rcon: Rcon, struct_log):
     send_to_discord_audit(message=struct_log["message"], by=struct_log["player"])
+    short_name: Final = RconServerSettingsUserConfig.load_from_db().short_name
 
     try:
         if hooks := get_prepared_discord_hooks(CameraWebhooksUserConfig):
             embeded = DiscordEmbed(
                 title=f'{escape_markdown(struct_log["player"])}  - {escape_markdown(struct_log["steam_id_64_1"])}',
-                description=struct_log["sub_content"],
+                description=f'{short_name} - {struct_log["sub_content"]}',
                 color=242424,
             )
             for h in hooks:


### PR DESCRIPTION
Some players may have balanced `*` or other MD characters in their names. Use `markdown_escape()` to escape these special characters in the Audit and Camera webhooks.

Also add the server `short_name` to the Camera webhook embed.