### PR TITLE
Include tagged version in logging/API calls

### DIFF
--- a/rcon/settings.py
+++ b/rcon/settings.py
@@ -1,22 +1,26 @@
 import os
+import re
 import socket
 from logging.config import dictConfig
+from subprocess import PIPE, run
 
 from rcon.types import ServerInfoType
-from subprocess import run, PIPE
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
-import re
 
 try:
-    TAG_VERSION = run(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE).stdout.decode().strip()
+    TAG_VERSION = (
+        run(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE)
+        .stdout.decode()
+        .strip()
+    )
 except Exception:
     TAG_VERSION = "unknown"
 
 try:
     config = RconServerSettingsUserConfig.load_from_db()
-    ENVIRONMENT = re.sub(
-            "[^0-9a-zA-Z]+", "", (config.short_name or "default").strip()
-        )[:64]
+    ENVIRONMENT = re.sub("[^0-9a-zA-Z]+", "", (config.short_name or "default").strip())[
+        :64
+    ]
 except Exception:
     ENVIRONMENT = "undefined"
 

--- a/rcon/settings.py
+++ b/rcon/settings.py
@@ -3,6 +3,22 @@ import socket
 from logging.config import dictConfig
 
 from rcon.types import ServerInfoType
+from subprocess import run, PIPE
+from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
+import re
+
+try:
+    TAG_VERSION = run(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE).stdout.decode().strip()
+except Exception:
+    TAG_VERSION = "unknown"
+
+try:
+    config = RconServerSettingsUserConfig.load_from_db()
+    ENVIRONMENT = re.sub(
+            "[^0-9a-zA-Z]+", "", (config.short_name or "default").strip()
+        )[:64]
+except Exception:
+    ENVIRONMENT = "undefined"
 
 # TODO: Use a config style that is not required at import time
 
@@ -30,7 +46,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "console": {
-            "format": "[%(asctime)s][%(levelname)s] %(name)s "
+            "format": f"[%(asctime)s][%(levelname)s][{ENVIRONMENT}][{TAG_VERSION}] %(name)s "
             "%(filename)s:%(funcName)s:%(lineno)d | %(message)s",
         },
     },

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -18,7 +18,7 @@ from django.views.decorators.http import require_http_methods
 from rcon.audit import heartbeat, ingame_mods, online_mods, set_registered_mods
 from rcon.cache_utils import ttl_cache
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
-from rconweb.settings import SECRET_KEY
+from rconweb.settings import SECRET_KEY, TAG_VERSION
 
 from .decorators import require_content_type
 from .models import DjangoAPIKey, SteamPlayer
@@ -48,6 +48,7 @@ class RconResponse:
     failed: bool = True
     error: str = None
     forwards_results: Any = None
+    version: str | None = None
 
     def to_dict(self):
         # asdict() cannot convert a Django QueryDict properly
@@ -58,7 +59,7 @@ class RconResponse:
 
 def api_response(*args, **kwargs):
     status_code = kwargs.pop("status_code", 200)
-    return JsonResponse(RconResponse(*args, **kwargs).to_dict(), status=status_code)
+    return JsonResponse(RconResponse(version=TAG_VERSION, *args, **kwargs).to_dict(), status=status_code)
 
 
 def api_csv_response(content, name, header):

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -36,6 +36,8 @@ from .decorators import require_content_type
 from .multi_servers import forward_command, forward_request
 from .utils import _get_data
 
+from rconweb.settings import TAG_VERSION
+
 logger = logging.getLogger("rconweb")
 
 ctl = get_rcon()
@@ -469,6 +471,7 @@ def expose_api_endpoint(func, command_name, permissions: list[str] | set[str] | 
                 failed=failure,
                 error=error,
                 forward_results=others,
+                version=TAG_VERSION
             )
         )
         if data.get("forward"):

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -22,21 +22,20 @@ from rcon.cache_utils import RedisCached, get_redis_pool
 from rcon.commands import CommandFailedError
 from rcon.discord import send_to_discord_audit
 from rcon.gtx import GTXFtp
+from rcon.maps import parse_layer, safe_get_map_name
 from rcon.player_history import add_player_to_blacklist, remove_player_from_blacklist
 from rcon.rcon import get_rcon
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
-from rcon.maps import safe_get_map_name, parse_layer
 from rcon.utils import MapsHistory, get_server_number
 from rcon.watchlist import PlayerWatch
 from rcon.workers import temporary_broadcast, temporary_welcome
+from rconweb.settings import TAG_VERSION
 
 from .audit_log import auto_record_audit, record_audit
 from .auth import AUTHORIZATION, api_response, login_required
 from .decorators import require_content_type
 from .multi_servers import forward_command, forward_request
 from .utils import _get_data
-
-from rconweb.settings import TAG_VERSION
 
 logger = logging.getLogger("rconweb")
 
@@ -471,7 +470,7 @@ def expose_api_endpoint(func, command_name, permissions: list[str] | set[str] | 
                 failed=failure,
                 error=error,
                 forward_results=others,
-                version=TAG_VERSION
+                version=TAG_VERSION,
             )
         )
         if data.get("forward"):

--- a/rconweb/rconweb/settings.py
+++ b/rconweb/rconweb/settings.py
@@ -15,24 +15,29 @@ import os
 import re
 import socket
 
+from typing import Final
 import sentry_sdk
 from sentry_sdk import configure_scope
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from subprocess import run, PIPE
 
-from rcon.rcon import get_rcon
+from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
+
+try:
+    TAG_VERSION = run(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE).stdout.decode().strip()
+except Exception:
+    TAG_VERSION = "unknown"
 
 HLL_MAINTENANCE_CONTAINER = os.getenv("HLL_MAINTENANCE_CONTAINER")
 
 
 try:
-    if HLL_MAINTENANCE_CONTAINER:
-        ENVIRONMENT = "undefined"
-    else:
-        ENVIRONMENT = re.sub(
-            "[^0-9a-zA-Z]+", "", (get_rcon().get_name() or "default").strip()
+    config = RconServerSettingsUserConfig.load_from_db()
+    ENVIRONMENT = re.sub(
+            "[^0-9a-zA-Z]+", "", (config.short_name or "default").strip()
         )[:64]
-except:
+except Exception:
     ENVIRONMENT = "undefined"
 
 LOGGING = {
@@ -40,7 +45,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "console": {
-            "format": f"[%(asctime)s][%(levelname)s][{ENVIRONMENT}] %(name)s "
+            "format": f"[%(asctime)s][%(levelname)s][{ENVIRONMENT}][{TAG_VERSION}] %(name)s "
             "%(filename)s:%(funcName)s:%(lineno)d | %(message)s",
         },
     },

--- a/rconweb/rconweb/settings.py
+++ b/rconweb/rconweb/settings.py
@@ -14,18 +14,21 @@ import logging
 import os
 import re
 import socket
+from subprocess import PIPE, run
 
-from typing import Final
 import sentry_sdk
 from sentry_sdk import configure_scope
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
-from subprocess import run, PIPE
 
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
 
 try:
-    TAG_VERSION = run(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE).stdout.decode().strip()
+    TAG_VERSION = (
+        run(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE)
+        .stdout.decode()
+        .strip()
+    )
 except Exception:
     TAG_VERSION = "unknown"
 
@@ -34,9 +37,9 @@ HLL_MAINTENANCE_CONTAINER = os.getenv("HLL_MAINTENANCE_CONTAINER")
 
 try:
     config = RconServerSettingsUserConfig.load_from_db()
-    ENVIRONMENT = re.sub(
-            "[^0-9a-zA-Z]+", "", (config.short_name or "default").strip()
-        )[:64]
+    ENVIRONMENT = re.sub("[^0-9a-zA-Z]+", "", (config.short_name or "default").strip())[
+        :64
+    ]
 except Exception:
     ENVIRONMENT = "undefined"
 


### PR DESCRIPTION
Including the version in output should make it a lot easier to help people troubleshoot their problems, especially when people are running an older version where a problem is already fixed.

* Standardizes the logging format between the `rcon` and `rconweb` packages
  * `rcon` logging wasn't including the server name
* Use the server short name as configured instead of the server name returned by the game server
* Include the tagged version in log files
* Include the tagged version in API responses

Example output:

`api_1.log`:

```
[2024-04-09 21:41:24,792][WARNING][MyServer1][v9.6.2] rconweb auth.py:is_logged_in:120 | admin's steam id is not set 
```

`startup.log`
```
[2024-04-09 21:51:10,482][INFO][MyServer1][v9.6.2] __main__ seed_db.py:seed_default_config:42 | Seeding DB
```

`get_status`:
```
{
    "result": {
        "name": "The BEER [HAUS] 2 |US EAST-VA| discord.gg/beerhaus",
        "map": "omahabeach_warfare",
        "nb_players": "98/100",
        "short_name": "MyServer1",
        "player_count": "98",
        "server_number": 1
    },
    "command": "get_status",
    "arguments": {},
    "failed": false,
    "error": "",
    "forward_results": null,
    "version": "v9.6.2"
}
```