### PR TITLE
UI: Log table player filter selection restarts

### DIFF
--- a/rcongui/src/pages/views/live/logs-table.jsx
+++ b/rcongui/src/pages/views/live/logs-table.jsx
@@ -76,10 +76,10 @@ export default function LogsTable({
     }));
   };
 
-  const handleClientPlayerFilterChange = (actionName) => {
+  const handleClientPlayerFilterChange = (playerName) => {
     setPlayerOptions((prev) => ({
       ...prev,
-      [actionName]: !prev[actionName],
+      [playerName]: !prev[playerName],
     }));
   };
 
@@ -114,9 +114,8 @@ export default function LogsTable({
         acc[player] = false;
         return acc;
       }, {}) ?? {};
-
     setPlayerOptions((prev) => {
-      for (const [name, selected] in prev) {
+      for (const [name, selected] of Object.entries(prev)) {
         if (name in incomingPlayers) {
           incomingPlayers[name] = selected;
         }


### PR DESCRIPTION
Issue: Player filter selection restarts every time the list of players involved in logs changes -> https://discord.com/channels/685692524442026020/706075642885832764/1320222405976920105
Fix: There was a for..in loop trough an Object that always resulted in setting all states to `false` as it should be for..of loop.