### PR TITLE
Cast logs_highlight_logs to a bool

### DIFF
--- a/rcongui/src/components/LogsView/logs.js
+++ b/rcongui/src/components/LogsView/logs.js
@@ -62,7 +62,7 @@ const formatClass = (action, classes, highlightLogs) => {
   }
   return classes.logs;
 };
-  
+
 const Selector = ({
   classes,
   defaultValue,
@@ -125,7 +125,7 @@ class Logs extends React.Component {
         100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
       ],
       highlightLogs: localStorage.getItem("logs_highlight_logs")
-        ? localStorage.getItem("logs_highlight_logs")
+        ? localStorage.getItem("logs_highlight_logs") === 'true'
         : false,
     };
 
@@ -210,17 +210,17 @@ class Logs extends React.Component {
               <IconButton onClick={onFullScreen}>
                 {isFullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
               </IconButton>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={highlightLogs}
-                  onChange={(e) => this.setHighlightLogs(e.target.checked)}
-                  color="primary"
-                />
-              }
-              label="Highlight Logs"
-              labelPlacement="top"
-            />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={highlightLogs}
+                    onChange={(e) => this.setHighlightLogs(e.target.checked)}
+                    color="primary"
+                  />
+                }
+                label="Highlight Logs"
+                labelPlacement="top"
+              />
             </h1>
             <ListItemText secondary="30s auto refresh" />
             <AutoRefreshLine


### PR DESCRIPTION
The highlight logs toggle was defaulting to enabled on page load or refresh because we weren't casting it to a bool when retrieving it from local storage.

Line 128 is the only actual change the rest is formatting from prettier.