### PR TITLE
Include required permissions by endpoint in `get_api_documentation`

### DIFF
--- a/rconweb/api/audit_log.py
+++ b/rconweb/api/audit_log.py
@@ -5,13 +5,13 @@ from functools import wraps
 
 from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
-from sqlalchemy import and_, or_, select, func
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import query
 
 from rcon.models import AuditLog, enter_session
 
 from .auth import api_response, login_required
-from .decorators import require_http_methods
+from .decorators import permission_required, require_http_methods
 from .utils import _get_data
 
 logger = logging.getLogger("rconweb")
@@ -143,16 +143,16 @@ def get_audit_logs(request):
 
             paged_stmt = stmt.offset((page - 1) * page_size).limit(page_size)
             res = sess.execute(paged_stmt).scalars().all()
-            if data.get('page') is None:
+            if data.get("page") is None:
                 res = [r.to_dict() for r in res]
             else:
                 count = sess.execute(count_stmt).scalar_one()
                 res = {
-                    'audit_logs': [r.to_dict() for r in res],
-                    'page': page,
-                    'page_size': page_size,
-                    'total_pages': math.ceil(count / page_size),
-                    'total_entries': count,
+                    "audit_logs": [r.to_dict() for r in res],
+                    "page": page,
+                    "page_size": page_size,
+                    "total_pages": math.ceil(count / page_size),
+                    "total_entries": count,
                 }
     except Exception as e:
         logger.exception("Getting audit log failed")

--- a/rconweb/api/auth.py
+++ b/rconweb/api/auth.py
@@ -157,6 +157,8 @@ class RconJsonResponse(HttpResponse):
             return o.model_dump()
         elif isinstance(o, datetime.timedelta):
             return o.total_seconds()
+        elif isinstance(o, set):
+            return [val for val in sorted(o)]
         else:
             raise ValueError(f"Cannot serialize {o}, {type(o)} to JSON")
 

--- a/rconweb/api/auto_settings.py
+++ b/rconweb/api/auto_settings.py
@@ -1,14 +1,13 @@
 import json
 import os
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.user_config.auto_settings import AutoSettingsConfig
 
 from .audit_log import record_audit
 from .auth import api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import permission_required, require_content_type, require_http_methods
 from .multi_servers import forward_request
 from .services import get_supervisor_client
 from .utils import _get_data

--- a/rconweb/api/history.py
+++ b/rconweb/api/history.py
@@ -1,11 +1,10 @@
 from dateutil import parser
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.api_commands import get_rcon_api
 
 from .auth import api_csv_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import permission_required, require_content_type, require_http_methods
 from .utils import _get_data
 
 

--- a/rconweb/api/multi_servers.py
+++ b/rconweb/api/multi_servers.py
@@ -4,14 +4,13 @@ from copy import deepcopy
 from typing import Any
 
 import requests
-from django.contrib.auth.decorators import permission_required
 from django.http import QueryDict
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.utils import ApiKey
 
 from .auth import AUTHORIZATION, api_response, login_required
-from .decorators import require_http_methods
+from .decorators import permission_required, require_http_methods
 
 logger = logging.getLogger("rcon")
 

--- a/rconweb/api/services.py
+++ b/rconweb/api/services.py
@@ -1,17 +1,16 @@
 import os
-from xmlrpc.client import Fault, ServerProxy
 from http.client import CannotSendRequest
+from logging import getLogger
+from xmlrpc.client import Fault, ServerProxy
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.discord import send_to_discord_audit
 
 from .audit_log import record_audit
 from .auth import api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import permission_required, require_content_type, require_http_methods
 from .utils import _get_data
-from logging import getLogger
 
 logger = getLogger(__name__)
 

--- a/rconweb/api/urls.py
+++ b/rconweb/api/urls.py
@@ -18,7 +18,7 @@ from . import (
     vips,
 )
 from .auth import api_response
-from .decorators import ENDPOINT_HTTP_METHODS
+from .decorators import ENDPOINT_HTTP_METHODS, ENDPOINT_PERMISSIONS_LOOKUP
 
 logger = getLogger("rconweb")
 
@@ -63,6 +63,12 @@ def get_api_documentation(request):
         # but almost all of our endpoints share the name with functions, and those that don't map
         # to entirely different things like `login -> do_login` that are out of scope of RconAPI
         item["auto_settings_capable"] = name in dir(RconAPI)
+
+        try:
+            item["permissions_required"] = ENDPOINT_PERMISSIONS_LOOKUP[func.__name__]
+        except KeyError:
+            # Not all endpoints require a permission
+            item["permissions_required"] = []
 
         try:
             item["allowed_http_methods"] = ENDPOINT_HTTP_METHODS[func.__name__]

--- a/rconweb/api/user_settings.py
+++ b/rconweb/api/user_settings.py
@@ -1,6 +1,5 @@
 from logging import getLogger
 
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.csrf import csrf_exempt
 
 from rcon.user_config.auto_broadcast import AutoBroadcastUserConfig
@@ -43,7 +42,7 @@ from rcon.user_config.webhooks import (
 )
 
 from .auth import api_response, login_required
-from .decorators import require_http_methods
+from .decorators import permission_required, require_http_methods
 
 logger = getLogger(__name__)
 

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -8,7 +8,6 @@ from subprocess import PIPE, run
 from typing import Any, Callable
 
 import pydantic
-from django.contrib.auth.decorators import permission_required
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -35,7 +34,7 @@ from rconweb.settings import TAG_VERSION
 
 from .audit_log import auto_record_audit, record_audit
 from .auth import AUTHORIZATION, RconJsonResponse, api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import permission_required, require_content_type, require_http_methods
 from .multi_servers import forward_command
 from .utils import _get_data
 

--- a/rconweb/api/vips.py
+++ b/rconweb/api/vips.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 
 from dateutil import parser, relativedelta
 from django import forms
-from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
@@ -21,7 +20,7 @@ from rcon.workers import get_job_results, worker_bulk_vip
 
 from .audit_log import record_audit
 from .auth import api_response, login_required
-from .decorators import require_content_type, require_http_methods
+from .decorators import permission_required, require_content_type, require_http_methods
 from .views import rcon_api
 
 logger = logging.getLogger("rconweb")


### PR DESCRIPTION
* Creates our own `permission_required` decorator which just passes through to Django's method so that we can track which permissions are required by endpoint
* Include the permission(s) required in `get_api_documentation` to make it easier to determine which access a user requires to consume the API (whether through a tool or the UI)

Output looks like:

```json
 {
      "endpoint": "add_admin",
      "arguments": {
        "player_id": {
          "default": null,
          "annotation": null
        },
        "role": {
          "default": null,
          "annotation": null
        },
        "description": {
          "default": null,
          "annotation": null
        }
      },
      "return_type": "<class 'bool'>",
      "doc_string": null,
      "auto_settings_capable": true,
      "permissions_required": [
        "api.can_add_admin_roles"
      ],
      "allowed_http_methods": [
        "POST"
      ]
    },
```