### PR TITLE
Salvage stats when player reconnects

### DIFF
--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -414,14 +414,20 @@ class LogLoop:
                 steam_id,
                 PlayerStat(
                     combat=player["combat"],
+                    p_combat=0,
                     offense=player["offense"],
+                    p_offense=0,
                     defense=player["defense"],
+                    p_defense=0,
                     support=player["support"],
+                    p_support=0,
                 ),
             )
             for stat in ["combat", "offense", "defense", "support"]:
-                if player[stat] > p[stat]:
-                    p[stat] = player[stat]
+                if player[stat] < p[stat]:
+                    p['p_' + stat] = p['p_' + stat] + p[stat]
+
+                p[stat] = player[stat]
             map_players[steam_id] = p
         maps.update(0, m)
 

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -586,10 +586,10 @@ def current_game_stats():
         if map_stat is None:
             logger.info("No stats for: " + stat["steam_id_64"])
             continue
-        stat["combat"] = map_stat["combat"]
-        stat["offense"] = map_stat["offense"]
-        stat["defense"] = map_stat["defense"]
-        stat["support"] = map_stat["support"]
+        stat["combat"] = map_stat["combat"] + map_stat['p_combat']
+        stat["offense"] = map_stat["offense"] + map_stat['p_offense']
+        stat["defense"] = map_stat["defense"] + map_stat['p_defense']
+        stat["support"] = map_stat["support"] + map_stat['p_support']
     return stats
 
 

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -349,9 +349,13 @@ class PlayerStatsType(TypedDict):
 
 class PlayerStat(TypedDict):
     combat: int
+    p_combat: int
     offense: int
+    p_offense: int
     defense: int
+    p_defense: int
     support: int
+    p_support: int
 
 
 class CachedLiveGameStats(TypedDict):

--- a/rcon/workers.py
+++ b/rcon/workers.py
@@ -167,7 +167,7 @@ def record_stats_from_map(
                     defense=existing.defense,
                     support=existing.support,
                 )
-            map_stats = ps.get(steam_id_64, default_stat)
+            map_stats: PlayerStat = ps.get(steam_id_64, default_stat)
             player_stat = dict(
                 playersteamid_id=player_record.id,
                 map_id=map_.id,
@@ -193,10 +193,10 @@ def record_stats_from_map(
                 most_killed=stats.get("most_killed"),
                 death_by=stats.get("death_by"),
                 death_by_weapons=stats.get("death_by_weapons"),
-                combat=map_stats.get("combat"),
-                offense=map_stats.get("offense"),
-                defense=map_stats.get("defense"),
-                support=map_stats.get("support"),
+                combat=map_stats.get("combat") + map_stats.get("p_combat"),
+                offense=map_stats.get("offense") + map_stats.get('p_offense'),
+                defense=map_stats.get("defense") + map_stats.get('p_defense'),
+                support=map_stats.get("support") + map_stats.get('p_support'),
             )
             if existing is not None and force != True:
                 continue


### PR DESCRIPTION
Previously, when a player disconnects and then reconnects to the server the stats gained in the previous session where lost. The CRCON would always only save the 'higher' stats value to compensate this a bit, which was far from perfect.
With this commit, the CRCON will try to salvage the previously gained stats and combine them after the round ended.