### PR TITLE
Fix typo: Change "commmand" to "command

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -1489,6 +1489,20 @@ class Rcon(ServerCtl):
             time = Rcon._extract_time(raw_timestamp)
             try:
                 log_line = Rcon.parse_log_line(raw_log_line)
+                
+                if filter_action and not log_line["action"].startswith(filter_action):
+                    continue
+    
+                if filter_player and filter_player not in raw_log_line:
+                    continue
+    
+                if player := log_line["player_name_1"]:
+                    players.add(player)
+    
+                if player2 := log_line["player_name_2"]:
+                    players.add(player2)
+    
+                actions.add(log_line["action"])
                 parsed_log_lines.append(
                     {
                         "version": 1,
@@ -1512,20 +1526,6 @@ class Rcon(ServerCtl):
                     f"Unable to parse line: '{raw_relative_time} {raw_timestamp} {raw_log_line}'"
                 )
                 continue
-
-            if filter_action and not log_line["action"].startswith(filter_action):
-                continue
-
-            if filter_player and filter_player not in raw_log_line:
-                continue
-
-            if player := log_line["player_name_1"]:
-                players.add(player)
-
-            if player2 := log_line["player_name_2"]:
-                players.add(player2)
-
-            actions.add(log_line["action"])
 
         parsed_log_lines.reverse()
 

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -1489,20 +1489,6 @@ class Rcon(ServerCtl):
             time = Rcon._extract_time(raw_timestamp)
             try:
                 log_line = Rcon.parse_log_line(raw_log_line)
-                
-                if filter_action and not log_line["action"].startswith(filter_action):
-                    continue
-    
-                if filter_player and filter_player not in raw_log_line:
-                    continue
-    
-                if player := log_line["player_name_1"]:
-                    players.add(player)
-    
-                if player2 := log_line["player_name_2"]:
-                    players.add(player2)
-    
-                actions.add(log_line["action"])
                 parsed_log_lines.append(
                     {
                         "version": 1,
@@ -1526,6 +1512,20 @@ class Rcon(ServerCtl):
                     f"Unable to parse line: '{raw_relative_time} {raw_timestamp} {raw_log_line}'"
                 )
                 continue
+
+            if filter_action and not log_line["action"].startswith(filter_action):
+                continue
+
+            if filter_player and filter_player not in raw_log_line:
+                continue
+
+            if player := log_line["player_name_1"]:
+                players.add(player)
+
+            if player2 := log_line["player_name_2"]:
+                players.add(player2)
+
+            actions.add(log_line["action"])
 
         parsed_log_lines.reverse()
 

--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -451,7 +451,7 @@ def parse_raw_player_info(raw: str, player) -> GetDetailedPlayer:
     data[PLAYER_ID] = raw_data.get("steamid64")  # type: ignore
     data["team"] = raw_data.get("team", "None")
     if raw_data["role"].lower() == "armycommander":
-        data["unit_id"], data["unit_name"] = (-1, "Commmand")
+        data["unit_id"], data["unit_name"] = (-1, "Command")
     else:
         data["unit_id"], data["unit_name"] = (
             raw_data.get("unit").split(" - ")  # type: ignore


### PR DESCRIPTION
Hey, 
I found a typo in the API :(
The role "commmand" should be "command".
If you/we already do breaking changes, we should fix that too.

Thank you for looking into it!