### PR TITLE
UI: Bug fix - game score arrow display

### DIFF
--- a/rcongui_public/src/components/game/overview/index.tsx
+++ b/rcongui_public/src/components/game/overview/index.tsx
@@ -105,7 +105,7 @@ export default function GameOverview({
   const { t } = useTranslation('game')
 
   const displayArrows = () => {
-    if (!score.allies || !score.axis) return null
+    if (score.allies === undefined || score.axis === undefined) return null
 
     return (
       <ArrowsContainer>


### PR DESCRIPTION
Fixed public page stats arrow fix when it did not show up when match 0:5 or 5:0