### PR TITLE
Feature: custom language en24h

### DIFF
--- a/rcongui_public/src/components/language-selector/index.tsx
+++ b/rcongui_public/src/components/language-selector/index.tsx
@@ -10,6 +10,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Label } from '../ui/label'
 
 const getLocaleDisplayName = (locale: string, displayLocale?: string) => {
+  if (locale === 'en24h') {
+    return 'English (24h)';
+  } else if (locale === 'en') {
+    return 'English (AM/PM)';
+  }
   const displayName = new Intl.DisplayNames([displayLocale || locale], {
     type: 'language',
   }).of(locale)!

--- a/rcongui_public/src/i18n/config.ts
+++ b/rcongui_public/src/i18n/config.ts
@@ -3,27 +3,29 @@ import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import resourcesToBackend from 'i18next-resources-to-backend'
 
-export const LANGUAGES = ['en', 'de', 'fr', 'es', 'zh-Hans', 'zh-Hant', 'ja', 'ko', 'pt', 'it', 'ru', 'cs']
+export const LANGUAGES = ['en24h', 'en', 'de', 'fr', 'es', 'zh-Hans', 'zh-Hant', 'ja', 'ko', 'pt', 'it', 'ru', 'cs']
 
 /**
  *  Also add import in {@link LocaleHandler}
  */
-export const DAYJS_LANGUAGES = ['en', 'de', 'fr', 'es', 'zh', 'ja', 'ko', 'pt', 'it', 'ru', 'cs'];
+export const DAYJS_LANGUAGES = ['en24h', 'en', 'de', 'fr', 'es', 'zh', 'ja', 'ko', 'pt', 'it', 'ru', 'cs'];
 
 i18next
   .use(LanguageDetector)
   .use(initReactI18next)
   .use(
     resourcesToBackend((language: string, namespace: string) => {
-      // no reason there is a language called 'dev', just passed it away
+      // 'en24h' and 'en' are exactly the same for i18n. It has only an effect on dayjs
+      const lang = language === 'en24h' ? 'en' : language;
+
       if (language === 'dev') return
-      return import(`./locales/${language}/${namespace}.json`)
+      return import(`./locales/${lang}/${namespace}.json`)
     }),
   )
   .init({
     debug: import.meta.env.DEV,
     fallbackLng: {
       'de-CH': ['fr', 'it'],
-      default: ['en'],
+      default: ['en24h'],
     },
   })

--- a/rcongui_public/src/i18n/locale-provider.tsx
+++ b/rcongui_public/src/i18n/locale-provider.tsx
@@ -27,6 +27,8 @@ dayjs.locale('en24h', {
   ...dayjs.Ls.en,
   formats: {
     ...dayjs.Ls.it.formats,
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
   },
 });
 

--- a/rcongui_public/src/i18n/locale-provider.tsx
+++ b/rcongui_public/src/i18n/locale-provider.tsx
@@ -22,6 +22,13 @@ dayjs.extend(localizedFormat);
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(localeData);
+// mix 'en' date related translations with 'it' date format
+dayjs.locale('en24h', {
+  ...dayjs.Ls.en,
+  formats: {
+    ...dayjs.Ls.it.formats,
+  },
+});
 
 interface LocaleContextType {
   globalLocaleData: dayjs.GlobalLocaleDataReturn;


### PR DESCRIPTION
Many people prefer english ingame, but are used to 24h DD MM YYYY format. 

Adds custom language 'en24h'

in i18n it acts exactly like 'en'

in dayjs it combines the 'en' translations for weekdays, months etc with the 'it' date format.