### PR TITLE
fix: vip_name in reward_players typo

### DIFF
--- a/rcon/seed_vip/utils.py
+++ b/rcon/seed_vip/utils.py
@@ -257,8 +257,8 @@ def reward_players(
             continue
 
         vip_name = (
-            player.player.name
             if player
+                player.player.name            
             else format_vip_reward_name(
                 players_lookup.get(player_id, "No player name found"),
                 format_str=config.reward.player_name_format_not_current_vip,


### PR DESCRIPTION
Log:
```
[2024-10-28 20:27:19,871][INFO][teamphoenix1PublicEvent][v10.5.1] rcon.seed_vip.utils utils.py:reward_players:269 | config.dry_run=False adding VIP to player_id='XXXXX' player=None vip_name='Thank you for helping us seed.\n\nThe server is now live!' expiration_date=datetime.datetime(2024, 11, 2, 20, 27, 19, 662685, tzinfo=datetime.timezone.utc)
```
VIP List:
![image](https://github.com/user-attachments/assets/f8924c71-9ae6-4be5-97da-8757c4b95633)

PR should fix this?!