### PR TITLE
Use existing UNKNOWN_MAP_NAME when we can't properly record the map name

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -201,7 +201,7 @@ def handle_new_match_start(rcon: Rcon, struct_log):
             try:
                 current_map = rcon.get_map().replace("_RESTART", "")
             except (CommandFailedError, HLLServerError):
-                current_map = "bla_"
+                current_map = UNKNOWN_MAP_NAME
                 logger.error("Unable to get current map")
 
         map_name_to_save = LOG_MAP_NAMES_TO_MAP.get(
@@ -261,7 +261,7 @@ def record_map_end(rcon: Rcon, struct_log):
     try:
         current_map = rcon.get_map()
     except (CommandFailedError, HLLServerError):
-        current_map = "bla_"
+        current_map = UNKNOWN_MAP_NAME
         logger.error("Unable to get current map")
 
     map_name = LOG_MAP_NAMES_TO_MAP.get(struct_log["sub_content"], UNKNOWN_MAP_NAME)

--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -13,6 +13,7 @@ RE_LAYER_NAME = re.compile(
 )
 
 UNKNOWN_MAP_NAME = "unknown"
+UNKNOWN_MAP_TAG = "UNK"
 
 
 LOG_MAP_NAMES_TO_MAP = CaseInsensitiveDict(
@@ -67,6 +68,7 @@ LEGACY_MAP_TAGS = CaseInsensitiveDict(
         "kharkov": "KHA",
         "driel": "DRL",
         "elalamein": "ELA",
+        UNKNOWN_MAP_NAME: UNKNOWN_MAP_TAG,
     }
 )
 


### PR DESCRIPTION
Use `UNKNOWN_MAP_NAME` when there are issues recording the map name instead of `bla_`.

This was causing errors with the `get_scoreboard_maps` endpoint and cause the entire command to fail once it hit a map that was recorded with `bla_`.

I didn't explicitly build/test this but it's a simple change.