### PR TITLE
Fix error in log stream when server is idle

### DIFF
--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -336,9 +336,10 @@ class LogStream:
         """Return a list of logs more recent than the last_seen ID"""
         try:
             if last_seen is None:
-                logs: list[tuple[StreamID, StructuredLogLineWithMetaData]] = [
-                    self.log_stream.tail()
-                ]
+                logs: list[tuple[StreamID, StructuredLogLineWithMetaData]] = []
+                tail_log: tuple[StreamID, StructuredLogLineWithMetaData] = self.log_stream.tail()
+                if tail_log:
+                    logs.append(tail_log)
             else:
                 logs: list[tuple[StreamID, StructuredLogLineWithMetaData]] = (
                     self.log_stream.read(last_id=last_seen, block_ms=block_ms)


### PR DESCRIPTION
Fixes TypeError: cannot unpack non-iterable NoneType object when server has be idle in the log stream. 
The scenario occurs when last_seen is None and the tail returns None

![image](https://github.com/MarechJ/hll_rcon_tool/assets/16978537/4c518430-5433-4b37-a0df-bb1b0ad6a963)
