### PR TITLE
Maint/seed user config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,8 +31,8 @@ then
       exit 0
   fi
 
-  ./manage.py register_api
   python -m rcon.user_config.seed_db
+  ./manage.py register_api
   cd rconweb 
   ./manage.py collectstatic --noinput
   # If DONT_SEED_ADMIN_USER is not set to any value

--- a/rcon/user_config/seed_db.py
+++ b/rcon/user_config/seed_db.py
@@ -10,6 +10,7 @@ from rcon.user_config.auto_mod_seeding import AutoModSeedingUserConfig
 from rcon.user_config.auto_mod_solo_tank import AutoModNoSoloTankUserConfig
 from rcon.user_config.ban_tk_on_connect import BanTeamKillOnConnectUserConfig
 from rcon.user_config.camera_notification import CameraNotificationUserConfig
+from rcon.user_config.chat_commands import ChatCommandsUserConfig
 from rcon.user_config.expired_vips import ExpiredVipsUserConfig
 from rcon.user_config.gtx_server_name import GtxServerNameChangeUserConfig
 from rcon.user_config.log_line_webhooks import LogLineWebhookUserConfig
@@ -54,6 +55,7 @@ def seed_default_config():
             BanTeamKillOnConnectUserConfig.seed_db(sess)
             CameraNotificationUserConfig.seed_db(sess)
             CameraWebhooksUserConfig.seed_db(sess)
+            ChatCommandsUserConfig.seed_db(sess)
             ChatWebhooksUserConfig.seed_db(sess)
             ExpiredVipsUserConfig.seed_db(sess)
             GtxServerNameChangeUserConfig.seed_db(sess)


### PR DESCRIPTION
* Seed user configs before registering the API to eliminate error messages about the config not existing
* Seed the chat commands user config

Built/tested, works fine.