### PR TITLE
Hotfix: 500 Server Error on get_api_documentation

### DIFF
--- a/rconweb/api/user_settings.py
+++ b/rconweb/api/user_settings.py
@@ -443,6 +443,7 @@ def describe_chat_commands_config(request):
 
 @csrf_exempt
 @login_required()
+@require_http_methods(["GET"])
 def describe_log_stream_config(request):
     command_name = "describe_log_stream_config"
 


### PR DESCRIPTION
Added required http methods to describe_chat_commands_config to prevent 500 Server Error