### PR TITLE
Include next_map_id in RCon chat commands to skip current map

### DIFF
--- a/rcon/message_variables.py
+++ b/rcon/message_variables.py
@@ -50,6 +50,7 @@ def populate_message_variables(
         MessageVariable.num_online_mods: lambda: str(len(online_mods())),
         MessageVariable.num_ingame_mods: lambda: str(len(ingame_mods())),
         MessageVariable.next_map: _next_map,
+        MessageVariable.next_map_id: _next_map_id,
         MessageVariable.map_rotation: _map_rotation,
         MessageVariable.top_kills_player_name: lambda: _generic_score_ties(
             stat_key=StatTypes.top_killers, tie_key="kills", result_key="player"
@@ -335,6 +336,12 @@ def _next_map(rcon: Rcon | None = None) -> str:
     if rcon is None:
         rcon = get_rcon()
     return rcon.get_next_map().pretty_name
+
+
+def _next_map_id(rcon: Rcon | None = None) -> str:
+    if rcon is None:
+        rcon = get_rcon()
+    return rcon.get_next_map().id
 
 
 def _map_rotation(rcon: Rcon | None = None):

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -47,6 +47,7 @@ class MessageVariable(enum.Enum):
     num_online_mods = "num_online_mods"
     num_ingame_mods = "num_ingame_mods"
     next_map = "next_map"
+    next_map_id = "next_map_id"
     map_rotation = "map_rotation"
 
     # Deprecated: Taken over from previous auto-broadcast implementation

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,7 @@
 import os
-from unittest import TestCase
+from unittest import TestCase, mock
+
+from rcon.maps import parse_layer
 
 os.environ["HLL_MAINTENANCE_CONTAINER"] = "1"
 from rcon.arguments import max_arg_index, replace_params
@@ -67,3 +69,7 @@ class ReplaceParamsTest(TestCase):
 
     def test_dict_with_nested_argument(self):
         assert replace_params(self.ctx, self.args, {"$4 ignored": "$2", "key": {"key2": "$3", "key3": "{player_name}"}}) == {"$4 ignored": "parameter2", "key": {"key2": "$3", "key3": "SOME_PLAYER_NAME"}}
+
+    @mock.patch("rcon.rcon.Rcon.get_next_map", autospec=True, return_value=parse_layer("stmariedumont_warfare"))
+    def test_with_message_variables(self, _):
+        assert replace_params(self.ctx, self.args, "{next_map_id}") == "stmariedumont_warfare"


### PR DESCRIPTION
This can be used in every place where message variables are supported. With this commit, these variables are now also available in rcon chat commands. Most of them are potentially pretty useless, however, the new next_map_id might be helpful for cases where one wants to easily skip the current map to the next one in rotation. Either on a public server or on an event server (where only one map is in the rotation).

A command config should look like this:
```
{
  "words": [
    "!test2"
  ],
  "description": "Testing layout",
  "commands": {
    "set_map": {
      "map_name": "{next_map_id}"
    }
  },
  "enabled": true,
  "conditions": {}
}
```