### PR TITLE
UI: Settings votekick thresholds crashes the app

### DIFF
--- a/rcongui/src/utils/fetchUtils.js
+++ b/rcongui/src/utils/fetchUtils.js
@@ -162,6 +162,7 @@ export const cmd = {
   SET_VIP_SLOTS_NUM: (params) => requestFactory({ method: "POST", cmd: "set_vip_slots_num", ...params }),
   SET_VOTEKICK_AUTOTOGGLE_CONFIG: (params) => requestFactory({ method: "POST", cmd: "set_votekick_autotoggle_config", ...params }),
   SET_VOTEKICK_ENABLED: (params) => requestFactory({ method: "POST", cmd: "set_votekick_enabled", ...params }),
+  SET_VOTEKICK_THRESHOLDS: (params) => requestFactory({ method: "POST", cmd: "set_votekick_thresholds", ...params }),
   SET_WELCOME_MESSAGE: (params) => requestFactory({ method: "POST", cmd: "set_welcome_message", ...params }),
   TOGGLE_SERVICE: (params) => requestFactory({ method: "POST", cmd: "do_service", ...params }),
   UNFLAG_PLAYER: (params) => requestFactory({ method: "POST", cmd: "unflag_player", ...params }),


### PR DESCRIPTION
Issue: Settings votekick thresholds crashes the app
Solution: added SET_VOTEKICK_THRESHOLDS command as it was missing