### PR TITLE
Hotfix/duplicate steam profile records

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -365,7 +365,7 @@ def ban_if_has_vac_bans(rcon: Rcon, steam_id_64, name):
             logger.error("Can't check VAC history, player not found %s", steam_id_64)
             return
 
-        bans = player.steaminfo.bans
+        bans = player.steaminfo.bans if player.steaminfo else None
         if not bans or not isinstance(bans, dict):
             logger.warning(
                 "Can't fetch Bans for player %s, received %s", steam_id_64, bans

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -302,7 +302,7 @@ def update_db_player_info(
                 player.steaminfo.country = country_code
         else:
             player.steaminfo = SteamInfo(
-                profile=player_prof, bans=player_ban, country=country_code
+                profile=player_prof, bans=player_ban, country=country_code, steamid=player
             )
 
     return len(profiles), len(bans)

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -354,9 +354,7 @@ def update_missing_old_steam_info_single_player(
 
     if player.steaminfo is None:
         steam_info = SteamInfo(
-            profile=profile,
-            country=country_code,
-            bans=bans,
+            profile=profile, country=country_code, bans=bans, player=player
         )
         player.steaminfo = steam_info
     else:

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -354,7 +354,7 @@ def update_missing_old_steam_info_single_player(
 
     if player.steaminfo is None:
         steam_info = SteamInfo(
-            profile=profile, country=country_code, bans=bans, player=player
+            profile=profile, country=country_code, bans=bans, steamid=player
         )
         player.steaminfo = steam_info
     else:

--- a/rcon/steam_utils.py
+++ b/rcon/steam_utils.py
@@ -302,7 +302,10 @@ def update_db_player_info(
                 player.steaminfo.country = country_code
         else:
             player.steaminfo = SteamInfo(
-                profile=player_prof, bans=player_ban, country=country_code, steamid=player
+                profile=player_prof,
+                bans=player_ban,
+                country=country_code,
+                steamid=player,
             )
 
     return len(profiles), len(bans)
@@ -370,51 +373,52 @@ def enrich_db_users(chunk_size=100, update_from_days_old=30):
     """Use the Steam API to update steam profiles/bans for missing or old records"""
     max_age = datetime.datetime.utcnow() - datetime.timedelta(days=update_from_days_old)
     with enter_session() as sess:
-        # Missing JSONB records are surprisingly difficult to identify depending
-        # on how they've been persisted but JSONB.NULL should cover the different cases
-        # This query can also return many thousands of results, using stream_results and
-        # yield_per doesn't fetch all of the results at once, but pages through them
-        stmt = (
-            select(PlayerSteamID)
-            .execution_options(stream_results=True, yield_per=chunk_size)
-            .outerjoin(SteamInfo)
-            .where(func.length(PlayerSteamID.steam_id_64) == 17)
-            .where(
-                or_(
-                    PlayerSteamID.steaminfo == None,
-                    SteamInfo.updated <= max_age,
-                    SteamInfo.bans == JSONB.NULL,
-                    SteamInfo.profile == JSONB.NULL,
+        with sess.no_autoflush:
+            # Missing JSONB records are surprisingly difficult to identify depending
+            # on how they've been persisted but JSONB.NULL should cover the different cases
+            # This query can also return many thousands of results, using stream_results and
+            # yield_per doesn't fetch all of the results at once, but pages through them
+            stmt = (
+                select(PlayerSteamID)
+                .execution_options(stream_results=True, yield_per=chunk_size)
+                .outerjoin(SteamInfo)
+                .where(func.length(PlayerSteamID.steam_id_64) == 17)
+                .where(
+                    or_(
+                        PlayerSteamID.steaminfo == None,
+                        SteamInfo.updated <= max_age,
+                        SteamInfo.bans == JSONB.NULL,
+                        SteamInfo.profile == JSONB.NULL,
+                    )
                 )
             )
-        )
 
-        logger.info("Updating steam profiles/bans for missing/old users")
-        for idx, player_chunks in enumerate(sess.scalars(stmt).partitions()):
-            try:
-                players = list(player_chunks)
-                if not players:
-                    logger.warning("Empty query results for page %s", idx)
-                    continue
-                logger.info(
-                    "Updating page %s steam profile/bans, first steam ID of page: %s",
-                    idx + 1,
-                    players[0],
-                )
-                num_profs, num_bans = update_db_player_info(sess, players=players)
+            logger.info("Updating steam profiles/bans for missing/old users")
+            for idx, player_chunks in enumerate(sess.scalars(stmt).partitions()):
+                try:
+                    players = list(player_chunks)
+                    if not players:
+                        logger.warning("Empty query results for page %s", idx)
+                        continue
+                    logger.info(
+                        "Updating page %s steam profile/bans, first steam ID of page: %s",
+                        idx + 1,
+                        players[0],
+                    )
+                    num_profs, num_bans = update_db_player_info(sess, players=players)
 
-                logger.info(
-                    "%s profiles, %s bans fetched from steam API",
-                    num_profs,
-                    num_bans,
-                )
-            except Exception as e:
-                logger.exception(e)
-                logger.error("Error while fetching page %s: %s", idx + 1, e)
+                    logger.info(
+                        "%s profiles, %s bans fetched from steam API",
+                        num_profs,
+                        num_bans,
+                    )
+                except Exception as e:
+                    logger.exception(e)
+                    logger.error("Error while fetching page %s: %s", idx + 1, e)
 
-            # Shouldn't really need this with how many API calls we should be able to make
-            # but just to be on the safe side
-            time.sleep(1)
+                # Shouldn't really need this with how many API calls we should be able to make
+                # but just to be on the safe side
+                time.sleep(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes some issues I introduced when we switched to checking for steam API info on player connect.

It's still not perfect, there's some issues with `enrich_db_users` and objects being disconnected from the session, but I'm giving up on that for now, I think it needs someone more familiar with how sqlalchemy works.

I've been running this on our server for awhile now without issue, I was just trying to get `enrich_db_users` fixed but I'm giving up for now.

```
[2024-02-05 01:06:05,916][ERROR] rcon.game_logs game_logs.py:process_hooks:375 | Hook 'rcon.hooks.update_player_steaminfo_on_connect' for '{'version': 1, 'timestamp_ms': 1707095162000, 'relative_time_ms': -3513.884, 'raw': '[2.52 sec (1707095162)] CONNECTED -🆁- Happy (76561198177984307)', 'line_without_time': 'CONNECTED -🆁- Happy (76561198177984307)', 'action': 'CONNECTED', 'player': '-🆁- Happy', 'steam_id_64_1': '76561198177984307', 'player2': None, 'steam_id_64_2': None, 'weapon': None, 'message': '-🆁- Happy (76561198177984307)', 'sub_content': None}' returned an error: (psycopg2.errors.NotNullViolation) null value in column "playersteamid_id" violates not-null constraint
DETAIL:  Failing row contains (35004, null, 2023-07-14 02:48:32.996863, 2024-02-05 01:06:05.908874, {"avatar": "https://avatars.steamstatic.com/398f530c07edd1de9495..., null, null).

[SQL: UPDATE steam_info SET playersteamid_id=%(playersteamid_id)s, updated=%(updated)s WHERE steam_info.id = %(steam_info_id)s]
[parameters: {'playersteamid_id': None, 'updated': datetime.datetime(2024, 2, 5, 1, 6, 5, 908874), 'steam_info_id': 35004}]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1969, in _exec_single_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 922, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.NotNullViolation: null value in column "playersteamid_id" violates not-null constraint
```