### PR TITLE
Update PlayerInfo.js

### DIFF
--- a/rcongui/src/components/PlayerInfo/PlayerInfo.js
+++ b/rcongui/src/components/PlayerInfo/PlayerInfo.js
@@ -63,7 +63,7 @@ const NamePopOver = ({ names }) => {
   return (
     <Grid item>
       <Button endIcon={<ExpandMore />} onClick={handleClick}>
-        <Typography variant="h3">{names[0].name}</Typography>
+        <Typography variant="h3">{names.length ? names[0].name : "Player has no recorded names"}</Typography>
       </Button>
       <Popover
         id={id}


### PR DESCRIPTION
The detailed player view will crash when a player has no names but has a profile that exists.

When you create a blacklist record for a player who has never joined their record will be created without a name.