### PR TITLE
Convert old styler player IDs on startup (for U15.2)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,11 @@ env
 if [ "$1" == 'maintenance' ] 
 then
   alembic upgrade head
+  # Convert old stye player IDs to new style (md5 hash)
+  # TODO: we can eventually remove this in a few releases once old installs have updated their game servers and CRCON
+  # SERVER_NUMBER is mandatory and not otherwise set in the maintenance container; only want it to run once
+  # LOGGING_PATH and LOGGING_FILENAME need to be passed to get it to log to the directory that is bind mounted
+  SERVER_NUMBER=1 LOGGING_PATH=/logs/ LOGGING_FILENAME=startup.log python -m rcon.cli convert_win_player_ids
   cd rconweb 
   ./manage.py makemigrations --no-input
   ./manage.py migrate --noinput


### PR DESCRIPTION
* Add a CLI command to convert windows store player IDs from the old format to the new format (md5 hash)
* Modify entrypoint.sh so player IDs are converted each start up

People should not install this release until they have shut down their game server, shut down CRCON, patched/re-enabled their game server and cleared their CRCON cache so that old style player IDs don't leak through (you could end up with multiple player ID records for the same windows store ID)

This can be run from the shell where you host CRCON with `docker compose exec backend_1 python -m rcon.cli convert_win_player_ids`

This took about 0.25 to 0.5 ms when testing it locally with ~300k player ID records.