### PR TITLE
UI: Better Error pages

### DIFF
--- a/rcongui/src/components/shared/RouteError.jsx
+++ b/rcongui/src/components/shared/RouteError.jsx
@@ -1,0 +1,72 @@
+import { isRouteErrorResponse } from "react-router-dom";
+import { useRouteError, useLocation } from "react-router-dom";
+import { Stack, Typography, Button, Paper } from "@mui/material";
+import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDiscord } from "@fortawesome/free-brands-svg-icons";
+import siteConfig from "@/config/siteConfig";
+
+export default function RouteError() {
+  const error = useRouteError();
+  const location = useLocation();
+  console.error(error);
+  if (
+    isRouteErrorResponse(error) &&
+    error.status >= 400 &&
+    error.status < 500
+  ) {
+    // the response json is automatically parsed to
+    // `error.data`, you also have access to the status
+    return (
+      <Stack spacing={2} alignItems={"center"} justifyContent={"center"}>
+        <Typography variant="h3">{error.status}</Typography>
+        <Typography variant="h4">
+          {error.data.text ?? error.data.message ?? error.statusText}
+        </Typography>
+        <Typography>{error.data.command ?? error.data}</Typography>
+        <Typography>{error.data.name ?? error.data.error}</Typography>
+        <Button variant="contained" LinkComponent={Link} to={location.pathname}>
+          Try again!
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack
+      id="error-page"
+      spacing={2}
+      alignItems={"center"}
+      justifyContent={"center"}
+      sx={{ textAlign: "center" }}
+    >
+      <Typography variant="h1">Oops!</Typography>
+      <Typography variant="h2">
+        Sorry, an unexpected error has occurred.
+      </Typography>
+      <Typography variant="h3">
+        Please contact support when this error persists.
+      </Typography>
+      <Paper elevation={4} variant="outlined" sx={{ padding: 2 }}>
+        <Typography variant="h4">Error: {error.name ?? "Unknown"}</Typography>
+        <Typography variant="body1">
+          <i>{error.statusText || error.message || error.data}</i>
+        </Typography>
+      </Paper>
+      <Stack direction={"row"} spacing={2}>
+        <Button
+          variant="contained"
+          color="error"
+          LinkComponent={"a"}
+          href={siteConfig.bugReportChannelUrl}
+          startIcon={<FontAwesomeIcon icon={faDiscord} />}
+        >
+          Report this error
+        </Button>
+        <Button variant="contained" LinkComponent={Link} to={location.pathname}>
+          Go back
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/rcongui/src/config/siteConfig.js
+++ b/rcongui/src/config/siteConfig.js
@@ -2,4 +2,5 @@ export default {
     appName: 'crcon',
     repoOwner: 'MarechJ',
     repoName: 'hll_rcon_tool',
+    bugReportChannelUrl: 'https://discord.com/channels/685692524442026020/706075642885832764',
 }

--- a/rcongui/src/pages/settings/[configs]/detail.jsx
+++ b/rcongui/src/pages/settings/[configs]/detail.jsx
@@ -1,13 +1,9 @@
 import {
   Form,
-  isRouteErrorResponse,
   json,
-  Link,
   useActionData,
   useLoaderData,
-  useLocation,
   useRevalidator,
-  useRouteError,
   useSubmit,
 } from "react-router-dom";
 import {lazy, Suspense, useEffect, useState} from "react";
@@ -307,33 +303,5 @@ const ConfigPage = () => {
   );
 };
 
-export function ErrorElement() {
-  const error = useRouteError();
-  const location = useLocation();
-
-  if (
-    isRouteErrorResponse(error) &&
-    error.status >= 400 &&
-    error.status < 500
-  ) {
-    // the response json is automatically parsed to
-    // `error.data`, you also have access to the status
-    return (
-      <Stack spacing={2} alignItems={"center"} justifyContent={"center"}>
-        <Typography variant="h3">{error.status}</Typography>
-        <Typography variant="h4">{error.data.text ?? error.data.message ?? error.statusText}</Typography>
-        <Typography>{error.data.command ?? error.data}</Typography>
-        <Typography>{error.data.name ?? error.data.error}</Typography>
-        <Button variant="contained" LinkComponent={Link} to={location.pathname}>
-          Try again!
-        </Button>
-      </Stack>
-    );
-  }
-
-  // rethrow to let the parent error boundary handle it
-  // when it's not a special case for this route
-  throw error;
-}
 
 export default ConfigPage;

--- a/rcongui/src/pages/settings/index.jsx
+++ b/rcongui/src/pages/settings/index.jsx
@@ -100,6 +100,8 @@ export const action = async ({ request }) => {
           payload.value = value;
           executeCommand = cmd.SET_VIP_SLOTS_NUM;
           break;
+        default:
+          throw new ProgrammingError(`Trying to execute invalid command: ${key}`);
       }
       return executeCommand({ payload, throwRouteError: false });
     });

--- a/rcongui/src/router.jsx
+++ b/rcongui/src/router.jsx
@@ -4,7 +4,6 @@ import Root from "./pages/root"
 import { loader as rootLoader } from "./pages/root"
 import { action as rootAction } from "./pages/root"
 
-import ErrorPage from "./pages/error";
 import Dashboard from "./pages/dashboard";
 
 import LiveView from "./pages/views/live";
@@ -45,7 +44,6 @@ import MapVotemap from "./pages/settings/map-manager/votemap"
 import ConfigDetail from "./pages/settings/[configs]/detail"
 import { loader as configLoader } from "./pages/settings/[configs]/detail"
 import { action as configAction } from "./pages/settings/[configs]/detail"
-import { ErrorElement as SharedErrorElement } from "./pages/settings/[configs]/detail"
 
 import PlayerProfile from "./pages/records/players/[playerId]"
 import { loader as playerProfileLoader } from "./pages/records/players/[playerId]"
@@ -86,6 +84,7 @@ import { action as vipSettingsAction } from "./pages/settings/vip"
 
 import { AuthProvider } from "@/hooks/useAuth";
 import { GlobalState } from "@/hooks/useGlobalState";
+import RouteError from "@/components/shared/RouteError";
 
 const router = createBrowserRouter([
     {
@@ -96,7 +95,7 @@ const router = createBrowserRouter([
                 <Root />
             </AuthProvider>
         ),
-        errorElement: <ErrorPage />,
+        errorElement: <RouteError />,
         action: rootAction,
         loader: rootLoader,
         children: [
@@ -104,11 +103,11 @@ const router = createBrowserRouter([
                 path: '',
                 index: true,
                 element: <Dashboard />,
-                errorElement: <SharedErrorElement />,
+                errorElement: <RouteError />,
             },
             {
                 path: 'views',
-                errorElement: <SharedErrorElement />,
+                errorElement: <RouteError />,
                 handle: { crumb: () => <span>Views</span> },
                 children: [
                     {
@@ -116,23 +115,26 @@ const router = createBrowserRouter([
                         handle: { crumb: () => <Link to={'/views/live'}>Live</Link> },
                         element: <LiveView />,
                         loader: liveViewLoader,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'team',
                         handle: { crumb: () => <Link to={'/views/team'}>Team</Link> },
-                        element: <TeamView />
+                        element: <TeamView />,
+                        errorElement: <RouteError />,
                     }
                 ]
             },
             {
                 path: "records",
-                errorElement: <SharedErrorElement />,
+                errorElement: <RouteError />,
                 handle: { crumb: () => <span>Records</span> },
                 children: [
                     {
                         path: 'players',
                         handle: { crumb: () => <Link to={'/records/players'}>Players</Link> },
                         element: <PlayerRecords />,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'players/:playerId',
@@ -140,32 +142,37 @@ const router = createBrowserRouter([
                         loader: playerProfileLoader,
                         action: playerProfileAction,
                         handle: { crumb: (data) => [<Link to={'/records/players'}>Players</Link>, <Link to={'/records/players/' + data?.profile?.player_id}>{data?.profile?.names[0]?.name ?? ''}</Link>] },
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'blacklists',
                         handle: { crumb: () => <Link to={'/records/blacklists'}>Blacklists</Link> },
                         element: <BlacklistRecords />,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'blacklists/manage',
                         handle: { crumb: () => [<Link to={'/records/blacklists'}>Blacklists</Link>, <span>Manage</span>] },
                         element: <Blacklists />,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'game-logs',
                         handle: { crumb: () => <Link to={'/records/game-log'}>Game Logs</Link> },
                         element: <GameLogsRecords />,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'audit-logs',
                         handle: { crumb: () => <Link to={'/records/audit-log'}>Audit Logs</Link> },
                         element: <AuditLogsRecords />,
+                        errorElement: <RouteError />,
                     },
                 ],
             },
             {
                 path: 'settings',
-                errorElement: <SharedErrorElement />,
+                errorElement: <RouteError />,
                 handle: { crumb: () => <span>Settings</span> },
                 children: [
                     {
@@ -175,6 +182,7 @@ const router = createBrowserRouter([
                         loader: settingsLoader,
                         action: settingsAction,
                         index: true,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'services',
@@ -182,6 +190,7 @@ const router = createBrowserRouter([
                         element: <ServicesSettings />,
                         loader: servicesLoader,
                         action: servicesAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'vip',
@@ -189,6 +198,7 @@ const router = createBrowserRouter([
                         element: <VipSettings />,
                         loader: vipSettingsLoader,
                         action: vipSettingsAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'console-admins',
@@ -196,6 +206,7 @@ const router = createBrowserRouter([
                         element: <ConsoleAdminSettings />,
                         loader: consoleAdminSettingsLoader,
                         action: consoleAdminSettingsAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'profanity-filter',
@@ -203,6 +214,7 @@ const router = createBrowserRouter([
                         element: <ProfanityFilterSettings />,
                         loader: profanityFilterLoader,
                         action: profanityFilterAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'welcome-message',
@@ -210,6 +222,7 @@ const router = createBrowserRouter([
                         element: <WelcomeMessageSettings />,
                         loader: welcomeMessageLoader,
                         action: welcomeMessageAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'broadcast-message',
@@ -217,6 +230,7 @@ const router = createBrowserRouter([
                         element: <BroadcastMessageSettings />,
                         loader: broadcastMessageLoader,
                         action: broadcastMessageAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'autosettings',
@@ -224,6 +238,7 @@ const router = createBrowserRouter([
                         element: <AutoSettings />,
                         loader: autosettingsLoader,
                         action: autosettingsAction,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'maps',
@@ -234,21 +249,25 @@ const router = createBrowserRouter([
                                 path: 'change',
                                 handle: { crumb: () => <Link to={'/settings/maps/change'}>Change</Link> },
                                 element: <MapChange />,
+                                errorElement: <RouteError />,
                             },
                             {
                                 path: 'rotation',
                                 handle: { crumb: () => <Link to={'/settings/maps/rotation'}>Rotation</Link> },
                                 element: <MapRotation />,
+                                errorElement: <RouteError />,
                             },
                             {
                                 path: 'objectives',
                                 handle: { crumb: () => <Link to={'/settings/maps/objectives'}>Objectives</Link> },
                                 element: <MapObjectives />,
+                                errorElement: <RouteError />,
                             },
                             {
                                 path: 'votemap',
                                 handle: { crumb: () => <Link to={'/settings/maps/votemap'}>Votemap</Link> },
                                 element: <MapVotemap />,
+                                errorElement: <RouteError />,
                             }
                         ]
                     },
@@ -262,7 +281,7 @@ const router = createBrowserRouter([
                                 handle: { crumb: () => <span>Detail</span> },
                                 loader: templatesLoader,
                                 action: templatesAction,
-                                errorElement: <SharedErrorElement />,
+                                errorElement: <RouteError />,
                                 element: <TemplatesDetail />,
                             },
                         ]
@@ -272,13 +291,13 @@ const router = createBrowserRouter([
             {
                 path: '/settings/:category/:type',
                 element: <ConfigDetail />,
-                errorElement: <SharedErrorElement />,
+                errorElement: <RouteError />,
                 loader: configLoader,
                 action: configAction,
             },
             {
                 path: 'stats',
-                errorElement: <SharedErrorElement />,
+                errorElement: <RouteError />,
                 handle: { crumb: () => <span>Stats</span> },
                 children: [
                     {
@@ -286,11 +305,13 @@ const router = createBrowserRouter([
                         handle: { crumb: () => <Link to={'/stats/live-game'}>Live Game</Link> },
                         element: <LiveGamePage />,
                         loader: liveGameLoader,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'live-sessions',
                         handle: { crumb: () => <Link to={'/stats/live-sessions'}>Live Sessions</Link> },
                         element: <LiveSessionStats />,
+                        errorElement: <RouteError />,
                     },
                     {
                         path: 'games',
@@ -302,11 +323,13 @@ const router = createBrowserRouter([
                                 index: true,
                                 loader: gamesLoader,
                                 element: <GamesPage />,
+                                errorElement: <RouteError />,
                             },
                             {
                                 path: ':gameId',
                                 handle: { crumb: (data) => <span>{data?.gameId}</span> },
                                 element: <GameDetailsPage />,
+                                errorElement: <RouteError />,
                             }
                         ]
                     }
@@ -317,7 +340,7 @@ const router = createBrowserRouter([
     {
         path: '/login',
         element: <Login />,
-        errorElement: <ErrorPage />,
+        errorElement: <RouteError />,
         action: loginAction,
         loader: loginLoader,
     },

--- a/rcongui/src/utils/programminError.js
+++ b/rcongui/src/utils/programminError.js
@@ -1,0 +1,8 @@
+class ProgrammingError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ProgrammingError";
+  }
+}
+
+export default ProgrammingError;


### PR DESCRIPTION
Issue: When programming or some other unexpected error, it displays only a blank page with some error text
Solution: Every route now falls back to new error element handling HTTP errors(no auth, no permission, ...) and all other general errors.
`REPORT` link directs to Discord Bug channel.
`BACK` link to refresh the page

![Screenshot (380)](https://github.com/user-attachments/assets/4852623a-72b3-45dc-8ac4-c439c6731336)
![Screenshot (378)](https://github.com/user-attachments/assets/96541abe-8c2c-42ab-b3ef-fcc1ba9b8ceb)
