### PR TITLE
Fix: Show only player that are currently blacklisted, fixes #811

### DIFF
--- a/rcon/player_history.py
+++ b/rcon/player_history.py
@@ -209,7 +209,7 @@ def get_players_by_appearance(
                     BlacklistRecord.player_id_id == PlayerID.id,
                     or_(
                         BlacklistRecord.expires_at.is_(None),
-                        BlacklistRecord.expires_at < func.now(),
+                        BlacklistRecord.expires_at > func.now(),
                     ),
                 )
                 .exists()


### PR DESCRIPTION
Hello,
this fixes #811 . The current implementation includes player where the blacklist record is already expired.