### PR TITLE
Maint/requirements daphne

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: '3.12'
       - name: install requirements
         run: |
-          pip install -r requirements.txt -r requirements-dev.txt --no-compile daphne
+          pip install -r requirements.txt -r requirements-dev.txt --no-compile
       - name: start dependencies
         run: docker compose -f docker-compose.dev.yml up -d postgres redis
       - name: run tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black==24.10.0
 isort==5.13.2
 pytest==8.3.4
 cachetools==5.5.0
+daphne==4.1.2


### PR DESCRIPTION
* Wiki has been updated to show the proper way to start `redis` and `postgres` with the local ports exposed so the Django web server can connect
* Add `daphne` to the dev requirements file
* Remove `daphne` from the github action PR; it shouldn't be required for running the tests.