### PR TITLE
add support for async discord webhooks

### DIFF
--- a/rcon/discord.py
+++ b/rcon/discord.py
@@ -112,8 +112,6 @@ def send_to_discord_audit(
         # we get a future, not a response, but i don't see code using the responses
         for hook in dh_webhooks:
             DiscordAsyncio().send_webhook(hook)
-        # responses = [hook.execute() for hook in dh_webhooks]
-        # return responses
     except:
         logger.exception("Can't send audit log")
         if not silent:

--- a/rcon/discord.py
+++ b/rcon/discord.py
@@ -16,6 +16,7 @@ from rcon.user_config.webhooks import (
     CameraWebhooksUserConfig,
     WatchlistWebhooksUserConfig,
 )
+from rcon.discord_asyncio import DiscordAsyncio
 
 
 @lru_cache
@@ -101,14 +102,18 @@ def send_to_discord_audit(
         dh_webhooks = [
             DiscordWebhook(
                 url=str(url),
-                content="[{}][**{}**] {}".format(server_config.short_name, escape_markdown(by), escape_markdown(message)),
+                content=f"[{server_config.short_name}][**{escape_markdown(str(by))}**] {escape_markdown(message)}",
             )
             for url in webhookurls
             if url
         ]
 
-        responses = [hook.execute() for hook in dh_webhooks]
-        return responses
+        # use DiscordAsyncio to send webhooks asynchronously
+        # we get a future, not a response, but i don't see code using the responses
+        for hook in dh_webhooks:
+            DiscordAsyncio().send_webhook(hook)
+        # responses = [hook.execute() for hook in dh_webhooks]
+        # return responses
     except:
         logger.exception("Can't send audit log")
         if not silent:

--- a/rcon/discord_asyncio.py
+++ b/rcon/discord_asyncio.py
@@ -1,0 +1,98 @@
+import asyncio
+import logging
+import time
+import threading
+from discord_webhook import DiscordWebhook
+from discord_webhook import AsyncDiscordWebhook
+
+
+logger = logging.getLogger(__name__)
+
+
+# class the starts a new asyncio event loop in a new thread
+class DiscordAsyncio:
+    """
+    A class for handling asynchronous Discord operations using asyncio.
+    An event loop is created in a new thread when the class is instantiated.
+    The singleton pattern is used to ensure that only one instance of the
+    class is created.
+
+    Methods:
+    - send_webhook: Sends a DiscordWebhook asynchronously.
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        """
+        Create a new instance of the DiscordAsyncio class if it doesn't already exist.
+
+        Returns:
+            The instance of the DiscordAsyncio class.
+        """
+        if cls._instance is None:
+            # threading.Lock is expensive, so check if instance is None first
+            # since instance is not None should be the most common case
+            with cls._lock:
+                if cls._instance is None:
+                    logger.info(f"Creating new instance of {cls.__name__}")
+                    cls._instance = super(DiscordAsyncio, cls).__new__(cls)
+                    cls._instance._start_asyncio()
+        return cls._instance
+
+    def _start_asyncio(self):
+        self.loop = asyncio.new_event_loop()
+        t = threading.Thread(target=self.loop.run_forever)
+        t.daemon = True
+        t.start()
+        logger.info(
+            f"{threading.current_thread().name}:{threading.current_thread().ident}: started asyncio event loop in new thread: {t.name}:{t.ident}"
+        )
+        return self.loop
+
+    def _stop_async(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+    def send_webhook(self, webhook: DiscordWebhook):
+        """
+        Sends a DiscordWebhook asynchronously.
+
+        Args:
+        - webhook: The DiscordWebhook object to send.
+
+        Returns:
+        - A concurrent.futures.Future object representing the result of the asynchronous operation.
+        """
+        async_webhook: AsyncDiscordWebhook = self._make_async_webhook(webhook)
+        return self.send_async_webhook(async_webhook)
+
+    def send_async_webhook(self, async_webhook: AsyncDiscordWebhook):
+        """
+        Sends an AsyncDiscordWebhook.
+
+        Args:
+            async_webhook (AsyncDiscordWebhook): The asynchronous Discord webhook to send.
+
+        Returns:
+            concurrent.futures.Future: A future representing the result of the webhook send operation.
+        """
+        return asyncio.run_coroutine_threadsafe(
+            self._send_webhook(async_webhook), self.loop
+        )
+
+    @staticmethod
+    async def _send_webhook(webhook: AsyncDiscordWebhook):
+        await webhook.execute()
+
+    @staticmethod
+    def _make_async_webhook(webhook):
+        return AsyncDiscordWebhook(
+            url=webhook.url,
+            content=webhook.content,
+            embeds=webhook.embeds,
+            avatar_url=webhook.avatar_url,
+            allowed_mentions=webhook.allowed_mentions,
+            username=webhook.username,
+            rate_limit_retry=True,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ simplejson==3.19.2
 psycopg2-binary
 sentry-sdk[django]==1.40.3
 python-dateutil==2.8.2
-discord-webhook
+discord-webhook[async]
 requests==2.31.0
 steam==1.4.4
 # Alembic does not use semantic versioning, so be careful with the version numbers https://alembic.sqlalchemy.org/en/latest/front.html#versioning-scheme

--- a/tests/test_discord_asyncio.py
+++ b/tests/test_discord_asyncio.py
@@ -1,0 +1,20 @@
+import unittest
+from rcon.discord_asyncio import DiscordAsyncio
+
+
+class TestDiscordAsyncio(unittest.TestCase):
+
+    def setUp(self):
+        self.discord_asyncio = DiscordAsyncio()
+
+    def test_only_one_instance(self):
+        """
+        Test that only one instance of DiscordAsyncio is created.
+        """
+        discord_asyncio = DiscordAsyncio()
+        another_discord_asyncio = DiscordAsyncio()
+        assert discord_asyncio is another_discord_asyncio
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add support for async discord webhooks, allowing handling of discord rate limiting.

Support is via a singleton class that creates an asyncio event loop in a new thread.

Use `DiscordAsyncio().send_webhook(hook)` to send an existing `DiscordWebhook` asynchronously. The fields in `hook` will be copied to a new `AsyncDiscordWebhook` before being sent.

Currently only used in `send_to_discord_audit()`, mostly because it rate-limits hard when using https://github.com/cemathey/hll_seed_vip.