### PR TITLE
UI: Player detail made scrollable

### DIFF
--- a/rcongui_public/src/components/game/statistics/player/index.tsx
+++ b/rcongui_public/src/components/game/statistics/player/index.tsx
@@ -95,10 +95,10 @@ export default function PlayerGameDetail({
           <CollapsibleSection name={t('playerStats.encounters')} defaultOpen={true}>
             <SimpleTable columns={faceoffColumns} data={mergeKillsDeaths(player)} />
           </CollapsibleSection>
-          <CollapsibleSection name={t('playerStats.killsByWeapon')}>
+          <CollapsibleSection name={t('playerStats.killsByWeapon')} defaultOpen={true}>
             <SimpleTable columns={killByColumns} data={killsBy} />
           </CollapsibleSection>
-          <CollapsibleSection name={t('playerStats.deathsByWeapon')}>
+          <CollapsibleSection name={t('playerStats.deathsByWeapon')} defaultOpen={true}>
             <SimpleTable columns={deathByColumns} data={deathsBy} />
           </CollapsibleSection>
         </div>

--- a/rcongui_public/tailwind.config.js
+++ b/rcongui_public/tailwind.config.js
@@ -82,6 +82,9 @@ module.exports = {
   		animation: {
   			'accordion-down': 'accordion-down 0.2s ease-out',
   			'accordion-up': 'accordion-up 0.2s ease-out'
+  		},
+  		height: {
+  			'player-detail': 'calc(100vh - 10rem)'
   		}
   	}
   },


### PR DESCRIPTION
A user can scroll the player detail without scrolling to the bottom of the page.

![image](https://github.com/user-attachments/assets/f614b440-f478-4112-9641-97837037d184)
