### PR TITLE
Return map layer info instead of just a plain map name

### DIFF
--- a/rconweb/api/scoreboards.py
+++ b/rconweb/api/scoreboards.py
@@ -109,6 +109,7 @@ def get_map_scoreboard(request):
                 failed = True
             else:
                 game = game.to_dict(with_stats=True)
+                game['map_name'] = parse_layer(game['map_name'])
     except Exception as e:
         game = None
         error = repr(e)


### PR DESCRIPTION
Include the map as a layer in `get_map_scoreboard`:

![image](https://github.com/user-attachments/assets/a52968da-c9de-4187-9a43-ed96a4ae5fb7)
