### PR TITLE
[FEATURE] Allow arbitrary RCon commands in chat commands

### DIFF
--- a/rcon/api_commands.py
+++ b/rcon/api_commands.py
@@ -1769,3 +1769,11 @@ class RconAPI(Rcon):
 
     def get_objective_row(self, row: int):
         return super().get_objective_row(int(row))
+
+    def set_chat_command_enabled(self, word: str, enabled: bool):
+        c = ChatCommandsUserConfig.load_from_db()
+        for command in c.command_words:
+            if word not in command.words:
+                continue
+            command.enabled = enabled
+        ChatCommandsUserConfig.save_to_db(c.model_dump())

--- a/rcon/auto_settings.py
+++ b/rcon/auto_settings.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import time
 from datetime import datetime
 
@@ -8,13 +7,11 @@ import pytz
 from rcon.api_commands import get_rcon_api
 from rcon.audit import ingame_mods, online_mods
 from rcon.commands import BrokenHllConnection, CommandFailedError
+from rcon.rcon import do_run_commands
 from rcon.user_config.auto_settings import AutoSettingsConfig
-from rcon.user_config.utils import BaseUserConfig
 
 
 logger = logging.getLogger(__name__)
-
-USER_CONFIG_NAME_PATTERN = re.compile(r"set_.*_config")
 
 
 def _get_current_map_metric(rcon):
@@ -32,10 +29,6 @@ METRICS = {
     "current_map": _get_current_map_metric,
     "time_of_day": lambda tz: datetime.now(tz=tz),
 }
-
-
-def is_user_config_func(name: str) -> bool:
-    return re.match(USER_CONFIG_NAME_PATTERN, name) is not None
 
 
 class BaseCondition:
@@ -194,37 +187,6 @@ def create_condition(name, **kwargs):
         return TimeOfDayCondition(**kwargs)
     else:
         raise ValueError("Invalid condition type: %s" % name)
-
-
-def do_run_commands(rcon, commands):
-    for command, params in commands.items():
-        try:
-            logger.info("Applying %s %s", command, params)
-
-            # Allow people to apply partial changes to a user config to make
-            # auto settings less gigantic
-            if is_user_config_func(command):
-                # super dirty we should probably make an actual look up table
-                # but all the names are consistent
-                get_config_command = f"g{command[1:]}"
-                config: BaseUserConfig = rcon.__getattribute__(get_config_command)()
-                # get the existing config, override anything set in params
-                merged_params = config.model_dump() | params
-
-                if "by" not in merged_params:
-                    merged_params["by"] = "AutoSettings"
-
-                rcon.__getattribute__(command)(**merged_params)
-            else:
-                # Non user config settings
-                rcon.__getattribute__(command)(**params)
-        except AttributeError as e:
-            logger.exception(
-                "%s is not a valid command, double check the name!", command
-            )
-        except Exception as e:
-            logger.exception("Unable to apply %s %s: %s", command, params, e)
-        time.sleep(5)  # go easy on the server
 
 
 def run():

--- a/rcon/user_config/auto_broadcast.py
+++ b/rcon/user_config/auto_broadcast.py
@@ -64,7 +64,7 @@ class AutoBroadcastUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: AutoBroadcastType, dry_run=False):
-        key_check(AutoBroadcastType.__required_keys__, values.keys())
+        key_check(AutoBroadcastType.__required_keys__, AutoBroadcastType.__optional_keys__, values.keys())
 
         raw_messages = values.get("messages")
         _listType(values=raw_messages)  # type: ignore

--- a/rcon/user_config/auto_kick.py
+++ b/rcon/user_config/auto_kick.py
@@ -44,7 +44,7 @@ class AutoVoteKickUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: AutoVoteKickType, dry_run=False):
-        key_check(AutoVoteKickType.__required_keys__, values.keys())
+        key_check(AutoVoteKickType.__required_keys__, AutoVoteKickType.__optional_keys__, values.keys())
 
         validated_conf = AutoVoteKickUserConfig(
             enabled=values.get("enabled"),

--- a/rcon/user_config/auto_mod_level.py
+++ b/rcon/user_config/auto_mod_level.py
@@ -132,7 +132,7 @@ class AutoModLevelUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: AutoModLevelType, dry_run=False):
-        key_check(AutoModLevelType.__required_keys__, values.keys())
+        key_check(AutoModLevelType.__required_keys__, AutoModLevelType.__optional_keys__, values.keys())
 
         validated_conf = AutoModLevelUserConfig(
             enabled=values.get("enabled"),

--- a/rcon/user_config/auto_mod_no_leader.py
+++ b/rcon/user_config/auto_mod_no_leader.py
@@ -88,7 +88,7 @@ class AutoModNoLeaderUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: AutoModNoLeaderType, dry_run=False):
-        key_check(AutoModNoLeaderType.__required_keys__, values.keys())
+        key_check(AutoModNoLeaderType.__required_keys__, AutoModNoLeaderType.__optional_keys__, values.keys())
 
         validated_conf = AutoModNoLeaderUserConfig(
             enabled=values.get("enabled"),

--- a/rcon/user_config/auto_mod_seeding.py
+++ b/rcon/user_config/auto_mod_seeding.py
@@ -155,7 +155,7 @@ class AutoModSeedingUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: AutoModSeedingType, dry_run=False):
-        key_check(AutoModSeedingType.__required_keys__, values.keys())
+        key_check(AutoModSeedingType.__required_keys__, AutoModSeedingType.__optional_keys__, values.keys())
 
         disallowed_roles = DisallowedRoles(
             min_players=values.get("disallowed_roles").get("min_players"),

--- a/rcon/user_config/auto_mod_solo_tank.py
+++ b/rcon/user_config/auto_mod_solo_tank.py
@@ -84,7 +84,7 @@ class AutoModNoSoloTankUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: AutoModNoSoloTankType, dry_run=False) -> None:
-        key_check(AutoModNoSoloTankType.__required_keys__, values.keys())
+        key_check(AutoModNoSoloTankType.__required_keys__, AutoModNoSoloTankType.__optional_keys__, values.keys())
 
         validated_conf = AutoModNoSoloTankUserConfig(
             enabled=values.get("enabled"),

--- a/rcon/user_config/ban_tk_on_connect.py
+++ b/rcon/user_config/ban_tk_on_connect.py
@@ -60,7 +60,7 @@ class BanTeamKillOnConnectUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: BanTeamKillOnConnectType, dry_run=False):
-        key_check(BanTeamKillOnConnectType.__required_keys__, values.keys())
+        key_check(BanTeamKillOnConnectType.__required_keys__, BanTeamKillOnConnectType.__optional_keys__, values.keys())
 
         whitelist_players = BanTeamKillOnConnectWhiteList(
             has_flag=values.get("whitelist_players", {}).get("has_flag"),

--- a/rcon/user_config/camera_notification.py
+++ b/rcon/user_config/camera_notification.py
@@ -16,7 +16,7 @@ class CameraNotificationUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: CameraNotificationType, dry_run=False):
-        key_check(CameraNotificationType.__required_keys__, values.keys())
+        key_check(CameraNotificationType.__required_keys__, CameraNotificationType.__optional_keys__, values.keys())
 
         validated_conf = CameraNotificationUserConfig(
             broadcast=values.get("broadcast"), welcome=values.get("welcome")

--- a/rcon/user_config/chat_commands.py
+++ b/rcon/user_config/chat_commands.py
@@ -144,8 +144,9 @@ class ChatCommandsUserConfig(BaseUserConfig):
             message = raw_word.get("message")
             command = raw_word.get("command")
             description = raw_word.get("description")
+            enabled = raw_word.get("enabled")
             validated_words.append(
-                ChatCommand(words=words, message=message, description=description, command=command)
+                ChatCommand(words=words, message=message, description=description, command=command, enabled=enabled)
             )
 
         validated_conf = ChatCommandsUserConfig(

--- a/rcon/user_config/expired_vips.py
+++ b/rcon/user_config/expired_vips.py
@@ -25,7 +25,7 @@ class ExpiredVipsUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: ExpiredVipsType, dry_run=False):
-        key_check(ExpiredVipsType.__required_keys__, values.keys())
+        key_check(ExpiredVipsType.__required_keys__, ExpiredVipsType.__optional_keys__, values.keys())
 
         validated_conf = ExpiredVipsUserConfig(
             enabled=values.get("enabled"),

--- a/rcon/user_config/gtx_server_name.py
+++ b/rcon/user_config/gtx_server_name.py
@@ -24,7 +24,7 @@ class GtxServerNameChangeUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: GtxServerNameChangeType, dry_run=False):
-        key_check(GtxServerNameChangeType.__required_keys__, values.keys())
+        key_check(GtxServerNameChangeType.__required_keys__, GtxServerNameChangeType.__optional_keys__, values.keys())
 
         validated_conf = GtxServerNameChangeUserConfig(
             ip=values.get("ip"),

--- a/rcon/user_config/log_line_webhooks.py
+++ b/rcon/user_config/log_line_webhooks.py
@@ -26,13 +26,13 @@ class LogLineWebhookUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: LogLineType, dry_run=False):
-        key_check(LogLineType.__required_keys__, values.keys())
+        key_check(LogLineType.__required_keys__, LogLineType.__optional_keys__, values.keys())
         raw_objects: list[LogLineWebhookType] = values.get("webhooks")
         _listType(values=raw_objects)  # type: ignore
 
         validated_log_lines: list[LogLineWebhook] = []
         for obj in raw_objects:
-            key_check(LogLineWebhookType.__required_keys__, obj.keys())
+            key_check(LogLineWebhookType.__required_keys__, LogLineWebhookType.__optional_keys__, obj.keys())
 
             raw_webhook = obj.get("webhook")
             raw_log_types = obj.get("log_types")

--- a/rcon/user_config/name_kicks.py
+++ b/rcon/user_config/name_kicks.py
@@ -41,7 +41,7 @@ class NameKickUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: NameKickType, dry_run=False):
-        key_check(NameKickType.__required_keys__, values.keys())
+        key_check(NameKickType.__required_keys__, NameKickType.__optional_keys__, values.keys())
 
         validated_conf = NameKickUserConfig(
             regular_expressions=values.get("regular_expressions"),

--- a/rcon/user_config/rcon_connection_settings.py
+++ b/rcon/user_config/rcon_connection_settings.py
@@ -19,7 +19,7 @@ class RconConnectionSettingsUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: RconConnectionSettingsType, dry_run=False):
-        key_check(RconConnectionSettingsType.__required_keys__, values.keys())
+        key_check(RconConnectionSettingsType.__required_keys__, RconConnectionSettingsType.__optional_keys__, values.keys())
 
         validated_conf = RconConnectionSettingsUserConfig(
             thread_pool_size=values.get("thread_pool_size"),

--- a/rcon/user_config/rcon_server_settings.py
+++ b/rcon/user_config/rcon_server_settings.py
@@ -155,7 +155,7 @@ class RconServerSettingsUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: RconServerSettingsType, dry_run=False):
-        key_check(RconServerSettingsType.__required_keys__, values.keys())
+        key_check(RconServerSettingsType.__required_keys__, RconServerSettingsType.__optional_keys__, values.keys())
 
         raw_invalid_names = values.get("invalid_names")
         validated_invalid_names = InvalidName(

--- a/rcon/user_config/scorebot.py
+++ b/rcon/user_config/scorebot.py
@@ -225,7 +225,7 @@ class ScorebotUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: ScorebotConfigType, dry_run=False):
-        key_check(ScorebotConfigType.__required_keys__, values.keys())
+        key_check(ScorebotConfigType.__required_keys__, ScorebotConfigType.__optional_keys__, values.keys())
 
         validated_conf = ScorebotUserConfig(
             all_stats_text=values.get("all_stats_text"),

--- a/rcon/user_config/standard_messages.py
+++ b/rcon/user_config/standard_messages.py
@@ -33,7 +33,7 @@ class BaseStandardMessageUserConfig(BaseUserConfig):
 
     @classmethod
     def save_to_db(cls, values, dry_run=False):
-        key_check(StandardMessageType.__required_keys__, values.keys())
+        key_check(StandardMessageType.__required_keys__, StandardMessageType.__optional_keys__, values.keys())
         messages: list[str] = values.get("messages")
         _listType(values=messages)  # type: ignore
 
@@ -117,7 +117,7 @@ class StandardBroadcastMessagesUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: StandardBroadcastMessagesType, dry_run=False):
-        key_check(StandardBroadcastMessagesType.__required_keys__, values.keys())
+        key_check(StandardBroadcastMessagesType.__required_keys__, StandardBroadcastMessagesType.__optional_keys__, values.keys())
 
         raw_messages = values.get("messages")
         _listType(values=raw_messages)  # type: ignore

--- a/rcon/user_config/steam.py
+++ b/rcon/user_config/steam.py
@@ -12,7 +12,7 @@ class SteamUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: SteamType, dry_run=False):
-        key_check(SteamType.__required_keys__, values.keys())
+        key_check(SteamType.__required_keys__, SteamType.__optional_keys__, values.keys())
 
         validated_conf = SteamUserConfig(api_key=values.get("api_key"))
 

--- a/rcon/user_config/utils.py
+++ b/rcon/user_config/utils.py
@@ -22,9 +22,9 @@ def all_subclasses(cls):
     )
 
 
-def key_check(mandatory_keys: frozenset, provided_keys: Iterable[str]):
+def key_check(mandatory_keys: frozenset, optional_keys: frozenset, provided_keys: Iterable[str]):
     missing_keys = mandatory_keys - set(provided_keys)
-    extra_keys = set(provided_keys) - mandatory_keys
+    extra_keys = set(provided_keys) - mandatory_keys - optional_keys
     if extra_keys or missing_keys:
         raise InvalidKeysConfigurationError(
             missing_keys=set(missing_keys),

--- a/rcon/user_config/vac_game_bans.py
+++ b/rcon/user_config/vac_game_bans.py
@@ -26,7 +26,7 @@ class VacGameBansUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: VacGameBansType, dry_run=False):
-        key_check(VacGameBansType.__required_keys__, values.keys())
+        key_check(VacGameBansType.__required_keys__, VacGameBansType.__optional_keys__, values.keys())
 
         validated_conf = VacGameBansUserConfig(
             vac_history_days=values.get("vac_history_days"),

--- a/rcon/user_config/vote_map.py
+++ b/rcon/user_config/vote_map.py
@@ -84,7 +84,7 @@ class VoteMapUserConfig(BaseUserConfig):
 
     @staticmethod
     def save_to_db(values: VoteMapType, dry_run=False):
-        key_check(VoteMapType.__required_keys__, values.keys())
+        key_check(VoteMapType.__required_keys__, VoteMapType.__optional_keys__, values.keys())
 
         validated_conf = VoteMapUserConfig(
             enabled=values.get("enabled"),

--- a/rcon/user_config/webhooks.py
+++ b/rcon/user_config/webhooks.py
@@ -88,7 +88,7 @@ class BaseMentionWebhookUserConfig(BaseUserConfig):
         _listType(values=raw_hooks)
 
         for obj in raw_hooks:
-            key_check(WebhookMentionType.__required_keys__, obj.keys())
+            key_check(WebhookMentionType.__required_keys__, WebhookMentionType.__optional_keys__, obj.keys())
 
         validated_hooks = parse_raw_mention_hooks(raw_hooks)
         validated_conf = cls(hooks=validated_hooks)
@@ -106,7 +106,7 @@ class BaseWebhookUserConfig(BaseUserConfig):
         _listType(values=raw_hooks)
 
         for obj in raw_hooks:
-            key_check(WebhookType.__required_keys__, obj.keys())
+            key_check(WebhookType.__required_keys__, WebhookType.__optional_keys__, obj.keys())
 
         validated_hooks = [DiscordWebhook(url=obj.get("url")) for obj in raw_hooks]
         validated_conf = cls(hooks=validated_hooks)
@@ -144,7 +144,7 @@ class AdminPingWebhooksUserConfig(BaseMentionWebhookUserConfig):
         _listType(values=raw_hooks)
 
         for obj in raw_hooks:
-            key_check(WebhookMentionType.__required_keys__, obj.keys())
+            key_check(WebhookMentionType.__required_keys__, WebhookMentionType.__optional_keys__, obj.keys())
 
         validated_hooks = parse_raw_mention_hooks(raw_hooks)
         validated_conf = AdminPingWebhooksUserConfig(
@@ -165,7 +165,7 @@ class ChatWebhooksUserConfig(BaseWebhookUserConfig):
         _listType(values=raw_hooks)
 
         for obj in raw_hooks:
-            key_check(WebhookType.__required_keys__, obj.keys())
+            key_check(WebhookType.__required_keys__, WebhookType.__optional_keys__, obj.keys())
 
         validated_hooks = [DiscordWebhook(url=obj.get("url")) for obj in raw_hooks]
         validated_conf = ChatWebhooksUserConfig(
@@ -191,7 +191,7 @@ class KillsWebhooksUserConfig(BaseWebhookUserConfig):
         _listType(values=raw_hooks)
 
         for obj in raw_hooks:
-            key_check(WebhookType.__required_keys__, obj.keys())
+            key_check(WebhookType.__required_keys__, WebhookType.__optional_keys__, obj.keys())
 
         validated_hooks = [DiscordWebhook(url=obj.get("url")) for obj in raw_hooks]
         validated_conf = KillsWebhooksUserConfig(

--- a/rcongui/src/components/UserSettings/miscellaneous.js
+++ b/rcongui/src/components/UserSettings/miscellaneous.js
@@ -11,7 +11,7 @@ export const ChatCommands = ({
   const notes = `
   {
     "enabled": false,
-
+  
     /* A list of commands, their trigger words, the message to send to the player and a description */
     "command_words": [
       {
@@ -30,6 +30,36 @@ export const ChatCommands = ({
         ],
         "message": "You can join our discord at {discord_invite_url}",
         "description": "Discord invite"
+      },
+      {
+        "words": [
+          "!switch"
+        ],
+        "message": null,
+        /* Can hold a list of commands that should be executed (in an undefined order). The syntax is the same as in AutoSettings commands. */
+        "command": {
+          "switch_player_now": {
+            /* Param values can have context parameters replace. Context parameters are things like player_name or player_id of the player issuing the command. */
+            "player_name": "{player_name}"
+          }
+        },
+        "enabled": true,
+        "description": "Switch yourself in side"
+      },
+      {
+        "words": [
+          "!admin"
+        ],
+        "message": null,
+        "command": {
+          "add_admin": {
+            "role": "junior",
+            "player_id": "{player_id}",
+            "description": "{player_name}"
+          }
+        },
+        "enabled": true,
+        "description": "Add yourself to admin cam list"
       }
     ],
     /* A list of commands that will send a description of all commands to the player */

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -589,7 +589,8 @@ ENDPOINT_PERMISSIONS: dict[Callable, list[str] | set[str] | str] = {
     },
     rcon_api.get_objective_row: "api.can_view_current_map",
     rcon_api.get_objective_rows: "api.can_view_current_map",
-    rcon_api.set_game_layout: "api.can_change_game_layout"
+    rcon_api.set_game_layout: "api.can_change_game_layout",
+    rcon_api.set_chat_command_enabled: "api.can_change_chat_command_status"
 }
 
 PREFIXES_TO_EXPOSE = [
@@ -816,6 +817,7 @@ RCON_ENDPOINT_HTTP_METHODS: dict[Callable, list[str]] = {
     rcon_api.edit_blacklist_record: ["POST"],
     rcon_api.delete_blacklist_record: ["POST"],
     rcon_api.unblacklist_player: ["POST"],
+    rcon_api.set_chat_command_enabled: ["POST"],
 }
 
 # Check to make sure that ENDPOINT_HTTP_METHODS and ENDPOINT_PERMISSIONS have the same endpoints


### PR DESCRIPTION
There are communities that would like to use chat commands with a more powerful set of actions that can be triggered when a player uses a chat command. Two real-worl example from the "event server for prepping" use case:

### Switching player side
Changing a side without needing to redeploy for themself, a command "!switch" is useful. Issuing this command will forward a switch_player_now RCon command with the player_name of the issuing player.

### Redeploying with 10 instead of 20 seconds
Redeploying with the `punish` command might be useful when needing to redeploy for multiple times. A command "!redeploy", which issues a `punish` command for the issuing player, might be useful here.


This feature is implemented with this PR. A chat command can either have a `message` key or a `command` key (message takes precendence). The `command` config is an object that has the same signature and functinality as auto-settings commands.
This allows for a powerful set of tools, while it also has some risks, as _everything_ can now be executed with a player issuing a specific chat command.

The parameters of the command will replace message parameters same as the message itself, however, only context keys are populated. No other variables are available in commands params.