### PR TITLE
Update api_commands.py

### DIFF
--- a/rcon/api_commands.py
+++ b/rcon/api_commands.py
@@ -745,7 +745,7 @@ class RconAPI(Rcon):
         new_config = VoteMapUserConfig.load_from_db()
 
         # on -> off or off -> on
-        if old_config.enabled != new_config:
+        if old_config.enabled != new_config.enabled:
             self.reset_votemap_state()
 
         return True


### PR DESCRIPTION
Setting the "enabled" parameter was always resetting the votemap state, though it should only do it if being toggled from on to off or off to on. A property was missing in the condition.