### PR TITLE
Hotfix/votemap reset

### DIFF
--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -157,7 +157,7 @@ class Layer(pydantic.BaseModel):
         return self.id
 
     def __repr__(self) -> str:
-        return str(self)
+        return f"{self.__class__}(id={self.id}, map={self.map}, attackers={self.attackers}, environment={self.environment})"
 
     def __hash__(self) -> int:
         return hash(self.id)
@@ -719,7 +719,10 @@ LAYERS = {
 }
 
 
-def parse_layer(layer_name: str):
+def parse_layer(layer_name: str | Layer):
+    if isinstance(layer_name, Layer):
+        layer_name = str(layer_name)
+
     layer = LAYERS.get(layer_name)
     if layer:
         return layer

--- a/rcon/vote_map.py
+++ b/rcon/vote_map.py
@@ -129,7 +129,7 @@ def _suggest_next_maps(
     else:
         last_n_maps: set[maps.Layer] = set()
     logger.info("Excluding last %s player maps: %s", exclude_last_n, last_n_maps)
-    remaining_maps = set(allowed_maps) - last_n_maps
+    remaining_maps = [maps.parse_layer(m) for m in allowed_maps - last_n_maps]
     logger.info("Remaining maps to suggest from: %s", remaining_maps)
 
     current_side = current_map.attackers
@@ -140,12 +140,18 @@ def _suggest_next_maps(
         logger.info(
             "Considering offensive/skirmish mode as same map, excluding %s", map_ids
         )
-        remaining_maps = set(m for m in remaining_maps if m.map not in map_ids)
+        remaining_maps = [
+            maps.parse_layer(m) for m in remaining_maps if m.map not in map_ids
+        ]
         logger.info("Remaining maps to suggest from: %s", remaining_maps)
 
     if not allow_consecutive_offensives_of_opposite_side and current_side:
         # TODO: make sure this is correct
-        remaining_maps = [m for m in remaining_maps if m.opposite_side != current_side]
+        remaining_maps = [
+            maps.parse_layer(m)
+            for m in remaining_maps
+            if m.opposite_side != current_side
+        ]
         logger.info(
             "Not allowing consecutive offensive with opposite side: %s",
             maps.get_opposite_side(current_side),


### PR DESCRIPTION
This fixes the issues with resetting votemap state, the set operations were returning sets of strings and not sets of `Layer`.

Updates the `__repr__` method on `Layer` to make it more obvious if it's a string map name or an actual `Layer` in log statements.