### PR TITLE
Merge foreign key IDs for duplicated player IDs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ then
   # TODO: we can eventually remove this in a few releases once old installs have updated their game servers and CRCON
   # SERVER_NUMBER is mandatory and not otherwise set in the maintenance container; only want it to run once
   # LOGGING_PATH and LOGGING_FILENAME need to be passed to get it to log to the directory that is bind mounted
+  SERVER_NUMBER=1 LOGGING_PATH=/logs/ LOGGING_FILENAME=startup.log python -m rcon.cli merge_duplicate_player_ids
   SERVER_NUMBER=1 LOGGING_PATH=/logs/ LOGGING_FILENAME=startup.log python -m rcon.cli convert_win_player_ids
   cd rconweb 
   ./manage.py makemigrations --no-input


### PR DESCRIPTION
Courtesy of SourceCode in the Discord.

I just translated this to use the SQLAlchemy session for running the textual SQL instead of the raw connection.

Ran it against a copy of our database that has duplicate records, looks like it works fine and it allows the player IDs to convert after the merging command runs.

Took about 8 seconds to run on our VPS.