### PR TITLE
Include player ID when kicking, can't retrieve it from the game serve…

### DIFF
--- a/rcon/auto_kick.py
+++ b/rcon/auto_kick.py
@@ -35,7 +35,7 @@ def auto_kick(rcon, struct_log, name, steam_id_64):
 
         if re.match(r, name):
             logger.info("%s matched player %s", r, name)
-            rcon.do_kick(player=name, reason=config.kick_reason, by="NAME_KICK")
+            rcon.do_kick(player=name, reason=config.kick_reason, by="NAME_KICK", steam_id_64=steam_id_64)
             try:
                 webhookurls: list[HttpUrl | None] | None
                 if config.discord_webhook_url is None:

--- a/rcon/automods/automod.py
+++ b/rcon/automods/automod.py
@@ -98,7 +98,7 @@ def _do_punitions(
             if method == ActionMethod.KICK:
                 if not aplayer.details.dry_run:
                     rcon.do_kick(
-                        aplayer.name, aplayer.details.message, by=aplayer.details.author
+                        player=aplayer.name,reason= aplayer.details.message, by=aplayer.details.author, steam_id_64=aplayer.steam_id_64
                     )
                 audit(
                     aplayer.details.discord_audit_url,

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -514,6 +514,7 @@ def windows_store_player_check(rcon: Rcon, _, name: str, player_id: str):
                 name,
                 reason=config.player_message,
                 by=config.audit_message_author,
+                steam_id_64=player_id
             )
         elif action == WindowsStoreIdActionType.temp_ban:
             rcon.do_temp_ban(
@@ -583,6 +584,7 @@ def notify_invalid_names(rcon: Rcon, _, name: str, steam_id_64: str):
                     name,
                     reason=config.whitespace_name_player_message,
                     by=config.audit_message_author,
+                    steam_id_64=steam_id_64
                 )
             except Exception as e:
                 logger.error(


### PR DESCRIPTION
Resolves #572 

The `kick` command can only be performed by player name and not player ID (steam/windows), but the `save_player_action` tries to poll the game server for the steam ID when it isn't provided.

Explicitly pass the player ID in even though it's being done by player name so the save action won't fail.

Tested this with both an automod (seeding with a restricted role) and a manual kick and it seems to work just fine.