### PR TITLE
Feat/tk on connect expiration

### DIFF
--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -7,7 +7,6 @@ from typing import List, Mapping, Optional, TypedDict
 from pydantic import HttpUrl
 from pydantic.dataclasses import dataclass
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -82,7 +81,7 @@ class PunishPlayer:
     name: str
     squad: str
     team: str
-    flags: List[Flag]
+    flags: List[Flag] = field(default_factory=list)
     role: str = None
     lvl: int = None
     details: PunishDetails = None

--- a/rcon/game_logs.py
+++ b/rcon/game_logs.py
@@ -845,12 +845,20 @@ def auto_ban_if_tks_right_after_connection(
                 logger.info(
                     "Banning player %s for TEAMKILL after connect %s", player_name, log
                 )
+                if config.ban_duration.total_seconds > 0:
+                    expires_at = (
+                        datetime.datetime.now() + config.ban_duration.as_timedelta
+                    )
+                else:
+                    expires_at = None
+
                 result = blacklist_or_ban(
                     rcon=rcon,
                     blacklist_id=config.blacklist_id,
                     player_id=player_id,
                     reason=reason,
                     admin_name=author,
+                    expires_at=expires_at,
                 )
                 logger.info(
                     "Banned player %s for TEAMKILL after connect %s", player_name, log

--- a/rcon/user_config/ban_tk_on_connect.py
+++ b/rcon/user_config/ban_tk_on_connect.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Optional, TypedDict
 
 from pydantic import BaseModel, Field, HttpUrl, field_serializer
@@ -6,6 +7,14 @@ from rcon.user_config.utils import BaseUserConfig, key_check, set_user_config
 
 DISCORD_WEBHOOK_MESSAGE = "{player} banned for TK right after connecting"
 MESSAGE = "Your first action on the server was a TEAM KILL you were banned as a result"
+
+
+class TimeFrameType(TypedDict):
+    minutes: int
+    hours: int
+    days: int
+    weeks: int
+    years: int
 
 
 class BanTeamKillOnConnectWhitelistType(TypedDict):
@@ -19,6 +28,7 @@ class BanTeamKillOnConnectType(TypedDict):
     message: str
     author_name: str
     blacklist_id: int | None
+    ban_duration: TimeFrameType
     excluded_weapons: list[str]
     max_time_after_connect_minutes: int
     ignore_tk_after_n_kills: int
@@ -35,11 +45,30 @@ class BanTeamKillOnConnectWhiteList(BaseModel):
     has_at_least_n_sessions: int = Field(ge=0, default=10)
 
 
+class TimeFrame(BaseModel):
+    minutes: int = Field(default=0, ge=0)
+    hours: int = Field(default=0, ge=0)
+    days: int = Field(default=0, ge=0)
+    weeks: int = Field(default=0, ge=0)
+    years: int = Field(default=0, ge=0)
+
+    @property
+    def as_timedelta(self):
+        return timedelta(
+            minutes=self.minutes, hours=self.hours, days=self.days, weeks=self.weeks
+        )
+
+    @property
+    def total_seconds(self):
+        return int(self.as_timedelta.total_seconds())
+
+
 class BanTeamKillOnConnectUserConfig(BaseUserConfig):
     enabled: bool = Field(default=False)
     message: str = Field(default=MESSAGE)
     author_name: str = Field(default="HATERS GONNA HATE")
     blacklist_id: int | None = None
+    ban_duration: TimeFrame = Field(default_factory=TimeFrame)
     excluded_weapons: list[str] = Field(default_factory=list)
     max_time_after_connect_minutes: int = Field(ge=1, default=5)
     ignore_tk_after_n_kills: int = Field(ge=1, default=1)
@@ -70,10 +99,20 @@ class BanTeamKillOnConnectUserConfig(BaseUserConfig):
             ),
         )
 
+        raw_duration = values.get("ban_duration")
+        ban_duration = TimeFrame(
+            minutes=raw_duration["minutes"],
+            hours=raw_duration["hours"],
+            days=raw_duration["days"],
+            weeks=raw_duration["weeks"],
+            years=raw_duration["years"],
+        )
+
         validated_conf = BanTeamKillOnConnectUserConfig(
             enabled=values.get("enabled"),
             message=values.get("message"),
             blacklist_id=values.get("blacklist_id"),
+            ban_duration=ban_duration,
             author_name=values.get("author_name"),
             excluded_weapons=values.get("excluded_weapons"),
             max_time_after_connect_minutes=values.get("max_time_after_connect_minutes"),

--- a/rcongui/src/components/UserSettings/miscellaneous.js
+++ b/rcongui/src/components/UserSettings/miscellaneous.js
@@ -461,6 +461,19 @@ export const TeamKillBanOnConnect = ({
         "message": "Your first action on the server was a TEAM KILL you were banned as a result",
         "author_name": "HATERS GONNA HATE",
         
+        /* The ID of the blacklist to add these bans to */
+        "blacklist_id": 0,
+
+        /* The cumulative amount of time to ban the player for, set all to 0 for a permanent ban */
+        "ban_duration": {
+        "minutes": 0,
+        "hours": 0,
+        "days": 0,
+        "weeks": 0,
+        "years": 0
+      },
+
+
         /*
             Exlude TK with certain weapons from triggering the ban, weapon names can be found at: https://gist.github.com/timraay/5634d85eab552b5dfafb9fd61273dc52#available-weapons
         */

--- a/tests/test_ban_tk_connect.py
+++ b/tests/test_ban_tk_connect.py
@@ -4,7 +4,7 @@ from rcon.game_logs import (
     BanTeamKillOnConnectUserConfig,
     auto_ban_if_tks_right_after_connection,
 )
-from rcon.user_config.ban_tk_on_connect import BanTeamKillOnConnectWhiteList
+from rcon.user_config.ban_tk_on_connect import BanTeamKillOnConnectWhiteList, TimeFrame
 
 
 @mock.patch("rcon.game_logs.get_player_profile", autospec=True, return_value=None)
@@ -124,6 +124,67 @@ def test_ban_success(*args):
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
         result = auto_ban_if_tks_right_after_connection(rcon, tk_log, config)
         assert result
+
+
+@mock.patch("rcon.game_logs.get_player_profile", autospec=True, return_value=None)
+def test_ban_success_temp_ban(*args):
+    tk_log = {
+        "version": 1,
+        "timestamp_ms": 1612695641000,
+        "action": "TEAM KILL",
+        "player_name_1": "[ARC] DYDSO ★ツ",
+        "player_id_1": "76561198091327692",
+        "player_name_2": "Francky Mc Fly",
+        "player_id_1": "76561198091327692",
+        "weapon": "G43",
+        "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
+        "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
+    }
+    logs = [
+        tk_log,
+        tk_log,
+        {
+            "id": 1381028,
+            "version": 1,
+            "creation_time": "2021-02-07T11:02:11.725",
+            "timestamp_ms": 1612695428000,
+            "action": "CONNECTED",
+            "player_name_1": "[ARC] DYDSO ★ツ",
+            "player_name_2": None,
+            "weapon": None,
+            "player_id_1": None,
+            "player_id_1": None,
+            "raw": "[600 ms (1612695428)] CONNECTED [ARC] DYDSO ★ツ",
+            "content": "[ARC] DYDSO ★ツ",
+            "server": "1",
+        },
+    ]
+
+    config = BanTeamKillOnConnectUserConfig(
+        enabled=True,
+        message="Vous avez été banni automatiquement car votre premiere action apres connection est un TEAM KILL.\nSi c'etait un accident demandez votre déban sur: https://discord.io/HLLFR (Via un navigateur, pas directement dans discord)\n\nYou've been banned automatically for TEAM KILLING. Cheers",
+        author_name="HATERS GONNA HATE",
+        excluded_weapons=["None"],
+        max_time_after_connect_minutes=5,
+        ignore_tk_after_n_kills=1,
+        ignore_tk_after_n_deaths=2,
+        discord_webhook_message="{player} banned for TK right after connecting",
+        whitelist_players=BanTeamKillOnConnectWhiteList(
+            has_flag=["✅"], is_vip=True, has_at_least_n_sessions=10
+        ),
+        blacklist_id=0,
+        ban_duration=TimeFrame(days=1),
+    )
+
+    with (
+        mock.patch("rcon.game_logs.Rcon") as rcon,
+        mock.patch(
+            "rcon.game_logs.get_recent_logs", return_value={"logs": logs}
+        ) as get,
+    ):
+        rcon.get_vips_ids = mock.MagicMock(return_value=[])
+        result = auto_ban_if_tks_right_after_connection(rcon, tk_log, config)
+        assert result and result["expires_at"]
 
 
 @mock.patch("rcon.game_logs.get_player_profile", autospec=True, return_value=None)

--- a/tests/test_ban_tk_connect.py
+++ b/tests/test_ban_tk_connect.py
@@ -21,6 +21,7 @@ from rcon.user_config.ban_tk_on_connect import BanTeamKillOnConnectWhiteList
         whitelist_players=BanTeamKillOnConnectWhiteList(
             has_flag=["✅"], is_vip=True, has_at_least_n_sessions=10
         ),
+        blacklist_id=0,
     ),
 )
 def test_ban_excluded_weapon(*args):
@@ -73,14 +74,15 @@ def test_ban_success(*args):
         "timestamp_ms": 1612695641000,
         "action": "TEAM KILL",
         "player_name_1": "[ARC] DYDSO ★ツ",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "player_name_2": "Francky Mc Fly",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "weapon": "G43",
         "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
         "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
     }
     logs = [
+        tk_log,
         tk_log,
         {
             "id": 1381028,
@@ -111,6 +113,7 @@ def test_ban_success(*args):
         whitelist_players=BanTeamKillOnConnectWhiteList(
             has_flag=["✅"], is_vip=True, has_at_least_n_sessions=10
         ),
+        blacklist_id=0,
     )
     with (
         mock.patch("rcon.game_logs.Rcon") as rcon,
@@ -119,8 +122,8 @@ def test_ban_success(*args):
         ) as get,
     ):
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
-        auto_ban_if_tks_right_after_connection(rcon, tk_log, config)
-        rcon.perma_ban.assert_called()
+        result = auto_ban_if_tks_right_after_connection(rcon, tk_log, config)
+        assert result
 
 
 @mock.patch("rcon.game_logs.get_player_profile", autospec=True, return_value=None)
@@ -130,9 +133,9 @@ def test_ban_ignored_kill(*args):
         "timestamp_ms": 1612695641000,
         "action": "TEAM KILL",
         "player_name_1": "[ARC] DYDSO ★ツ",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "player_name_2": "Francky Mc Fly",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "weapon": "G43",
         "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
         "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
@@ -144,9 +147,9 @@ def test_ban_ignored_kill(*args):
             "timestamp_ms": 1612695641000,
             "action": "KILL",
             "player_name_1": "[ARC] DYDSO ★ツ",
-            "player_id_1": 76561198091327692,
+            "player_id_1": "76561198091327692",
             "player_name_2": "Francky Mc Fly",
-            "player_id_1": 76561198091327692,
+            "player_id_1": "76561198091327692",
             "weapon": "G43",
             "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
             "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
@@ -198,23 +201,24 @@ def test_ban_count_one_death(*args):
         "timestamp_ms": 1612695641000,
         "action": "TEAM KILL",
         "player_name_1": "[ARC] DYDSO ★ツ",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "player_name_2": "Francky Mc Fly",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "weapon": "G43",
         "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
         "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
     }
     logs = [
         tk_log,
+        tk_log,
         {
             "version": 1,
             "timestamp_ms": 1612695641000,
             "action": "KILL",
             "player_name_2": "[ARC] DYDSO ★ツ",
-            "player_id_2": 76561198091327692,
+            "player_id_2": "76561198091327692",
             "player_name_1": "Francky Mc Fly",
-            "player_id_1": 76561198091327692,
+            "player_id_1": "76561198091327692",
             "weapon": "G43",
             "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
             "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
@@ -248,6 +252,7 @@ def test_ban_count_one_death(*args):
         whitelist_players=BanTeamKillOnConnectWhiteList(
             has_flag=["✅"], is_vip=True, has_at_least_n_sessions=10
         ),
+        blacklist_id=0,
     )
 
     with (
@@ -257,8 +262,8 @@ def test_ban_count_one_death(*args):
         ) as get,
     ):
         rcon.get_vips_ids = mock.MagicMock(return_value=[])
-        auto_ban_if_tks_right_after_connection(rcon, tk_log, config)
-        rcon.perma_ban.assert_called()
+        result = auto_ban_if_tks_right_after_connection(rcon, tk_log, config)
+        assert result
 
 
 @mock.patch("rcon.game_logs.get_player_profile", autospec=True, return_value=None)
@@ -268,9 +273,9 @@ def test_ban_ignored_2_death(*args):
         "timestamp_ms": 1612695641000,
         "action": "TEAM KILL",
         "player_name_1": "[ARC] DYDSO ★ツ",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "player_name_2": "Francky Mc Fly",
-        "player_id_1": 76561198091327692,
+        "player_id_1": "76561198091327692",
         "weapon": "G43",
         "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
         "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
@@ -282,9 +287,9 @@ def test_ban_ignored_2_death(*args):
             "timestamp_ms": 1612695641000,
             "action": "KILL",
             "player_name_2": "[ARC] DYDSO ★ツ",
-            "player_id_2": 76561198091327692,
+            "player_id_2": "76561198091327692",
             "player_name_1": "Francky Mc Fly",
-            "player_id_1": 76561198091327692,
+            "player_id_1": "76561198091327692",
             "weapon": "G43",
             "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
             "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
@@ -294,9 +299,9 @@ def test_ban_ignored_2_death(*args):
             "timestamp_ms": 1612695641000,
             "action": "KILL",
             "player_name_2": "[ARC] DYDSO ★ツ",
-            "player_id_2": 76561198091327692,
+            "player_id_2": "76561198091327692",
             "player_name_1": "Francky Mc Fly",
-            "player_id_1": 76561198091327692,
+            "player_id_1": "76561198091327692",
             "weapon": "G43",
             "raw": "[646 ms (1612695641)] TEAM KILL: [ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",
             "content": "[ARC] DYDSO ★ツ(Axis/76561198091327692) -> Francky Mc Fly(Axis/76561198133214514) with None",

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -23,7 +23,7 @@ def test_no_mentions():
     embed = handler.create_chat_message(
         log={
             "sub_content": "test message",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         }
@@ -45,7 +45,7 @@ def test_chat_mentions_are_escaped():
     embed = handler.create_chat_message(
         log={
             "sub_content": "test message @here",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         }
@@ -60,7 +60,7 @@ def test_admin_ping_mentions_always_escaped():
     embed = handler.create_chat_embed(
         log={
             "sub_content": "test message @here",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         },
@@ -84,7 +84,7 @@ def test_mentions_are_not_escaped():
     embed = handler.create_chat_message(
         log={
             "sub_content": "test message @here",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         }
@@ -107,7 +107,7 @@ def test_admin_pings_mention_start():
     content, embed, triggered = handler.create_admin_ping_message(
         log={
             "sub_content": "!admin test @here",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         }
@@ -132,7 +132,7 @@ def test_admin_pings_mention_middle():
     content, embed, triggered = handler.create_admin_ping_message(
         log={
             "sub_content": "test !admin @here",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         }
@@ -157,7 +157,7 @@ def test_admin_pings_contains_numbers():
     content, embed, triggered = handler.create_admin_ping_message(
         log={
             "sub_content": "testword123 test @here",
-            "player": "some dude",
+            "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
         }
@@ -180,7 +180,7 @@ def test_kill_message():
     embed = handler.create_kill_message(
         log={
             "action": "KILL",
-            "player": "EL MONO LOKO",
+            "player_name_1": "EL MONO LOKO",
             "player_id_1": "76561198823171234",
             "player_name_2": "zerothreeOG",
             "player_id_2": "76561199371581234",
@@ -212,7 +212,7 @@ def test_team_kill_message():
     embed = handler.create_kill_message(
         log={
             "action": "TEAM KILL",
-            "player": "EL MONO LOKO",
+            "player_name_1": "EL MONO LOKO",
             "player_id_1": "76561198823171234",
             "player_name_2": "zerothreeOG",
             "player_id_2": "76561199371581234",


### PR DESCRIPTION
The old TK ban on connect feature would blacklist people (permanent ban across all of the game servers hosted inside CRCON).

With the new blacklist feature we can support temporary bans for this.

This also fixed some of the tests for TK ban on connect (they've been broken for uh, years I think) and the tests are updated to match the actual code behavior.

This defaults to an indefinite blacklist which won't change anything for existing users.

`rcon/automods/models.py` was an unrelated change when looking at tests, just passes a default factory so the model can be instantiated even if a flag list isn't passed.
`tests/test_discord_handler.py` was an unrelated change when looking at tests, the log fields had old style keys.