### PR TITLE
Add auto settings to message templates

### DIFF
--- a/alembic/versions/1e8fd0c19cb0_update_message_template_enum.py
+++ b/alembic/versions/1e8fd0c19cb0_update_message_template_enum.py
@@ -1,0 +1,24 @@
+"""Update message template enum
+
+Revision ID: 1e8fd0c19cb0
+Revises: f9614e41e6e5
+Create Date: 2024-10-29 18:37:09.613989
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1e8fd0c19cb0'
+down_revision = 'f9614e41e6e5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE message_template_category ADD VALUE IF NOT EXISTS 'AUTO_SETTINGS';")
+
+
+def downgrade():
+    pass

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -805,6 +805,7 @@ class MessageTemplateCategory(enum.StrEnum):
     BROADCAST = "BROADCAST"
     WELCOME = "WELCOME"
     REASON = "REASON"
+    AUTO_SETTINGS = "AUTO_SETTINGS"
 
 
 class MessageTemplateType(TypedDict):


### PR DESCRIPTION
* Adds `AUTO_SETTINGS` as a category for message templates so that different auto setting versions can be persisted in the database