### PR TITLE
Bugfix: include is_vip and profile in get_detailed_player_info

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -254,12 +254,6 @@ class Rcon(ServerCtl):
         players_by_id = detailed_players["players"]
         fail_count = detailed_players["fail_count"]
 
-        logger.debug("Getting DB profiles")
-        steam_profiles = {
-            profile[PLAYER_ID]: profile
-            for profile in get_profiles(list(players_by_id.keys()))
-        }
-
         logger.debug("Getting VIP list")
         try:
             vips = set(v[PLAYER_ID] for v in super().get_vip_ids())
@@ -269,8 +263,6 @@ class Rcon(ServerCtl):
 
         for player in players_by_id.values():
             player_id = player[PLAYER_ID]
-            profile = steam_profiles.get(player.get(PLAYER_ID), {}) or {}
-            player["profile"] = profile
             player["is_vip"] = player_id in vips
 
             teams.setdefault(player.get("team"), {}).setdefault(

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -469,8 +469,8 @@ class Rcon(ServerCtl):
         """
         player_data = parse_raw_player_info(raw, player_name)
         vip_player_ids = set(v[PLAYER_ID] for v in super().get_vip_ids())
-        players_data["is_vip"] = player_data["player_id"] in vip_player_ids
-        return players_data
+        player_data["is_vip"] = player_data["player_id"] in vip_player_ids
+        return player_data
 
     @ttl_cache(ttl=60 * 10)
     def get_admin_ids(self) -> list[AdminType]:

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -254,16 +254,8 @@ class Rcon(ServerCtl):
         players_by_id = detailed_players["players"]
         fail_count = detailed_players["fail_count"]
 
-        logger.debug("Getting VIP list")
-        try:
-            vips = set(v[PLAYER_ID] for v in super().get_vip_ids())
-        except Exception:
-            logger.exception("Failed to get VIPs")
-            vips = set()
-
         for player in players_by_id.values():
             player_id = player[PLAYER_ID]
-            player["is_vip"] = player_id in vips
 
             teams.setdefault(player.get("team"), {}).setdefault(
                 player.get("unit_name"), {}

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -16,7 +16,7 @@ from rcon.cache_utils import get_redis_client, invalidates, ttl_cache
 from rcon.commands import SUCCESS, CommandFailedError, ServerCtl, VipId
 from rcon.maps import UNKNOWN_MAP_NAME, Layer, is_server_loading_map, parse_layer
 from rcon.models import PlayerID, PlayerVIP, enter_session
-from rcon.player_history import get_profiles, safe_save_player_action, save_player
+from rcon.player_history import get_profiles, safe_save_player_action, save_player, get_player_profile
 from rcon.settings import SERVER_INFO
 from rcon.types import (
     AdminType,
@@ -457,8 +457,8 @@ class Rcon(ServerCtl):
         player_data["is_vip"] = player_data["player_id"] in vip_player_ids
 
         # Add Profile
-        profile = get_profiles([player_data["player_id"]])
-        player_data["profile"] = profile[0]
+        profile = get_player_profile(player_data["player_id"], 1)
+        player_data["profile"] = profile
         return player_data
 
     @ttl_cache(ttl=60 * 10)

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -457,7 +457,8 @@ class Rcon(ServerCtl):
         player_data["is_vip"] = player_data["player_id"] in vip_player_ids
 
         # Add Profile
-        player_data["profile"] = get_profiles([player_data["player_id"]])
+        profile = get_profiles([player_data["player_id"]])
+        player_data["profile"] = profile[0]
         return player_data
 
     @ttl_cache(ttl=60 * 10)

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -467,8 +467,10 @@ class Rcon(ServerCtl):
         Level: 34
 
         """
-
-        return parse_raw_player_info(raw, player_name)
+        player_data = parse_raw_player_info(raw, player_name)
+        vip_player_ids = set(v[PLAYER_ID] for v in super().get_vip_ids())
+        players_data["is_vip"] = player_data["player_id"] in vip_player_ids
+        return players_data
 
     @ttl_cache(ttl=60 * 10)
     def get_admin_ids(self) -> list[AdminType]:

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -471,6 +471,9 @@ class Rcon(ServerCtl):
         player_data = parse_raw_player_info(raw, player_name)
         vip_player_ids = set(v[PLAYER_ID] for v in super().get_vip_ids())
         player_data["is_vip"] = player_data["player_id"] in vip_player_ids
+
+        # Add Profile
+        player_data["profile"] = get_profiles([player_data["player_id"]])
         return player_data
 
     @ttl_cache(ttl=60 * 10)

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -467,6 +467,7 @@ class Rcon(ServerCtl):
         Level: 34
 
         """
+        # Add VIP Status
         player_data = parse_raw_player_info(raw, player_name)
         vip_player_ids = set(v[PLAYER_ID] for v in super().get_vip_ids())
         player_data["is_vip"] = player_data["player_id"] in vip_player_ids


### PR DESCRIPTION
Hello,
`get_detailed_player_info` did not override the default `false` for `is_vip` and `null` for `profile` with the correct values. 
This PR fixes that and removes the workaround in `get_team_view` to not fetch the profiles twice. This also fixes the wrong value `is_vip` in `get_detailed_players`.

Thank you!