### PR TITLE
UI: No players and gamestate is visible

### DIFF
--- a/rcongui/src/pages/views/live/index.jsx
+++ b/rcongui/src/pages/views/live/index.jsx
@@ -53,7 +53,7 @@ const Live = () => {
     if (!teamData) return [];
     return extractPlayers(teamData).map((player) => ({
       ...player,
-      profile: normalizePlayerProfile(player?.profile),
+      profile: normalizePlayerProfile(player?.profile ?? {}),
     }));
   }, [teamData]);
 

--- a/rcongui/src/queries/teams-live-query.jsx
+++ b/rcongui/src/queries/teams-live-query.jsx
@@ -12,7 +12,7 @@ export const teamsLiveQueryOptions = {
     // in case the API returns something different than what we expect
     const onlinePlayers = extractPlayers(data).map((player) => ({
       ...player,
-      profile: normalizePlayerProfile(player.profile),
+      profile: normalizePlayerProfile(player?.profile ?? {}),
     }));
     useGlobalStore.setState(() => ({ onlinePlayers }));
     return data;

--- a/rcongui/src/utils/lib.js
+++ b/rcongui/src/utils/lib.js
@@ -71,6 +71,8 @@ export const mapIdsToLayers = (layers, ids) => {
 };
 
 export const normalizePlayerProfile = (profile) => {
+  profile = profile ?? {};
+
   return {
     ...profile,
     received_actions: profile.received_actions ?? [],


### PR DESCRIPTION
When any player have `player.profile=null` it does not show players in the table nor the game state.
Solution: Update `normalizePlayerProfile` to handle `null` cases.