### PR TITLE
Create build-docker-images-manual-tag-only,yml

### DIFF
--- a/.github/workflows/build-docker-images-manual-tag-only,yml
+++ b/.github/workflows/build-docker-images-manual-tag-only,yml
@@ -1,0 +1,54 @@
+name: build-docker-images-manual-tag-only
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Choose a tag"
+        required: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cericmathey/hll_rcon_tool:${{ github.event.inputs.tag }}
+      - name: Build and push frontend
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile-frontend
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cericmathey/hll_rcon_tool_frontend:${{ github.event.inputs.tag }}
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool_frontend


### PR DESCRIPTION
Does not replace the `latest` image on Docker Hub, otherwise identical to the other manual build workflow.