### PR TITLE
Handle parsing UNKNOWN_MAP_NAME as a Layer

### DIFF
--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -1,7 +1,7 @@
 import re
 from enum import Enum
 from logging import getLogger
-from typing import Iterable, Literal, Union, Sequence
+from typing import Iterable, Literal, Sequence, Union
 
 import pydantic
 from requests.structures import CaseInsensitiveDict
@@ -12,6 +12,7 @@ RE_LAYER_NAME = re.compile(
     r"(?P<tag>\w{3})_(?P<size>S|L)_(?P<year>\d{4})_(?:(?P<environment>\w+)_)?P_(?P<gamemode>\w+)$"
 )
 
+UNKNOWN_MODE = "unknown"
 UNKNOWN_MAP_NAME = "unknown"
 UNKNOWN_MAP_TAG = "UNK"
 
@@ -779,7 +780,12 @@ def parse_layer(layer_name: str | Layer):
 
 
 def _parse_legacy_layer(layer_name: str):
-    _map, _mode = layer_name.split("_", 1)
+    try:
+        _map, _mode = layer_name.split("_", 1)
+    except ValueError:
+        _map = UNKNOWN_MAP_NAME
+        _mode = UNKNOWN_MODE
+
     map = MAPS.get(_map)
 
     if _mode.startswith("off"):

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,5 +1,13 @@
 import pytest
-from rcon.maps import Layer, MAPS, Gamemode, numbered_maps
+
+from rcon.maps import (
+    MAPS,
+    UNKNOWN_MAP_NAME,
+    Gamemode,
+    Layer,
+    numbered_maps,
+    parse_layer,
+)
 
 SMDM_WARFARE = Layer(
     id="stmariedumont_warfare",
@@ -22,3 +30,7 @@ SME_WARFARE = Layer(
 )
 def test_numbered_maps(maps, expected):
     assert numbered_maps(maps=maps) == expected
+
+
+def test_parse_layer():
+    assert parse_layer(layer_name="unknown").id == UNKNOWN_MAP_NAME


### PR DESCRIPTION
`_parse_legacy_layer` would fail when trying to parse map names set to `unknown` because of the missing trailing `_`

* Adds a test for parsing that style map name into a Layer
* Sets the map name/mode to `unknown`

This should preserve the other things that depend on map names being set to `unknown` like UI stuff and the map picture for it.