### PR TITLE
FE: Stats: fixed: vertical scrolling while selecting different games

### DIFF
--- a/rcongui_public/src/pages/games/horizontal-games-list.tsx
+++ b/rcongui_public/src/pages/games/horizontal-games-list.tsx
@@ -24,7 +24,7 @@ export const HorizontalGamesList = ({ games }: { games: ScoreboardMaps }) => {
         pathname.startsWith(href)
       )?.[1];
       if (targetElement) {
-        targetElement.scrollIntoView({ behavior: "smooth", inline: "center" });
+        targetElement.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
       }
     }
   }, [pathname]);


### PR DESCRIPTION
Bug: When selecting a game sometimes the window would scroll vertically. 

The issue was that it would scroll the Game Card to the top and ignored the sticky tool bar, but only if the site was scrollable (table was big enough).

https://discord.com/channels/685692524442026020/698857000804548629/1324752912055931021