### PR TITLE
Hotfix/player history

### DIFF
--- a/rcongui/src/components/PlayersHistory/index.js
+++ b/rcongui/src/components/PlayersHistory/index.js
@@ -170,7 +170,7 @@ class PlayersHistory extends React.Component {
       flags: "",
       country: "",
       bans: new Map(),
-      blacklists: undefined,
+      blacklists: [],
       blacklistDialogOpen: false,
       blacklistDialogInitialValues: undefined,
     };

--- a/rcongui/src/components/PlayersHistory/index.js
+++ b/rcongui/src/components/PlayersHistory/index.js
@@ -523,7 +523,7 @@ class PlayersHistory extends React.Component {
         playerId: player.get("player_id")
       }
     });
-    if (!this.state.blacklists) {
+    if (!this.state.blacklists.length) {
       this.loadBlacklists()
     }
   }


### PR DESCRIPTION
* Load the blacklists on the history page so the dialog box will work, I induced this bug when changing the behavior of the blacklists initial state from `undefined` to an empty array.