### PR TITLE
UI: Log table selection popover input focus

### DIFF
--- a/rcongui/src/components/shared/SearchInput.jsx
+++ b/rcongui/src/components/shared/SearchInput.jsx
@@ -1,6 +1,7 @@
 import { InputBase, Box, styled, IconButton } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import CloseIcon from "@mui/icons-material/Close";
+import React from "react";
 
 const SearchWrapper = styled(Box)({
   display: "flex",
@@ -19,7 +20,7 @@ const StyledInput = styled(InputBase)({
   }
 })
 
-export function SearchInput({ ...props }) {
+export const SearchInput = React.forwardRef(({ ...props }, ref) => {
   const { sx, onClear, ...rest } = props;
   return (
     <SearchWrapper sx={sx}>
@@ -27,6 +28,7 @@ export function SearchInput({ ...props }) {
         <SearchIcon />
       </Box>
       <StyledInput
+        inputRef={ref}
         placeholder={props.placeholder ?? "Search"}
         inputProps={{
           "aria-label": props.placeholder?.toLowerCase() ?? "search",
@@ -36,4 +38,6 @@ export function SearchInput({ ...props }) {
       />
     </SearchWrapper>
   );
-}
+});
+
+SearchInput.displayName = 'SearchInput';

--- a/rcongui/src/components/table/selection/LogActionHighlightMenu.jsx
+++ b/rcongui/src/components/table/selection/LogActionHighlightMenu.jsx
@@ -40,6 +40,7 @@ export const LogActionHighlightMenu = ({
     onOpen,
     onClose,
     filteredOptions,
+    searchInputRef,
   } = useSelectionMenu(actionOptions);
 
   return (
@@ -103,6 +104,7 @@ export const LogActionHighlightMenu = ({
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         placeholder="Search actions"
+        ref={searchInputRef}
       />
       {filteredOptions.map((actionName) => (
         <ListItem

--- a/rcongui/src/components/table/selection/LogActionSelectionMenu.jsx
+++ b/rcongui/src/components/table/selection/LogActionSelectionMenu.jsx
@@ -29,13 +29,18 @@ export const LogActionSelectionMenu = ({ actionOptions, onActionSelect }) => {
     onClose,
     hasSelected,
     filteredOptions,
+    searchInputRef,
   } = useSelectionMenu(actionOptions);
+
+  const handleOpen = () => {
+    onOpen();
+  }
 
   return (
     <PopoverMenu
       id="log-action-picker"
       description="Pick an action to filter the logs"
-      onOpen={onOpen}
+      onOpen={handleOpen}
       onClose={onClose}
       renderButton={(props) => (
         <Button {...props}>
@@ -52,7 +57,11 @@ export const LogActionSelectionMenu = ({ actionOptions, onActionSelect }) => {
         </Button>
       )}
     >
-      <SearchInput value={search} onChange={(e) => setSearch(e.target.value)} />
+      <SearchInput 
+        ref={searchInputRef}
+        value={search} 
+        onChange={(e) => setSearch(e.target.value)} 
+      />
       <List
         sx={{
           width: "100%",

--- a/rcongui/src/components/table/selection/LogPlayerSelectionMenu.jsx
+++ b/rcongui/src/components/table/selection/LogPlayerSelectionMenu.jsx
@@ -28,6 +28,7 @@ export const LogPlayerSelectionMenu = ({ actionOptions, onActionSelect }) => {
     onClose,
     hasSelected,
     filteredOptions,
+    searchInputRef,
   } = useSelectionMenu(actionOptions);
 
   return (
@@ -51,7 +52,11 @@ export const LogPlayerSelectionMenu = ({ actionOptions, onActionSelect }) => {
         </Button>
       )}
     >
-      <SearchInput value={search} onChange={(e) => setSearch(e.target.value)} />
+      <SearchInput
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        ref={searchInputRef}
+      />
       <List
         sx={{
           width: "100%",

--- a/rcongui/src/hooks/useSelectionMenu.js
+++ b/rcongui/src/hooks/useSelectionMenu.js
@@ -1,8 +1,9 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 
 export const useSelectionMenu = (options) => {
   const [search, setSearch] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const searchInputRef = useRef(null);
 
   const sortedOptions = useMemo(() => {
     if (!isOpen) return [];
@@ -26,6 +27,9 @@ export const useSelectionMenu = (options) => {
 
   const onOpen = () => {
     setIsOpen(true);
+    setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 0);
   };
 
   const onClose = () => {
@@ -40,5 +44,6 @@ export const useSelectionMenu = (options) => {
     filteredOptions,
     onOpen,
     onClose,
+    searchInputRef,
   };
 };


### PR DESCRIPTION
Issue: The search input is not focused when the popover opens.
Solution: Adding `ref` to the input element and triggering `tabIndex=0` on popover's opened state.