### PR TITLE
Fix server list / forwarding

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,7 @@ then
   fi
 
   python -m rcon.user_config.seed_db
+  ./manage.py register_api
   cd rconweb 
   ./manage.py collectstatic --noinput
   # If DONT_SEED_ADMIN_USER is not set to any value

--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -326,6 +326,8 @@ class ApiKey:
         if not REDIS_PARTS["PORT"]:
             raise ValueError("HLL_REDIS_PORT must be set")
 
+        # For the multi server stuff (server discovery, forwarding, etc.)
+        # they must share the same redis database for this, db 0 is unused by default
         self.red = redis.StrictRedis(
             host=REDIS_PARTS["HOST"], port=REDIS_PARTS["PORT"], db=0
         )


### PR DESCRIPTION
I deleted this line when doing the Docker change up and that was a mistake, I misunderstood what it was doing.

This was preventing the server drop down list (when you click the server name in the header in the UI) from working and likely (but I didn't explicitly test it) breaking forwarding requests from one server to another.