### PR TITLE
Hotfix/untitled maps

### DIFF
--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -193,6 +193,15 @@ MAPS = {
     m.id: m
     for m in (
         Map(
+            id=UNKNOWN_MAP_NAME,
+            name=UNKNOWN_MAP_NAME,
+            tag="",
+            prettyname=UNKNOWN_MAP_NAME,
+            shortname=UNKNOWN_MAP_NAME,
+            allies=Faction.US,
+            axis=Faction.GER,
+        ),
+        Map(
             id="stmereeglise",
             name="SAINTE-MÈRE-ÉGLISE",
             tag="SME",
@@ -342,6 +351,9 @@ MAPS = {
 LAYERS = {
     l.id: l
     for l in (
+        Layer(
+            id=UNKNOWN_MAP_NAME, map=MAPS[UNKNOWN_MAP_NAME], gamemode=Gamemode.WARFARE
+        ),
         Layer(
             id="stmereeglise_warfare",
             map=MAPS["stmereeglise"],
@@ -782,9 +794,11 @@ LAYERS = {
 }
 
 
-def parse_layer(layer_name: str | Layer):
+def parse_layer(layer_name: str | Layer) -> Layer:
     if isinstance(layer_name, Layer):
         layer_name = str(layer_name)
+    elif is_server_loading_map(map_name=layer_name):
+        return LAYERS[UNKNOWN_MAP_NAME]
 
     layer = LAYERS.get(layer_name)
     if layer:
@@ -930,3 +944,7 @@ def safe_get_map_name(map_name: str, pretty: bool = True) -> str:
         return map_.pretty()
     else:
         return map_.map.name
+
+
+def is_server_loading_map(map_name: str) -> bool:
+    return "untitled" in map_name.lower()

--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -351,6 +351,9 @@ MAPS = {
 LAYERS = {
     l.id: l
     for l in (
+        # In older versions (prior to v9.8.0) map names could be recorded as bla_
+        # if the map name could not be retrieved from the game server
+        Layer(id="bla_", map=MAPS[UNKNOWN_MAP_NAME], gamemode=Gamemode.WARFARE),
         Layer(
             id=UNKNOWN_MAP_NAME, map=MAPS[UNKNOWN_MAP_NAME], gamemode=Gamemode.WARFARE
         ),

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -12,6 +12,7 @@ from dateutil import parser
 import rcon.steam_utils
 from rcon.cache_utils import get_redis_client, invalidates, ttl_cache
 from rcon.commands import CommandFailedError, ServerCtl, VipId
+from rcon.maps import UNKNOWN_MAP_NAME, Layer, is_server_loading_map, parse_layer
 from rcon.models import PlayerSteamID, PlayerVIP, enter_session
 from rcon.player_history import (
     add_player_to_blacklist,
@@ -158,6 +159,18 @@ class Rcon(ServerCtl):
             self.pool_size = pool_size
         else:
             self.pool_size = config.thread_pool_size
+
+        self._current_map = parse_layer(UNKNOWN_MAP_NAME)
+
+    @property
+    def current_map(self) -> Layer:
+        """Store the last valid map we've seen, game server reports Untitled_ maps when loading"""
+        return self._current_map
+
+    @current_map.setter
+    def current_map(self, map_name: str):
+        if not is_server_loading_map(map_name):
+            self._current_map = parse_layer(map_name)
 
     @cached_property
     def thread_pool(self):
@@ -809,7 +822,8 @@ class Rcon(ServerCtl):
             raise ValueError("Game server returned junk for get_gamestate")
 
         raw_time_remaining = raw_time_remaining.split("Remaining Time: ")[1]
-        current_map = raw_current_map.split(": ")[1]
+        # Handle Untitled_ style map names when maps are loading
+        self.current_map = raw_current_map.split(": ")[1]
         next_map = raw_next_map.split(": ")[1]
 
         return {
@@ -821,7 +835,8 @@ class Rcon(ServerCtl):
                 hours=float(hours), minutes=float(mins), seconds=float(secs)
             ),
             "raw_time_remaining": raw_time_remaining,
-            "current_map": current_map,
+            # TODO: Update this when we return Layers from the API
+            "current_map": str(self.current_map),
             "next_map": next_map,
         }
 
@@ -873,7 +888,10 @@ class Rcon(ServerCtl):
         if not self.map_regexp.match(current_map):
             raise CommandFailedError("Server returned wrong data")
 
-        return current_map
+        self.current_map = current_map
+
+        # TODO: Update this when we return Layers from the API
+        return str(self.current_map)
 
     @ttl_cache(ttl=60 * 5)
     def get_current_map_sequence(self) -> list[str]:

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,13 +1,16 @@
 import pytest
 
 from rcon.maps import (
+    LAYERS,
     MAPS,
-    Team,
+    UNKNOWN_MAP_NAME,
+    Environment,
     Gamemode,
     Layer,
+    Team,
+    is_server_loading_map,
     numbered_maps,
     parse_layer,
-    Environment,
 )
 
 MOR_WARFARE_DAY = Layer(
@@ -102,6 +105,8 @@ SMDM_SKIRMISH_RAIN = Layer(
     environment=Environment.RAIN,
 )
 
+UNKNOWN_MAP = LAYERS[UNKNOWN_MAP_NAME]
+
 
 @pytest.mark.parametrize(
     "maps, expected",
@@ -116,6 +121,8 @@ def test_numbered_maps(maps, expected):
 @pytest.mark.parametrize(
     "layer_name, expected",
     [
+        ("unknown", UNKNOWN_MAP),
+        ("Untitled_46", UNKNOWN_MAP),
         ("mortain_warfare_day", MOR_WARFARE_DAY),
         ("mortain_warfare_overcast", MOR_WARFARE_OVERCAST),
         ("mortain_offensiveUS_day", MOR_US_OFFENSIVE_DAY),
@@ -132,3 +139,10 @@ def test_numbered_maps(maps, expected):
 )
 def test_parse_layer(layer_name, expected):
     assert parse_layer(layer_name=layer_name) == expected
+
+
+@pytest.mark.parametrize(
+    "map_name, expected", [("Untitled_46", True), ("carentan_warfare", False)]
+)
+def test_is_server_loading_map(map_name, expected):
+    assert is_server_loading_map(map_name=map_name) == expected


### PR DESCRIPTION
* Explicitly add a `Map` and `Layer` for `UNKNOWN_MAP_NAME` lookups
* Explicitly add a `bla_` `Layer` for any users who still have any `bla_` maps recorded from before `v9.8.0`
  * This is probably easier/more robust than trying to run data migrations and update the records in peoples databases
* Update `parse_layer` to return `UNKNOWN_MAP_NAME` which should only happen during the narrow time window when a server is loading a map
* Add a `current_map` to `Rcon` which is used to cache the last real map that CRCON saw because this was breaking `Layer` parsing
  * This is initially set to  `UNKNOWN_MAP_NAME` but is updated anytime `get_gamestate` or `get_map` is called which will automatically update it anytime a match starts
  * This isn't intended to be used directly (it's not exposed through the API but it can be used directly)
  * Updates `get_gamestate` and `get_map` to set `current_map` and return its value

I did some manual testing and it seems like everything is fine, I specifically updated a map to `bla_` to make sure that is working correctly.