### PR TITLE
Properly compress frontend assets

### DIFF
--- a/rcongui/nginx.conf
+++ b/rcongui/nginx.conf
@@ -48,61 +48,65 @@ server {
         index index.html index.htm index.nginx-debian.html;
 
         server_name _;
-	#auth_basic           "Admin Login";
+        #auth_basic           "Admin Login";
         #auth_basic_user_file /pw/.htpasswd;
 
         gzip on;
-        gzip_types text/plain application/xml text/html application/json text/javascript; 
-        location / {
+        gzip_buffers 16 8k;
+        gzip_comp_level 6;
+        gzip_proxied any;
+        gzip_vary on;
+        gzip_types text/plain text/css image/svg+xml application/xml text/html application/json text/javascript application/javascript;
 
-                # First attempt to serve request as file, then
-                # as directory, then fall back to displaying a 404.
-                try_files $uri /index.html;
-                add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=6000';
-                if_modified_since off;
-                expires off;
-                etag off;
+        location / {
+            # First attempt to serve request as file, then
+            # as directory, then fall back to displaying a 404.
+            try_files $uri /index.html;
+            add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=6000';
+            if_modified_since off;
+            expires off;
+            etag off;
         }
 
         location /api/upload_vips {
-	  proxy_pass http://backend:8000/api/upload_vips;
-          proxy_read_timeout 600s;
-	}
+            proxy_pass http://backend:8000/api/upload_vips;
+            proxy_read_timeout 600s;
+        }
 
-	location /api {
-          proxy_set_header Forwarded $proxy_add_forwarded;
-          proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
-          proxy_pass http://backend:8000/api;
-	}
+        location /api {
+            proxy_set_header Forwarded $proxy_add_forwarded;
+            proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+            proxy_pass http://backend:8000/api;
+        }
 
-	location /djangostatic {
+        location /djangostatic {
             alias /static;
             autoindex off;
-	}
+        }
 
-	location /admin {
-          proxy_set_header Forwarded $proxy_add_forwarded;
-          proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
-          proxy_pass http://backend:8000/admin;
-	}
+        location /admin {
+            proxy_set_header Forwarded $proxy_add_forwarded;
+            proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+            proxy_pass http://backend:8000/admin;
+        }
 
         location /api/scoreboard {
-           auth_basic "off";
-           proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
-           proxy_set_header Forwarded $proxy_add_forwarded;
-	   proxy_pass http://backend:8000/api/scoreboard;
-	}
+            auth_basic "off";
+            proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+            proxy_set_header Forwarded $proxy_add_forwarded;
+            proxy_pass http://backend:8000/api/scoreboard;
+        }
 
         location /ws {
-                proxy_pass http://backend:8001;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection "upgrade";
-                proxy_redirect off;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
-                proxy_set_header Forwarded $proxy_add_forwarded;
-                proxy_set_header X-Forwarded-Host $server_name;
+            proxy_pass http://backend:8001;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_redirect off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+            proxy_set_header Forwarded $proxy_add_forwarded;
+            proxy_set_header X-Forwarded-Host $server_name;
         }
 }
 
@@ -137,29 +141,33 @@ server {
         index index.html index.htm index.nginx-debian.html;
 
         server_name _;
-	#auth_basic           "Admin Login";
+        #auth_basic           "Admin Login";
         #auth_basic_user_file /pw/.htpasswd;
 
         gzip on;
-        gzip_types text/plain application/xml text/html application/json text/javascript; 
-        location / {
+        gzip_buffers 16 8k;
+        gzip_comp_level 6;
+        gzip_proxied any;
+        gzip_vary on;
+        gzip_types text/plain text/css image/svg+xml application/xml text/html application/json text/javascript application/javascript;
 
-                # First attempt to serve request as file, then
-                # as directory, then fall back to displaying a 404.
-                try_files $uri /index.html;
-                add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=6000';
-                if_modified_since off;
-                expires off;
-                etag off;
+        location / {
+            # First attempt to serve request as file, then
+            # as directory, then fall back to displaying a 404.
+            try_files $uri /index.html;
+            add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=6000';
+            if_modified_since off;
+            expires off;
+            etag off;
         }
 
-	location /api {
-          if_modified_since off;
-          expires off;
-          etag off;
-          add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-          proxy_set_header Forwarded $proxy_add_forwarded;
-          proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
-          proxy_pass http://backend:8000/api;
-	}
+        location /api {
+            if_modified_since off;
+            expires off;
+            etag off;
+            add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+            proxy_set_header Forwarded $proxy_add_forwarded;
+            proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+            proxy_pass http://backend:8000/api;
+        }
 }


### PR DESCRIPTION
Before this commit, the "biggest" asset of the frontend, the javascript, was not compressed, even though compression was enabled. Enabling compression for the actually used javascript mime type variant reduces the initial payload that nneeds to transferred from 3.7 MB to "just" 1 MB.

Note: Sorry for the indentation changes in the diff :(