### PR TITLE
Hotfix/automod flags

### DIFF
--- a/rcon/automods/level_thresholds.py
+++ b/rcon/automods/level_thresholds.py
@@ -290,16 +290,16 @@ class LevelThresholdsAutomod:
 
         with self.watch_state(team, squad_name) as watch_status:
 
-
             author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
 
             for player in squad["players"]:
+                profile = player.get("profile", {})
                 aplayer = PunishPlayer(
                     player_id=player["player_id"],
                     name=player["name"],
                     squad=squad_name,
                     team=team,
-                    flags=player.get("profile", {}).get("flags", []),
+                    flags=profile.get("flags") if profile else [],
                     role=player.get("role"),
                     lvl=int(player.get("level")),
                     details=PunishDetails(
@@ -340,12 +340,9 @@ class LevelThresholdsAutomod:
 
                 # Server max level threshold check
                 max_level = self.config.max_level
-                if (
-                    aplayer.lvl > max_level > 0
-                    and not any(
-                        flag_entry.flag in self.config.whitelist_flags
-                        for flag_entry in aplayer.flags
-                    )
+                if aplayer.lvl > max_level > 0 and not any(
+                    flag_entry.flag in self.config.whitelist_flags
+                    for flag_entry in aplayer.flags
                 ):
                     message = self.config.max_level_message
                     try:

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -125,7 +125,7 @@ class PunitionsToApply:
                             role=p.get("role"),
                             lvl=p.get("level"),
                         )
-                        for p in squad.get("players", [])
+                        for p in squad.get("players", []) if p
                     ],
                 )
             )

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -111,23 +111,23 @@ class PunitionsToApply:
         try:
             if any(s.team == team and s.name == squad_name for s in self.squads_state):
                 return
-            self.squads_state.append(
-                ASquad(
-                    team=team,
-                    name=squad_name,
-                    players=[
-                        PunishPlayer(
-                            player_id=p.get("player_id"),
-                            name=p.get("name"),
-                            squad=p.get("unit_name"),
-                            team=p.get("team"),
-                            flags=p.get("profile", {}).get("flags", []),
-                            role=p.get("role"),
-                            lvl=p.get("level"),
-                        )
-                        for p in squad.get("players", []) if p
-                    ],
+
+            players = []
+            for player in squad.get("players", []):
+                profile = player.get("profile", {})
+                punish_player = PunishPlayer(
+                    player_id=player.get("player_id"),
+                    name=player.get("name"),
+                    squad=player.get("unit_name"),
+                    team=player.get("team"),
+                    flags=profile.get("flags", []) if profile else [],
+                    role=player.get("role"),
+                    lvl=player.get("level"),
                 )
+                players.append(punish_player)
+
+            self.squads_state.append(
+                ASquad(team=team, name=squad_name, players=players)
             )
         except:
             logger.exception("Unable to add squad info")

--- a/rcon/automods/models.py
+++ b/rcon/automods/models.py
@@ -120,7 +120,7 @@ class PunitionsToApply:
                     name=player.get("name"),
                     squad=player.get("unit_name"),
                     team=player.get("team"),
-                    flags=profile.get("flags", []) if profile else [],
+                    flags=profile.get("flags") if profile else [],
                     role=player.get("role"),
                     lvl=player.get("level"),
                 )

--- a/rcon/automods/no_leader.py
+++ b/rcon/automods/no_leader.py
@@ -182,12 +182,13 @@ class NoLeaderAutomod:
             author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
 
             for player in squad["players"]:
+                profile = player.get("profile", {})
                 aplayer = PunishPlayer(
                     player_id=player["player_id"],
                     name=player["name"],
                     squad=squad_name,
                     team=team,
-                    flags=player.get("profile", {}).get("flags", []),
+                    flags=profile.get("flags") if profile else [],
                     role=player.get("role"),
                     lvl=int(player.get("level")),
                     details=PunishDetails(

--- a/rcon/automods/no_solotank.py
+++ b/rcon/automods/no_solotank.py
@@ -185,12 +185,13 @@ class NoSoloTankAutomod:
             author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
 
             for player in squad["players"]:
+                profile = player.get("profile", {})
                 aplayer = PunishPlayer(
                     player_id=player["player_id"],
                     name=player["name"],
                     squad=squad_name,
                     team=team,
-                    flags=player.get("profile", {}).get("flags", []),
+                    flags=profile.get("flags") if profile else [],
                     role=player.get("role"),
                     lvl=int(player.get("level")),
                     details=PunishDetails(

--- a/rcon/automods/seeding_rules.py
+++ b/rcon/automods/seeding_rules.py
@@ -331,12 +331,13 @@ class SeedingRulesAutomod:
             author = AUTOMOD_USERNAME + ("-DryRun" if self.config.dry_run else "")
 
             for player in squad["players"]:
+                profile = player.get("profile", {})
                 aplayer = PunishPlayer(
                     player_id=player["player_id"],
                     name=player["name"],
                     squad=squad_name,
                     team=team,
-                    flags=player.get("profile", {}).get("flags", []),
+                    flags=profile.get("flags") if profile else [],
                     role=player.get("role"),
                     lvl=int(player.get("level")),
                     details=PunishDetails(


### PR DESCRIPTION
Prevent crashing when a player has a `None` profile (should investigate why this is possible later) but this will allow the automods to work again.