### PR TITLE
Prevent crashing when a squad has null players added to it

### DIFF
--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -125,7 +125,7 @@ class PunitionsToApply:
                             role=p.get("role"),
                             lvl=p.get("level"),
                         )
-                        for p in squad.get("players", [])
+                        for p in squad.get("players", []) if p
                     ],
                 )
             )


### PR DESCRIPTION
Haven't investigated further; but sometimes the automod list of players to action can have `None` entries mixed in.

I wasn't able to reproduce the issue itself but I did build/verify that the level auto mod would still punish.