### PR TITLE
fix missing super call

### DIFF
--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -363,6 +363,7 @@ class LiveStats(BaseStats):
 
 class TimeWindowStats(BaseStats):
     def __init__(self):
+        super().__init__()
         self.match_end_result_regex = re.compile("MATCH ENDED `.+` ALLIED \((\d) - (\d)\) AXIS")
 
     def _set_start_end_times(


### PR DESCRIPTION
This fixes an issue when calculating stats (at least when recalculating, but it would be in the usual operation as well):
```
AttributeError("'TimeWindowStats' object has no attribute 'voted_no_regex'")
[2024-09-03 20:55:04,633][ERROR][][v10.3.0] rcon manage.py:<module>:55 | Unexpected error.
Traceback (most recent call last):
  File "/code/./manage.py", line 45, in <module>
    cli()
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/rcon/cli.py", line 243, in process_games
    record_stats_from_map(sess, map_, dict(), force=force)
  File "/code/rcon/workers.py", line 140, in record_stats_from_map
    player_stats = stats.get_players_stats_at_time(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/rcon/scoreboard.py", line 521, in get_players_stats_at_time
    return self._get_players_stats_for_logs(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/rcon/scoreboard.py", line 502, in _get_players_stats_for_logs
    return self.get_stats_by_player(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/rcon/scoreboard.py", line 232, in get_stats_by_player
    processor(stats=stats, player=p, log=l)
  File "/code/rcon/scoreboard.py", line 98, in _add_vote
    if self.voted_no_regex.match(log["raw"]):
       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'TimeWindowStats' object has no attribute 'voted_no_regex'
```