### PR TITLE
Small PR: some fixes

### DIFF
--- a/rcongui_public/src/components/game/statistics/game-table.tsx
+++ b/rcongui_public/src/components/game/statistics/game-table.tsx
@@ -132,7 +132,7 @@ export function DataTable<TData extends Player, TValue, TExtraColumnId extends s
                   </div>
                 </SelectItem>
                 {teamOptions.map((option, index) =>
-                  <SelectItem value={option}>
+                  <SelectItem key={option} value={option}>
                     <div className="flex">
                       <TeamIndicator team={option as TeamEnum} className="block m-auto" />
                       <div className="pl-3">{t(option)} ({teamCounts[index]})</div>
@@ -177,7 +177,7 @@ export function DataTable<TData extends Player, TValue, TExtraColumnId extends s
               </PlainSelectTrigger>
               <SelectContent className={'px-4 py-2 pl-2'}>
                 {extraColumns.map((column) => (
-                  <div>
+                  <div key={column.id}>
                     <Checkbox
                       value={column.id}
                       checked={column.displayed}

--- a/rcongui_public/src/components/game/statistics/game-table.tsx
+++ b/rcongui_public/src/components/game/statistics/game-table.tsx
@@ -106,7 +106,7 @@ export function DataTable<TData extends Player, TValue, TExtraColumnId extends s
 
   return (
     <div className="border w-full divide-y">
-      <div className="flex flex-row justify-between items-start p-2 flex-wrap gap-3">
+      <div className="flex flex-row justify-between items-start p-2 gap-3">
         <div className="flex flex-row items-start gap-3">
           {hasIsOnline && (
             <Select onValueChange={(value) => table.getColumn('is_online')?.setFilterValue(value)}>

--- a/rcongui_public/src/components/game/statistics/weapon-type-bar.tsx
+++ b/rcongui_public/src/components/game/statistics/weapon-type-bar.tsx
@@ -54,7 +54,7 @@ export function WeaponTypeBar({ player }: WeaponTypeBarProps) {
       </TooltipTrigger>
       <TooltipContent>
         {Object.entries(simpleWeaponTypeMap).map(([_, props]) =>
-          <div className="flex items-center">
+          <div className="flex items-center" key={props.t}>
             <span className="w-4 size-2" style={{background: props.color}}/>
             <span className="ml-2">{props.t}</span>
           </div>

--- a/rcongui_public/src/components/header/nav-links.tsx
+++ b/rcongui_public/src/components/header/nav-links.tsx
@@ -13,6 +13,7 @@ export function NavLinks() {
     const isNotActive = pathname.pathname !== link.href
     return (
       <Button
+        key={link.href}
         variant={'text'}
         className={cn(
           'text-sm font-medium transition-colors focus:ring-primary',

--- a/rcongui_public/src/pages/games/horizontal-games-list.tsx
+++ b/rcongui_public/src/pages/games/horizontal-games-list.tsx
@@ -90,8 +90,8 @@ export const HorizontalGamesList = ({ games }: { games: ScoreboardMaps }) => {
     <ScrollArea ref={scrollAreaRef} className="w-full whitespace-nowrap sm:-mx-4 xl:mx-0 pb-2 relative overflow-hidden z-auto">
       <div className="flex flex-row w-max">
         {validGames.map((game, index) => (
-          <>
-            <div ref={(element: any) => {
+          <React.Fragment key={game.id}>
+            <div key={game.id} ref={(element: any) => {
               if (element) {
                 gameBoundingRefs.current.set(index, element);
               } else {
@@ -99,7 +99,6 @@ export const HorizontalGamesList = ({ games }: { games: ScoreboardMaps }) => {
               }
             }}>
               <GameCard
-                key={game.id}
                 game={game}
                 pathname={pathname}
                 onMouseEnter={() => setHoverGameDate(game.start)}
@@ -116,16 +115,16 @@ export const HorizontalGamesList = ({ games }: { games: ScoreboardMaps }) => {
             {!dayjsLocal(game.start).isSame(dayjsLocal(validGames[index + 1]?.start), 'day') &&
               <>
                 <DateCard
-                  zIndex={validGames.length - index}
                   key={game.start}
+                  zIndex={validGames.length - index}
                   dateString={game.start}
                   highlight={!!hoverGameDate && dayjsLocal(hoverGameDate).isSame(dayjsLocal(game.start), 'day')}
                   sticky={false}
                 />
                 {!!stickyDate && stickyDate.isSame(dayjsLocal(game.start), 'day') &&
                   <DateCard
-                    zIndex={validGames.length - index}
                     key={`sticky-${game.start}`}
+                    zIndex={validGames.length - index}
                     dateString={game.start}
                     sticky={true}
                     highlight={!!hoverGameDate && dayjsLocal(hoverGameDate).isSame(dayjsLocal(game.start), 'day')}
@@ -133,7 +132,7 @@ export const HorizontalGamesList = ({ games }: { games: ScoreboardMaps }) => {
                 }
               </>
             }
-          </>
+          </React.Fragment>
         ))}
       </div>
       <ScrollBar orientation="horizontal"/>

--- a/rcongui_public/src/pages/games/layout.tsx
+++ b/rcongui_public/src/pages/games/layout.tsx
@@ -27,7 +27,7 @@ export default function GamesLayout() {
             onReset={reset}
           >
             <Suspense fallback={<div>Loading...</div>}>
-              <HorizontalGamesList games={games}/>
+              <HorizontalGamesList games={games} key={`${games.maps[0].id}-${games.maps[games.maps.length - 1].id}`}/>
             </Suspense>
           </ErrorBoundary>
         )}

--- a/rcongui_public/src/pages/games/list.tsx
+++ b/rcongui_public/src/pages/games/list.tsx
@@ -5,14 +5,22 @@ import { columns } from './columns'
 import { DataTable as MatchTable } from './table'
 import MatchPagination from './pagination'
 import { ScoreboardMap, ScoreboardMaps } from '@/types/api'
+import {GameMode} from "@/types/mapLayer";
 
 export function validGame(game: ScoreboardMap) {
+  const modeToTime: Record<GameMode, number> = {
+    ['warfare']: 90,
+    ['offensive']: 150,
+    ['skirmish']: 30,
+    ['control']: 30,
+  }
+
   const start = dayjs(game.start)
   const end = dayjs(game.end)
   const diffMinutes = end.diff(start, 'minutes')
   const isDraw = (game.result?.allied ?? 0) + (game.result?.axis ?? 0) === 4
 
-  return diffMinutes < 100 && diffMinutes > 9 && !isDraw
+  return diffMinutes < (modeToTime[game.map.game_mode] ?? 90) + 10 && diffMinutes > 9 && !isDraw
 }
 
 export default function GamesList({


### PR DESCRIPTION
1. valid games: offensive can be longer than 90 minutes (rare but can be the case)
2. Selecting older games would break the sticky date as the games array would change -> added key for rerender
3. added various missing keys in lists
4. removed the flexwrap from above the table as it is no longer necessary due to new player selection.