### PR TITLE
FIX---automod---level---whitelist-flags

### DIFF
--- a/rcon/automods/level_thresholds.py
+++ b/rcon/automods/level_thresholds.py
@@ -178,7 +178,8 @@ class LevelThresholdsAutomod:
         watch_status = self.red.get(redis_key)
         if watch_status:
             watch_status = pickle.loads(watch_status)
-        else:  # No punishments so far, starting a fresh one
+        # No punishments so far, starting a fresh one
+        else:
             watch_status = WatchStatus()
 
         try:
@@ -290,8 +291,6 @@ class LevelThresholdsAutomod:
 
         with self.watch_state(team, squad_name) as watch_status:
 
-            # if squad_name is None or squad is None:
-            #     raise NoLevelViolation()
 
             author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
 
@@ -321,7 +320,14 @@ class LevelThresholdsAutomod:
 
                 # Server min level threshold check
                 min_level = self.config.min_level
-                if min_level > 0 and aplayer.lvl < min_level:
+                if (
+                    min_level > 0
+                    and aplayer.lvl < min_level
+                    and not any(
+                        flag_entry.flag in self.config.whitelist_flags
+                        for flag_entry in aplayer.flags
+                    )
+                ):
                     message = self.config.min_level_message
                     try:
                         message = message.format(level=min_level)
@@ -335,8 +341,13 @@ class LevelThresholdsAutomod:
 
                 # Server max level threshold check
                 max_level = self.config.max_level
-                # if max_level > 0 and aplayer.lvl > max_level:
-                if aplayer.lvl > max_level > 0:
+                if (
+                    aplayer.lvl > max_level > 0
+                    and not any(
+                        flag_entry.flag in self.config.whitelist_flags
+                        for flag_entry in aplayer.flags
+                    )
+                ):
                     message = self.config.max_level_message
                     try:
                         message = message.format(level=max_level)


### PR DESCRIPTION
Players having one of the `whitelist_flags` weren't immuned when violating `min_level` and `max_level`.