### PR TITLE
Remove old comment that no longer applies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ requests==2.31.0
 steam==1.4.4
 # Alembic does not use semantic versioning, so be careful with the version numbers https://alembic.sqlalchemy.org/en/latest/front.html#versioning-scheme
 alembic==1.13.1
-# rq-scheduler doesn't work with rq > 1.13.0 right now because of a deprecated `ColorizingStreamHandler` import
 rq==1.16.1
 rq-scheduler==0.13.1
 paramiko==3.4.0


### PR DESCRIPTION
This used to be true but isn't anymore. I built and verified the supervisor service starts correctly.