### PR TITLE
Readme   expired discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ An extended RCON tool for [Hell Let Loose](https://www.hellletloose.com/), meant
 🆘 If you're having an issue installing or using CRCON, [please read this](https://github.com/MarechJ/hll_rcon_tool/wiki/Troubleshooting-&-Help-%E2%80%90-Need-help-%3F-%E2%80%90-Report-an-issue) before asking for help on Discord.
 
 For feedback, troubleshooting and information about updates and general Hell Let Loose hosting info :  
-<https://discord.gg/r8v3TkPk>
+<https://discord.com/invite/hRS2tKH>
 
 ## Support and contribute
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ An extended RCON tool for [Hell Let Loose](https://www.hellletloose.com/), meant
 🆘 If you're having an issue installing or using CRCON, [please read this](https://github.com/MarechJ/hll_rcon_tool/wiki/Troubleshooting-&-Help-%E2%80%90-Need-help-%3F-%E2%80%90-Report-an-issue) before asking for help on Discord.
 
 For feedback, troubleshooting and information about updates and general Hell Let Loose hosting info :  
-<https://discord.com/invite/hRS2tKH>
+<https://discord.gg/hRS2tKH>
 
 ## Support and contribute
 


### PR DESCRIPTION
The Discord invite url I had expired.
I took the new one from [hllrcon.app](https://hllrcon.app/).