### PR TITLE
Include required permissions by endpoint in `get_api_documentation`

### DIFF
--- a/rconweb/api/audit_log.py
+++ b/rconweb/api/audit_log.py
@@ -2,14 +2,13 @@ import json
 import logging
 from functools import wraps
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 from sqlalchemy import and_, or_
 
 from rcon.models import AuditLog, enter_session
 
 from .auth import api_response, login_required
-from .decorators import require_http_methods
+from .decorators import require_http_methods, permission_required
 from .utils import _get_data
 
 logger = logging.getLogger("rconweb")

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -130,6 +130,8 @@ class RconJsonResponse(HttpResponse):
             return o.model_dump()
         elif isinstance(o, datetime.timedelta):
             return o.total_seconds()
+        elif isinstance(o, set):
+            return [val for val in sorted(o)]
         else:
             raise ValueError(f"Cannot serialize {o}, {type(o)} to JSON")
 

--- a/rconweb/api/auto_settings.py
+++ b/rconweb/api/auto_settings.py
@@ -1,14 +1,13 @@
 import json
 import os
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.user_config.auto_settings import AutoSettingsConfig
 
 from .audit_log import record_audit
 from .auth import api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import require_content_type, require_http_methods, permission_required
 from .multi_servers import forward_request
 from .services import get_supervisor_client
 from .utils import _get_data

--- a/rconweb/api/decorators.py
+++ b/rconweb/api/decorators.py
@@ -22,8 +22,7 @@ def permission_required(
 ):
     def decorator(
         func,
-    ):  # -> _Wrapped[Callable[..., Any], Any, Callable[..., Any], Any]:  # -> _Wrapped[Callable[..., Any], Any, Callable[..., Any], Any]:  # -> _Wrapped[Callable[..., Any], Any, Callable[..., Any], Any]:
-
+    ):
         if isinstance(perm, str):
             ENDPOINT_PERMISSIONS_LOOKUP[func.__name__] = [perm]
         else:
@@ -44,7 +43,7 @@ def permission_required(
 def require_http_methods(request_method_list: list[str]):
     def decorator(
         func,
-    ):  # -> _Wrapped[Callable[..., Any], Any, Callable[..., Any], Any]:  # -> _Wrapped[Callable[..., Any], Any, Callable[..., Any], Any]:  # -> _Wrapped[Callable[..., Any], Any, Callable[..., Any], Any]:
+    ):
         if func.__name__ in ENDPOINT_HTTP_METHODS:
             raise ValueError(f"{func.__name__} already added to ENDPOINT_HTTP_METHODS")
 

--- a/rconweb/api/history.py
+++ b/rconweb/api/history.py
@@ -2,13 +2,12 @@ from .auth import api_csv_response
 from rcon.api_commands import get_rcon_api
 
 from dateutil import parser
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 from .decorators import require_http_methods
 
 
 from .auth import api_csv_response, login_required
-from .decorators import require_content_type
+from .decorators import require_content_type, permission_required
 from .utils import _get_data
 
 

--- a/rconweb/api/multi_servers.py
+++ b/rconweb/api/multi_servers.py
@@ -4,14 +4,13 @@ from copy import deepcopy
 from typing import Any
 
 import requests
-from django.contrib.auth.decorators import permission_required
 from django.http import QueryDict
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.utils import ApiKey
 
 from .auth import AUTHORIZATION, api_response, login_required
-from .decorators import require_http_methods
+from .decorators import require_http_methods, permission_required
 
 logger = logging.getLogger("rcon")
 

--- a/rconweb/api/scoreboards.py
+++ b/rconweb/api/scoreboards.py
@@ -2,7 +2,6 @@ import logging
 import os
 from datetime import datetime, timedelta
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.maps import parse_layer, safe_get_map_name
@@ -76,7 +75,7 @@ def get_scoreboard_maps(request):
                     end=r["end"],
                     server_number=r["server_number"],
                     player_stats=r["player_stats"],
-                    result=r['result']
+                    result=r["result"],
                 )
             )
 
@@ -109,7 +108,6 @@ def get_map_scoreboard(request):
                 failed = True
             else:
                 game = game.to_dict(with_stats=True)
-                game['map'] = parse_layer(game['map_name'])
     except Exception as e:
         game = None
         error = repr(e)

--- a/rconweb/api/services.py
+++ b/rconweb/api/services.py
@@ -1,14 +1,13 @@
 import os
 from xmlrpc.client import Fault, ServerProxy
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.discord import send_to_discord_audit
 
 from .audit_log import record_audit
 from .auth import api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import require_content_type, require_http_methods, permission_required
 from .utils import _get_data
 
 supervisor_client = None

--- a/rconweb/api/urls.py
+++ b/rconweb/api/urls.py
@@ -18,7 +18,7 @@ from . import (
     history,
 )
 from .auth import api_response
-from .decorators import ENDPOINT_HTTP_METHODS
+from .decorators import ENDPOINT_HTTP_METHODS, ENDPOINT_PERMISSIONS_LOOKUP
 
 logger = getLogger("rconweb")
 
@@ -63,6 +63,12 @@ def get_api_documentation(request):
         # but almost all of our endpoints share the name with functions, and those that don't map
         # to entirely different things like `login -> do_login` that are out of scope of RconAPI
         item["auto_settings_capable"] = name in dir(RconAPI)
+
+        try:
+            item["permissions_required"] = ENDPOINT_PERMISSIONS_LOOKUP[func.__name__]
+        except KeyError:
+            # Not all endpoints require a permission
+            item["permissions_required"] = []
 
         try:
             item["allowed_http_methods"] = ENDPOINT_HTTP_METHODS[func.__name__]

--- a/rconweb/api/user_settings.py
+++ b/rconweb/api/user_settings.py
@@ -1,6 +1,5 @@
 from logging import getLogger
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.user_config.auto_broadcast import AutoBroadcastUserConfig
@@ -41,7 +40,7 @@ from rcon.user_config.webhooks import (
 )
 
 from .auth import api_response, login_required
-from .decorators import require_http_methods
+from .decorators import require_http_methods, permission_required
 
 logger = getLogger(__name__)
 

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -8,7 +8,6 @@ from subprocess import PIPE, run
 from typing import Any, Callable
 
 import pydantic
-from django.contrib.auth.decorators import permission_required
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -36,7 +35,7 @@ from rconweb.settings import TAG_VERSION
 
 from .audit_log import auto_record_audit, record_audit
 from .auth import AUTHORIZATION, RconJsonResponse, api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import require_content_type, require_http_methods, permission_required
 from .multi_servers import forward_command
 from .utils import _get_data
 
@@ -192,7 +191,7 @@ def expose_api_endpoint(
     @wraps(func)
     def wrapper(request: HttpRequest):
         parameters = inspect.signature(func).parameters
-        aliases = getattr(func, '_parameter_aliases', {})
+        aliases = getattr(func, "_parameter_aliases", {})
         arguments = {}
         failure = False
         others = None
@@ -589,7 +588,7 @@ ENDPOINT_PERMISSIONS: dict[Callable, list[str] | set[str] | str] = {
     },
     rcon_api.get_objective_row: "api.can_view_current_map",
     rcon_api.get_objective_rows: "api.can_view_current_map",
-    rcon_api.set_game_layout: "api.can_change_game_layout"
+    rcon_api.set_game_layout: "api.can_change_game_layout",
 }
 
 PREFIXES_TO_EXPOSE = [
@@ -866,7 +865,8 @@ if not os.getenv("HLL_MAINTENANCE_CONTAINER"):
             )
         except:
             logger.exception(
-                "Failed to initialized endpoint for %r - Most likely bad configuration", func
+                "Failed to initialized endpoint for %r - Most likely bad configuration",
+                func,
             )
             raise
     logger.info("Done Initializing endpoints")

--- a/rconweb/api/vips.py
+++ b/rconweb/api/vips.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 
 from dateutil import parser, relativedelta
 from django import forms
-from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
@@ -21,7 +20,7 @@ from rcon.workers import get_job_results, worker_bulk_vip
 
 from .audit_log import record_audit
 from .auth import api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import require_content_type, require_http_methods, permission_required
 from .views import rcon_api
 
 logger = logging.getLogger("rconweb")
@@ -46,7 +45,8 @@ def upload_vips(request):
     vips = []
     if request.method == "POST":
         for name, data in request.FILES.items():
-            for line in data:
+            for idx, line in enumerate(data):
+                idx += 1
                 expiration_timestamp = None
                 try:
                     line = line.decode()
@@ -65,7 +65,7 @@ def upload_vips(request):
                             expiration_timestamp = parser.parse(possible_timestamp)
                         except:
                             logger.warning(
-                                f"Unable to parse {possible_timestamp=} for {name=} {player_id=}"
+                                f"#{idx} Unable to parse {possible_timestamp=} for {name=} {player_id=}"
                             )
                             # The last chunk should be treated as part of the players name if it's not a valid date
                             name += possible_timestamp
@@ -74,12 +74,12 @@ def upload_vips(request):
                         player_id
                     ):
                         errors.append(
-                            f"{line} has an invalid player ID: `{player_id}`, expected a 17 digit steam id or a windows store id. {is_steam_id=} {is_win_id=}"
+                            f"#{idx} {line} has an invalid player ID: `{player_id}`, expected a 17 digit steam id or a windows store id. {is_steam_id_64(player_id)=} {is_windows_store_id(player_id)=}"
                         )
                         continue
                     if not name:
                         errors.append(
-                            f"{line} doesn't have a name attached to the player ID"
+                            f"#{idx}  {line} doesn't have a name attached to the player ID"
                         )
                         continue
                     vips.append((name, player_id, expiration_timestamp))
@@ -87,7 +87,7 @@ def upload_vips(request):
                     errors.append("File encoding is not supported. Must use UTF8")
                     break
                 except Exception as e:
-                    errors.append(f"Error on line {line} {repr(2)}")
+                    errors.append(f"#{idx} Error on line {line}: {e}")
     else:
         return api_response(error="Bad method", status_code=400)
 


### PR DESCRIPTION
* Creates our own `permission_required` decorator which just passes through to Django's method so that we can track which permissions are required by endpoint
* Include the permission(s) required in `get_api_documentation` to make it easier to determine which access a user requires to consume the API (whether through a tool or the UI)

Output looks like:

```json
 {
      "endpoint": "add_admin",
      "arguments": {
        "player_id": {
          "default": null,
          "annotation": null
        },
        "role": {
          "default": null,
          "annotation": null
        },
        "description": {
          "default": null,
          "annotation": null
        }
      },
      "return_type": "<class 'bool'>",
      "doc_string": null,
      "auto_settings_capable": true,
      "permissions_required": [
        "api.can_add_admin_roles"
      ],
      "allowed_http_methods": [
        "POST"
      ]
    },
```