### PR TITLE
Trick JSON forms into rendering the admin ping settings correctly

### DIFF
--- a/rcon/user_config/log_line_webhooks.py
+++ b/rcon/user_config/log_line_webhooks.py
@@ -46,8 +46,8 @@ class LogLineWebhookUserConfig(BaseUserConfig):
 
             hook = DiscordMentionWebhook(
                 url=raw_webhook.get("url"),
-                user_mentions=raw_webhook.get("user_mentions"),
-                role_mentions=raw_webhook.get("role_mentions"),
+                user_mentions=raw_webhook.get("user_mentions", []),
+                role_mentions=raw_webhook.get("role_mentions", []),
             )
 
             log_types: list[AllLogTypes] = []

--- a/rcon/user_config/webhooks.py
+++ b/rcon/user_config/webhooks.py
@@ -51,14 +51,22 @@ class DiscordWebhook(pydantic.BaseModel):
 class DiscordMentionWebhook(DiscordWebhook):
     """A webhook URL and list of user/role IDs to mention in <@> and <@&> format"""
 
-    user_mentions: list[str] = pydantic.Field(default_factory=list)
-    role_mentions: list[str] = pydantic.Field(default_factory=list)
+    # The frontend uses the JSON schema and default values cause pydantic to not
+    # mark these as required, we handle this in the field validators by returning
+    # an empty list if we don't receive any items
+    user_mentions: list[str] = pydantic.Field()
+    role_mentions: list[str] = pydantic.Field()
 
     @pydantic.field_validator("user_mentions")
     @classmethod
-    def validate_user_formats(cls, vs: str) -> list[str]:
+    def validate_user_formats(cls, vs: list[str]) -> list[str]:
+        if not vs:
+            return []
+
         user_ids = set()
         for v in vs:
+            if not v:
+                continue
             if re.match(DISCORD_USER_ID_PATTERN, v):
                 user_ids.add(v)
             else:
@@ -67,9 +75,13 @@ class DiscordMentionWebhook(DiscordWebhook):
 
     @pydantic.field_validator("role_mentions")
     @classmethod
-    def validate_role_formats(cls, vs: str) -> list[str]:
+    def validate_role_formats(cls, vs: list[str]) -> list[str]:
+        if not vs:
+            return []
         role_ids = set()
         for v in vs:
+            if not v:
+                continue
             if re.match(DISCORD_ROLE_ID_PATTERN, v):
                 role_ids.add(v)
             else:

--- a/rcon/user_config/webhooks.py
+++ b/rcon/user_config/webhooks.py
@@ -147,8 +147,6 @@ class CameraWebhooksUserConfig(BaseMentionWebhookUserConfig):
 
 
 class AdminPingWebhooksUserConfig(BaseMentionWebhookUserConfig):
-    pass
-
     trigger_words: list[str] = pydantic.Field(default_factory=list)
 
     @pydantic.field_validator("trigger_words")
@@ -240,9 +238,9 @@ def parse_raw_mention_hooks(
 ) -> list["DiscordMentionWebhook"]:
     validated_hooks: list[DiscordMentionWebhook] = []
     for raw_hook in raw_hooks:
-        user_mentions = raw_hook.get("user_mentions")
+        user_mentions = raw_hook.get("user_mentions", [])
         user_ids = set(user_mentions)
-        role_mentions = raw_hook.get("role_mentions")
+        role_mentions = raw_hook.get("role_mentions", [])
         role_ids = set(role_mentions)
 
         h = DiscordMentionWebhook(

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -14,7 +14,9 @@ def test_no_mentions():
     config = ChatWebhooksUserConfig(
         hooks=[
             DiscordMentionWebhook(
-                url=HttpUrl("http://example.com"), user_mentions=["<@1212>"]
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1212>"],
+                role_mentions=[],
             )
         ],
         allow_mentions=True,
@@ -36,7 +38,9 @@ def test_chat_mentions_are_escaped():
     config = ChatWebhooksUserConfig(
         hooks=[
             DiscordMentionWebhook(
-                url=HttpUrl("http://example.com"), user_mentions=["<@1212>"]
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1212>"],
+                role_mentions=[],
             )
         ],
         allow_mentions=False,
@@ -74,7 +78,9 @@ def test_mentions_are_not_escaped():
     config = ChatWebhooksUserConfig(
         hooks=[
             DiscordMentionWebhook(
-                url=HttpUrl("http://example.com"), user_mentions=["<@1212>"]
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1212>"],
+                role_mentions=[],
             )
         ],
         allow_mentions=True,
@@ -98,7 +104,9 @@ def test_admin_pings_mention_start():
         trigger_words=["!admin"],
         hooks=[
             DiscordMentionWebhook(
-                url=HttpUrl("http://example.com"), user_mentions=["<@1212>"]
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1212>"],
+                role_mentions=[],
             )
         ],
     )
@@ -123,7 +131,9 @@ def test_admin_pings_mention_middle():
         trigger_words=["!admin"],
         hooks=[
             DiscordMentionWebhook(
-                url=HttpUrl("http://example.com"), user_mentions=["<@1212>"]
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1212>"],
+                role_mentions=[],
             )
         ],
     )
@@ -148,7 +158,9 @@ def test_admin_pings_contains_numbers():
         trigger_words=["testword123"],
         hooks=[
             DiscordMentionWebhook(
-                url=HttpUrl("http://example.com"), user_mentions=["<@1212>"]
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1212>"],
+                role_mentions=[],
             )
         ],
     )


### PR DESCRIPTION
The UI is using JSON forms to generate elements based off the Pydantic schema the user config models generate.

It was causing issues with the admin ping settings because it did not think that `user_mentions` and `role_mentions` were required items because we default those to empty lists on the backend.

This removes the defaults, but still allows the model to be instantiated without passing them (important for resetting or generating new blank configs) by creating an empty list if they aren't provided.

The UI would also pass empty `""` strings for user/role mentions if not provided, which would fail validation so we simply filter those out.