### PR TITLE
Set blacklists to an empty list on initialization

### DIFF
--- a/rcongui/src/components/PlayersHistory/index.js
+++ b/rcongui/src/components/PlayersHistory/index.js
@@ -170,7 +170,7 @@ class PlayersHistory extends React.Component {
       flags: "",
       country: "",
       bans: new Map(),
-      blacklists: undefined,
+      blacklists: [],
       blacklistDialogOpen: false,
       blacklistDialogInitialValues: undefined,
     };


### PR DESCRIPTION
* Use an empty array for the default value instead of `undefined` to allow the player history page to load correctly