### PR TITLE
Hotfix/player history vip

### DIFF
--- a/rcongui/src/components/PlayersHistory/index.js
+++ b/rcongui/src/components/PlayersHistory/index.js
@@ -711,6 +711,7 @@ class PlayersHistory extends React.Component {
         />
         <VipExpirationDialog
           open={doVIPPlayer}
+          player={doVIPPlayer}
           vips={vips}
           onDeleteVip={this.onDeleteVip}
           handleClose={() => this.setDoVIPPlayer(false)}

--- a/rcongui/src/components/SettingsView/vips.js
+++ b/rcongui/src/components/SettingsView/vips.js
@@ -248,6 +248,7 @@ const VipEditableList = ({
         <ForwardCheckBox bool={forward} onChange={onFowardChange} />
         <VipExpirationDialog
           open={VIPPlayer}
+          player={VIPPlayer}
           vips={vipListFromServer(peopleList)}
           onDeleteVip={(playerObj) =>
             onDelete(nameOf(playerObj), playerObj.get("player_id"))


### PR DESCRIPTION
I'm sure there is a better way to do this, but as a quick fix this lets the new VIP dialog work on both the history and settings page.

Tested both, not extensively but the dialog boxes open and I was able to give myself VIP