### PR TITLE
UI: Prettier player profile tab, platform link, cliboard id

### DIFF
--- a/rcongui/src/utils/lib.js
+++ b/rcongui/src/utils/lib.js
@@ -239,3 +239,16 @@ export function getGameDuration(start, end) {
 export function isLeader(role) {
   return ["officer", "tankcommander", "spotter", "armycommander"].includes(role);
 }
+
+export function isSteamPlayer(player) {
+  const { player_id: id } = player
+  return id.length === 17 && !Number.isNaN(Number(id))
+}
+
+export function getSteamProfileUrl(id) {
+  return `https://steamcommunity.com/profiles/${id}`
+}
+
+export function getXboxProfileUrl(playerName) {
+  return `https://xboxgamertag.com/search/${playerName}`
+}


### PR DESCRIPTION
- Better profile tab UI
- Name functions as a link to the player's profile
- ID can be copied to a clipboard by clicking a button
- New link to the player's platform profile - either Steam or Xbox

![image](https://github.com/user-attachments/assets/76b9aa56-bc8c-402c-9d42-c6a9ca9453a5)
