### PR TITLE
Update multi_servers.py

### DIFF
--- a/rconweb/api/multi_servers.py
+++ b/rconweb/api/multi_servers.py
@@ -25,6 +25,9 @@ def get_server_list(request):
     keys = api_key.get_all_keys()
     my_key = api_key.get_key()
 
+    auth_header: str | None = request.headers.get(AUTHORIZATION)
+    headers = {"AUTHORIZATION": auth_header} if auth_header else {}
+    
     logger.debug(keys)
     names = []
     for host, key in keys.items():
@@ -35,6 +38,7 @@ def get_server_list(request):
                 f"http://{host}/api/get_connection_info",
                 timeout=5,
                 cookies=dict(sessionid=request.COOKIES.get("sessionid")),
+                headers=headers,
             )
             if res.ok:
                 names.append(res.json()["result"])


### PR DESCRIPTION
Allow the `server_list` endpoint to return results when called with an API key.

Tested this on our server to verify that it works, we just weren't passing the headers so if it was called through a browser (with a `sessionid` cookie it would work properly), but not with an API key