### PR TITLE
Update seeding_rules.py

### DIFF
--- a/rcon/automods/seeding_rules.py
+++ b/rcon/automods/seeding_rules.py
@@ -97,9 +97,12 @@ class SeedingRulesAutomod:
 
         disallowed_roles = set(self.config.disallowed_roles.roles.values())
         disallowed_weapons = set(self.config.disallowed_weapons.weapons.values())
+        enforce_cap_fight_maxplayers = self.config.enforce_cap_fight.max_players
 
         if self.config.announcement_enabled and (
-            len(disallowed_roles) != 0 or len(disallowed_weapons) != 0
+            len(disallowed_roles) != 0
+            or len(disallowed_weapons) != 0
+            or enforce_cap_fight_maxplayers != 0
         ):
             if all([self._is_seeding_rule_disabled(r) for r in SEEDING_RULE_NAMES]):
                 return p
@@ -115,7 +118,7 @@ class SeedingRulesAutomod:
                 message = message.format(**data)
             except KeyError:
                 self.logger.warning(
-                    "The automod message for disallowed weapons (%s) contains an invalid key",
+                    "The automod message contains an invalid key for disallowed_roles and/or disallowed_weapons (%s)",
                     message,
                 )
 

--- a/rcongui/src/components/UserSettings/autoMods.js
+++ b/rcongui/src/components/UserSettings/autoMods.js
@@ -769,6 +769,7 @@ export const SeedingAutoMod = ({
                     The number is exclusive.
                     ie : if you use 30, this rule will be enforced for players 1 to 29,
                     once the 30th player has connected, this rule will NOT be enforced anymore.
+                    - set to 0 to disable
                 */
                 "max_players": 100,
 


### PR DESCRIPTION
Announcement message was only sent if there was either at least one `forbidden_roles` or one `forbidden weapons` set in config.
People only enabling the `enforce_cap_fight` rule and leaving `forbidden` parts empty didn't get any announcement message on their server.

This now watches for the `enforce_cap_fight.max_players` value in config, enabling the announcement if it's > 0.