### PR TITLE
Hotfix/blacklist penalty count

### DIFF
--- a/rcon/blacklist.py
+++ b/rcon/blacklist.py
@@ -611,7 +611,7 @@ def edit_record_from_blacklist(
             update_penalty_count(
                 player_id=record.player.player_id,
                 player_names=player_names,
-                action=PlayerActionState.TEMPBAN,
+                action=PlayerActionState.PERMABAN,
                 admin_name=new_record["admin_name"],
             )
         # perma ban -> temp ban
@@ -619,7 +619,7 @@ def edit_record_from_blacklist(
             update_penalty_count(
                 player_id=record.player.player_id,
                 player_names=player_names,
-                action=PlayerActionState.PERMABAN,
+                action=PlayerActionState.TEMPBAN,
                 admin_name=new_record["admin_name"],
             )
 

--- a/rcon/blacklist.py
+++ b/rcon/blacklist.py
@@ -606,6 +606,7 @@ def edit_record_from_blacklist(
                 )
             )
 
+        current_time = datetime.now(tz=timezone.utc)
         # temp ban -> perma ban
         if old_record["expires_at"] and not new_record["expires_at"]:
             update_penalty_count(
@@ -614,8 +615,24 @@ def edit_record_from_blacklist(
                 action=PlayerActionState.PERMABAN,
                 admin_name=new_record["admin_name"],
             )
-        # perma ban -> temp ban
-        elif not old_record["expires_at"] and new_record["expires_at"]:
+        # perma ban -> temp ban that isn't already expired
+        elif (
+            not old_record["expires_at"]
+            and new_record["expires_at"]
+            and new_record["expires_at"] > current_time
+        ):
+            update_penalty_count(
+                player_id=record.player.player_id,
+                player_names=player_names,
+                action=PlayerActionState.TEMPBAN,
+                admin_name=new_record["admin_name"],
+            )
+        # temp ban -> different duration temp ban that isn't already expired
+        elif (
+            old_record["expires_at"]
+            and new_record["expires_at"]
+            and new_record["expires_at"] > current_time
+        ):
             update_penalty_count(
                 player_id=record.player.player_id,
                 player_names=player_names,

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -8,14 +8,14 @@ from typing import Final
 
 from discord_webhook import DiscordEmbed
 
+import rcon.steam_utils as steam_utils
+from discord.utils import escape_markdown
 from rcon.blacklist import (
     apply_blacklist_punishment,
     blacklist_or_ban,
     is_player_blacklisted,
     synchronize_ban,
 )
-import rcon.steam_utils as steam_utils
-from discord.utils import escape_markdown
 from rcon.cache_utils import invalidates
 from rcon.commands import CommandFailedError, HLLServerError
 from rcon.discord import (
@@ -37,7 +37,6 @@ from rcon.models import enter_session
 from rcon.player_history import (
     _get_set_player,
     get_player,
-    safe_save_player_action,
     save_end_player_session,
     save_player,
     save_start_player_session,

--- a/rcon/models.py
+++ b/rcon/models.py
@@ -143,8 +143,12 @@ class PlayerID(Base):
     def get_penalty_count(self) -> PenaltyCountType:
         counts = defaultdict(int)
         for action in self.received_actions:
-            if PlayerActionState[action.action_type] in PlayerActionState:
-                counts[PlayerActionState[action.action_type]] += 1
+
+            try:
+                action = PlayerActionState[action.action_type]
+                counts[action] += 1
+            except KeyError:
+                continue
 
         return {
             PlayerActionState.KICK.name: counts[PlayerActionState.KICK],

--- a/rcon/models.py
+++ b/rcon/models.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Generator, List, Literal, Optional, Sequence, overload
@@ -32,6 +33,7 @@ from rcon.types import (
     DBLogLineType,
     MapsType,
     PenaltyCountType,
+    PlayerActionState,
     PlayerActionType,
     PlayerAtCountType,
     PlayerCommentType,
@@ -139,13 +141,17 @@ class PlayerID(Base):
         )
 
     def get_penalty_count(self) -> PenaltyCountType:
-        penalities_type = {"KICK", "PUNISH", "TEMPBAN", "PERMABAN"}
-        counts: PenaltyCountType = {"KICK": 0, "PUNISH": 0, "TEMPBAN": 0, "PERMABAN": 0}
+        counts = defaultdict(int)
         for action in self.received_actions:
-            if action.action_type in penalities_type:
-                counts[action.action_type] += 1
+            if PlayerActionState[action.action_type] in PlayerActionState:
+                counts[PlayerActionState[action.action_type]] += 1
 
-        return counts
+        return {
+            PlayerActionState.KICK.name: counts[PlayerActionState.KICK],
+            PlayerActionState.PUNISH.name: counts[PlayerActionState.PUNISH],
+            PlayerActionState.TEMPBAN.name: counts[PlayerActionState.TEMPBAN],
+            PlayerActionState.PERMABAN.name: counts[PlayerActionState.PERMABAN],
+        }
 
     def get_total_playtime_seconds(self) -> int:
         total = 0

--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -505,10 +505,10 @@ def remove_flag(
     return player, old_flag
 
 
-def get_player_messages(player_id: str) -> list[PlayerActionState]:
+def get_player_messages(player_id: str) -> list[PlayerActionType]:
     with enter_session() as sess:
         player = sess.query(PlayerID).filter_by(player_id=player_id).one_or_none()
-        actions: list[PlayerActionState] = []
+        actions: list[PlayerActionType] = []
         if player:
             actions = [
                 action.to_dict()

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -1133,7 +1133,7 @@ class Rcon(ServerCtl):
         safe_save_player_action(
             rcon=self,
             player_name=player_name,
-            action_type=PlayerActionState.MESSAGE,
+            action_type=PlayerActionState.PUNISH,
             reason=reason,
             by=by,
         )

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -15,11 +15,7 @@ from rcon.cache_utils import get_redis_client, invalidates, ttl_cache
 from rcon.commands import SUCCESS, CommandFailedError, ServerCtl, VipId
 from rcon.maps import UNKNOWN_MAP_NAME, Layer, is_server_loading_map, parse_layer
 from rcon.models import PlayerID, PlayerVIP, enter_session
-from rcon.player_history import (
-    get_profiles,
-    safe_save_player_action,
-    save_player,
-)
+from rcon.player_history import get_profiles, safe_save_player_action, save_player
 from rcon.settings import SERVER_INFO
 from rcon.types import (
     AdminType,
@@ -29,6 +25,7 @@ from rcon.types import (
     GetDetailedPlayers,
     GetPlayersType,
     ParsedLogsType,
+    PlayerActionState,
     ServerInfoType,
     SlotsType,
     StatusType,
@@ -741,7 +738,7 @@ class Rcon(ServerCtl):
             safe_save_player_action(
                 rcon=self,
                 player_name=player_name,
-                action_type="MESSAGE",
+                action_type=PlayerActionState.MESSAGE,
                 reason=message,
                 by=by,
                 player_id=player_id,
@@ -1136,7 +1133,7 @@ class Rcon(ServerCtl):
         safe_save_player_action(
             rcon=self,
             player_name=player_name,
-            action_type="PUNISH",
+            action_type=PlayerActionState.MESSAGE,
             reason=reason,
             by=by,
         )
@@ -1155,7 +1152,7 @@ class Rcon(ServerCtl):
         safe_save_player_action(
             rcon=self,
             player_name=player_name,
-            action_type="KICK",
+            action_type=PlayerActionState.KICK,
             reason=reason,
             by=by,
             player_id=player_id,
@@ -1182,7 +1179,7 @@ class Rcon(ServerCtl):
             safe_save_player_action(
                 rcon=self,
                 player_name=player_name,
-                action_type="TEMPBAN",
+                action_type=PlayerActionState.TEMPBAN,
                 reason=reason,
                 by=by,
                 player_id=player_id,
@@ -1212,7 +1209,7 @@ class Rcon(ServerCtl):
             safe_save_player_action(
                 rcon=self,
                 player_name=player_name,
-                action_type="PERMABAN",
+                action_type=PlayerActionState.PERMABAN,
                 reason=reason,
                 by=by,
                 player_id=player_id,

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -479,6 +479,14 @@ class AuditLogType(TypedDict):
     command_result: Optional[str]
 
 
+class PlayerActionState(enum.Enum):
+    KICK = 0
+    PUNISH = 1
+    TEMPBAN = 2
+    PERMABAN = 3
+    MESSAGE = 4
+
+
 class PenaltyCountType(TypedDict):
     KICK: int
     PUNISH: int

--- a/rcongui/src/components/Blacklist/BlacklistRecordCreateDialog.js
+++ b/rcongui/src/components/Blacklist/BlacklistRecordCreateDialog.js
@@ -1,15 +1,23 @@
-import * as React from 'react';
-import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import { FormControl, Grid, InputLabel, makeStyles, MenuItem, Select, Typography } from '@material-ui/core';
+import * as React from "react";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  makeStyles,
+  MenuItem,
+  Select,
+  Typography,
+} from "@material-ui/core";
 import moment from "moment";
-import { getServerStatus, getSharedMessages } from '../../utils/fetchUtils';
-import TextHistory from '../textHistory';
+import { getServerStatus, getSharedMessages } from "../../utils/fetchUtils";
+import TextHistory from "../textHistory";
 
 const ONE_HOUR = 60 * 60;
 const ONE_DAY = ONE_HOUR * 24;
@@ -25,11 +33,11 @@ const presetTimes = [
   { label: "14 days", value: ONE_DAY * 14 },
   { label: "30 days", value: ONE_DAY * 30 },
   { label: "365 days", value: ONE_DAY * 365 },
-  { label: "Never", value: null }
+  { label: "Never", value: null },
 ];
 
 function BlacklistServerWarning({ blacklist, currentServer }) {
-  const affectsAllServers = blacklist.servers === null
+  const affectsAllServers = blacklist.servers === null;
 
   if (affectsAllServers) {
     return null;
@@ -38,24 +46,28 @@ function BlacklistServerWarning({ blacklist, currentServer }) {
   let text = "";
   const affectsNone = blacklist.servers.length === 0;
   const failedToLoadCurrentServer = !("server_number" in currentServer);
-  const affectsOnlyOtherServers = blacklist.servers.length > 0 && !blacklist.servers.includes(currentServer?.server_number ?? -1)
+  const affectsOnlyOtherServers =
+    blacklist.servers.length > 0 &&
+    !blacklist.servers.includes(currentServer?.server_number ?? -1);
 
   if (affectsNone) {
-    text = "This blacklist does not affect any servers!"
-  }
-  else if (failedToLoadCurrentServer) {
-    text = `Failed to load current server information!\n`
-    text += `This blacklist MAY NOT affect THIS server. Affected servers: [${blacklist.servers.join(", ")}]`
-  }
-  else if (affectsOnlyOtherServers) {
-    text = `This blacklist DOES NOT affect THIS server! Affected servers: [${blacklist.servers.join(", ")}]`
+    text = "This blacklist does not affect any servers!";
+  } else if (failedToLoadCurrentServer) {
+    text = `Failed to load current server information!\n`;
+    text += `This blacklist MAY NOT affect THIS server. Affected servers: [${blacklist.servers.join(
+      ", "
+    )}]`;
+  } else if (affectsOnlyOtherServers) {
+    text = `This blacklist DOES NOT affect THIS server! Affected servers: [${blacklist.servers.join(
+      ", "
+    )}]`;
   }
 
   return (
     <Typography variant="caption" color="secondary">
       {text}
     </Typography>
-  )
+  );
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -79,57 +91,60 @@ export default function BlacklistRecordCreateDialog({
   const [playerId, setPlayerId] = React.useState("");
   const [expiresAt, setExpiresAt] = React.useState("");
   const [reason, setReason] = React.useState("");
-  const [currentServer, setCurrentServer] = React.useState({})
-  const [punishMessages, setPunishMessages] = React.useState([])
-  const [selectedMessage, setSelectedMessage] = React.useState("")
+  const [currentServer, setCurrentServer] = React.useState({});
+  const [punishMessages, setPunishMessages] = React.useState([]);
+  const [selectedMessage, setSelectedMessage] = React.useState("");
   const classes = useStyles();
 
   const handlePunishMessageChange = (event) => {
-    setSelectedMessage(event.target.value ?? "")
+    setSelectedMessage(event.target.value ?? "");
     setReason(punishMessages[event.target.value] ?? "");
   };
 
   React.useEffect(() => {
     if (open) {
-      const messageType = "punishments"
-      getServerStatus().then(server => setCurrentServer(server)).catch(() => setCurrentServer({}))
-      getSharedMessages(messageType).then(sharedMessages => {
+      const messageType = "punishments";
+      getServerStatus()
+        .then((server) => setCurrentServer(server))
+        .catch(() => setCurrentServer({}));
+      getSharedMessages(messageType).then((sharedMessages) => {
         const locallyStoredMessages = new TextHistory(messageType).getTexts();
-        setPunishMessages(sharedMessages.concat(locallyStoredMessages))
-      })
+        setPunishMessages(sharedMessages.concat(locallyStoredMessages));
+      });
     }
-  }, [open])
+  }, [open]);
 
   React.useEffect(() => {
     if (initialValues) {
       if (initialValues.blacklistId !== undefined) {
-        const blacklist = blacklists?.find((b) => b.id === initialValues.blacklistId);
+        const blacklist = blacklists?.find(
+          (b) => b.id === initialValues.blacklistId
+        );
         if (blacklist) setBlacklist(blacklist);
-      };
-      if (initialValues.playerId !== undefined) setPlayerId(initialValues.playerId);
+      }
+      if (initialValues.playerId !== undefined)
+        setPlayerId(initialValues.playerId);
       if (initialValues.expiresAt !== undefined) {
         setExpiresAt(
-          initialValues.expiresAt === null
-            ? ""
-            : initialValues.expiresAt
+          initialValues.expiresAt === null ? "" : initialValues.expiresAt
         );
       }
       if (initialValues.reason !== undefined) setReason(initialValues.reason);
     }
-  }, [open])
+  }, [open]);
 
   React.useEffect(() => {
     if (blacklists.length == 1) {
-      setBlacklist(blacklists[0])
+      setBlacklist(blacklists[0]);
     }
-  })
+  });
 
   const handleClose = () => {
     setOpen(false);
-    setBlacklist("")
-    setPlayerId("")
-    setExpiresAt("")
-    setReason("")
+    setBlacklist("");
+    setPlayerId("");
+    setExpiresAt("");
+    setReason("");
   };
 
   return (
@@ -137,17 +152,18 @@ export default function BlacklistRecordCreateDialog({
       open={open}
       onClose={handleClose}
       PaperProps={{
-        component: 'form',
+        component: "form",
         onSubmit: (event) => {
           event.preventDefault();
           const data = {
             blacklistId: blacklist.id,
             playerId,
-            expiresAt: expiresAt === "" ? null : expiresAt,
-            reason
-          }
+            expiresAt:
+              expiresAt === "" ? null : moment(expiresAt).utc().toISOString(),
+            reason,
+          };
           onSubmit(data);
-          setSelectedMessage("")
+          setSelectedMessage("");
           handleClose();
         },
       }}
@@ -155,7 +171,8 @@ export default function BlacklistRecordCreateDialog({
       <DialogTitle>{titleText}</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          By blacklisting a player you are revoking their access to one or more servers.
+          By blacklisting a player you are revoking their access to one or more
+          servers.
         </DialogContentText>
 
         <FormControl required fullWidth>
@@ -164,15 +181,20 @@ export default function BlacklistRecordCreateDialog({
             value={blacklist}
             onChange={(e) => setBlacklist(e.target.value)}
           >
-            {blacklists?.map(
-              (b) => <MenuItem key={b.id} value={b}>{b.name}</MenuItem>
-            )}
+            {blacklists?.map((b) => (
+              <MenuItem key={b.id} value={b}>
+                {b.name}
+              </MenuItem>
+            ))}
           </Select>
         </FormControl>
 
         {blacklist && (
           <React.Fragment>
-            <BlacklistServerWarning blacklist={blacklist} currentServer={currentServer} />
+            <BlacklistServerWarning
+              blacklist={blacklist}
+              currentServer={currentServer}
+            />
             {/* PLAYER ID */}
             <TextField
               required
@@ -189,10 +211,7 @@ export default function BlacklistRecordCreateDialog({
               multiline={hasManyIDs}
             />
             {/* EXPIRY */}
-            <Grid container
-              spacing={2}
-              alignItems="center"
-            >
+            <Grid container spacing={2} alignItems="center">
               <Grid item xs={8}>
                 <TextField
                   margin="dense"
@@ -214,7 +233,11 @@ export default function BlacklistRecordCreateDialog({
                   value={""}
                   onChange={(e) => {
                     e.target.value
-                      ? setExpiresAt(moment().utc().add(e.target.value, 'seconds').format("YYYY-MM-DDTHH:mm"))
+                      ? setExpiresAt(
+                          moment()
+                            .add(e.target.value, "seconds")
+                            .format("YYYY-MM-DDTHH:mm")
+                        )
                       : setExpiresAt("");
                   }}
                   fullWidth
@@ -225,16 +248,15 @@ export default function BlacklistRecordCreateDialog({
                     <em>Preset Times</em>
                   </MenuItem>
                   {presetTimes.map(({ value, label }) => (
-                    <MenuItem key={label} value={value}>{label}</MenuItem>
+                    <MenuItem key={label} value={value}>
+                      {label}
+                    </MenuItem>
                   ))}
                 </Select>
               </Grid>
             </Grid>
             {/* REASON */}
-            <Grid container
-              spacing={2}
-              alignItems="top"
-            >
+            <Grid container spacing={2} alignItems="top">
               <Grid item xs={8}>
                 <TextField
                   required
@@ -258,7 +280,7 @@ export default function BlacklistRecordCreateDialog({
                   id="saved-messages-select"
                   value={selectedMessage}
                   onChange={handlePunishMessageChange}
-                  inputProps={{ 'aria-label': 'Saved Messages' }}
+                  inputProps={{ "aria-label": "Saved Messages" }}
                   fullWidth
                   displayEmpty
                   className={classes.selectEmpty}
@@ -272,20 +294,22 @@ export default function BlacklistRecordCreateDialog({
                       label += "...";
                     }
                     return (
-                      <MenuItem key={label + i} value={i}>{label}</MenuItem>
-                    )
+                      <MenuItem key={label + i} value={i}>
+                        {label}
+                      </MenuItem>
+                    );
                   })}
                 </Select>
               </Grid>
             </Grid>
-
           </React.Fragment>
         )}
-
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button type="submit" disabled={blacklist === ""}>{submitText}</Button>
+        <Button type="submit" disabled={blacklist === ""}>
+          {submitText}
+        </Button>
       </DialogActions>
     </Dialog>
   );
@@ -323,5 +347,5 @@ export function BlacklistRecordCreateButton({
         disablePlayerId={disablePlayerId}
       />
     </React.Fragment>
-  )
+  );
 }

--- a/rcongui/src/components/PlayerInfo/PlayerInfo.js
+++ b/rcongui/src/components/PlayerInfo/PlayerInfo.js
@@ -207,7 +207,7 @@ const PlayerInfo = ({ classes }) => {
    */
   const fetchPlayer = (playerId) => {
     get(`get_player_profile?player_id=${playerId}`)
-      .then((response) => showResponse(response, "get_user", false))
+      .then((response) => showResponse(response, "get_player_profile", false))
       .then((data) => {
         if (
           data.result !== undefined &&


### PR DESCRIPTION
This will add a new player action (temp or perma) when adding a new blacklist record and will record a new action when editing an existing ban (temp -> perma or perma -> temp).

This means the penalty counts that are used in various places (live view, player profile page, maybe others?) will be recorded which mimics the old style behavior when doing a temp/perma native ban or when using the old blacklist.

I made a small refactor to remove some hard coded values (added an enum).

I haven't finished testing however it does appear to work properly when adding/editing a blacklist record; I need to make sure I didn't break anything for recording other actions like punishes/messages/etc.