### PR TITLE
Hotfix/compose image

### DIFF
--- a/default.env
+++ b/default.env
@@ -28,8 +28,8 @@ POSTGRES_IMAGE=postgres:12-alpine
 
 # The name of the Docker hub repository, you should never need to change
 # this unless we host images on a different repository
-BACKEND_DOCKER_REPOSITORY=cericmathey/hll_rcon
-FRONTEND_DOCKER_REPOSITORY=cericmathey/hll_rcon_frontend
+BACKEND_DOCKER_REPOSITORY=cericmathey/hll_rcon_tool
+FRONTEND_DOCKER_REPOSITORY=cericmathey/hll_rcon_tool_frontend
 
 # This is the version of CRCON that will be pulled from Docker hub when you
 # pull images, leave this at `latest` to have the latest version, or 

--- a/docker-templates/one-server.yaml
+++ b/docker-templates/one-server.yaml
@@ -59,8 +59,8 @@ x-backend: &backend
 x-supervisor: &supervisor
   build:
     context: .
-    dockerfile: Dockerfile-frontend
-  image: ${FRONTEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
+    dockerfile: Dockerfile
+  image: ${BACKEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
   restart: on-failure
   command: supervisor
   volumes:

--- a/docker-templates/ten-servers.yaml
+++ b/docker-templates/ten-servers.yaml
@@ -68,8 +68,8 @@ x-backend: &backend
 x-supervisor: &supervisor
   build:
     context: .
-    dockerfile: Dockerfile-frontend
-  image: ${FRONTEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
+    dockerfile: Dockerfile
+  image: ${BACKEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
   restart: on-failure
   command: supervisor
   volumes:


### PR DESCRIPTION
Silly mistakes on my part!

This fixes the repository names in `default.env` (I could have changed the repo name on my end on Docker Hub, but in case anyone has already pulled these I don't want to undo their changes)

This also fixes the `supervisor` container accidentally using the `frontend` image.