### PR TITLE
Bugfix: Check if API Key is used and valid

### DIFF
--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -248,7 +248,7 @@ def stats_login_required(func):
 
     @wraps(func)
     def wrapper(request, *args, **kwargs):
-        request = check_api_key(request)
+        check_api_key(request)
 
 
         if not request.user.is_authenticated:

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -275,6 +275,7 @@ def stats_login_required(func):
 
     @wraps(func)
     def wrapper(request, *args, **kwargs):
+        # Check if API-Key is used
         check_api_key(request)
 
 

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -195,6 +195,33 @@ def do_logout(request):
     return api_response(result=True, command="logout", failed=False)
 
 
+def check_api_key(request):
+    # Extract the header and bearer key if present, otherwise fall back on
+    # requiring the user to be logged in
+    try:
+        header_name, raw_api_key = request.META[
+            HTTP_AUTHORIZATION_HEADER
+        ].split(maxsplit=1)
+        if not header_name.upper().strip() in BEARER:
+            raw_api_key = None
+    except (KeyError, ValueError):
+        raw_api_key = None
+
+    try:
+        # If we don't include the salt, the hasher generates its own
+        # and it will generate different hashed values every time
+        hashed_api_key = make_password(
+            raw_api_key, salt=SECRET_KEY.replace("$", "")
+        )
+        api_key_model = DjangoAPIKey.objects.get(api_key=hashed_api_key)
+
+        # Retrieve the user to use the normal authentication system
+        # to include their permissions
+        request.user = api_key_model.user
+    except DjangoAPIKey.DoesNotExist:
+        pass
+
+
 def login_required():
     """Flag this endpoint as one that requires the user
     to be logged in.
@@ -316,29 +343,3 @@ def get_own_user_permissions(request):
         failed=False,
     )
 
-
-def check_api_key(request):
-    # Extract the header and bearer key if present, otherwise fall back on
-    # requiring the user to be logged in
-    try:
-        header_name, raw_api_key = request.META[
-            HTTP_AUTHORIZATION_HEADER
-        ].split(maxsplit=1)
-        if not header_name.upper().strip() in BEARER:
-            raw_api_key = None
-    except (KeyError, ValueError):
-        raw_api_key = None
-
-    try:
-        # If we don't include the salt, the hasher generates its own
-        # and it will generate different hashed values every time
-        hashed_api_key = make_password(
-            raw_api_key, salt=SECRET_KEY.replace("$", "")
-        )
-        api_key_model = DjangoAPIKey.objects.get(api_key=hashed_api_key)
-
-        # Retrieve the user to use the normal authentication system
-        # to include their permissions
-        request.user = api_key_model.user
-    except DjangoAPIKey.DoesNotExist:
-        pass

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -270,6 +270,30 @@ def stats_login_required(func):
 
     @wraps(func)
     def wrapper(request, *args, **kwargs):
+        try:
+            header_name, raw_api_key = request.META[
+                HTTP_AUTHORIZATION_HEADER
+            ].split(maxsplit=1)
+            if not header_name.upper().strip() in BEARER:
+                raw_api_key = None
+        except (KeyError, ValueError):
+            raw_api_key = None
+
+        try:
+            # If we don't include the salt, the hasher generates its own
+            # and it will generate different hashed values every time
+            hashed_api_key = make_password(
+                raw_api_key, salt=SECRET_KEY.replace("$", "")
+            )
+            api_key_model = DjangoAPIKey.objects.get(api_key=hashed_api_key)
+
+            # Retrieve the user to use the normal authentication system
+            # to include their permissions
+            request.user = api_key_model.user
+        except DjangoAPIKey.DoesNotExist:
+            pass
+
+
         if not request.user.is_authenticated:
             return api_response(
                 command=request.path,


### PR DESCRIPTION
Hello,
currently the CRCON does not check when using the Stats API if an API key is used and the API is locked for the public in the CRCON settings.
This leads to "You must be logged in to use this" errors.

This PR introduces that the API key is also checked. I have used the source code of "login_required" for this. 
Is it perhaps smarter to outsource the code to an extra function? But because of two occurrences a separate function seemed a bit stupid to me.

I am open to feedback!

Thank you for this amazing software!