### PR TITLE
Bugfix: Apply filters before adding to result

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -1498,6 +1498,17 @@ class Rcon(ServerCtl):
             time = Rcon._extract_time(raw_timestamp)
             try:
                 log_line = Rcon.parse_log_line(raw_log_line)
+                if filter_action and not log_line["action"].startswith(filter_action):
+                    continue
+    
+                if filter_player and filter_player not in raw_log_line:
+                    continue
+    
+                if player := log_line["player"]:
+                    players.add(player)
+    
+                if player2 := log_line["player2"]:
+                    players.add(player2)
                 parsed_log_lines.append(
                     {
                         "version": 1,
@@ -1520,18 +1531,6 @@ class Rcon(ServerCtl):
                     f"Unable to parse line: '{raw_relative_time} {raw_timestamp} {raw_log_line}'"
                 )
                 continue
-
-            if filter_action and not log_line["action"].startswith(filter_action):
-                continue
-
-            if filter_player and filter_player not in raw_log_line:
-                continue
-
-            if player := log_line["player"]:
-                players.add(player)
-
-            if player2 := log_line["player2"]:
-                players.add(player2)
 
             actions.add(log_line["action"])
 


### PR DESCRIPTION
Hello!

I discovered the following bug:
Currently the filters in the "get_structued_logs" does not get applied, because the filter is applied after coping the line in the result. This PR patches that.

Thank you!