### PR TITLE
Fix: Add Churchill Mk.VII to British Weapon Definitions

### DIFF
--- a/rcon/weapons.py
+++ b/rcon/weapons.py
@@ -124,6 +124,7 @@ BRITISH_WEAPONS = {
     'COAXIAL M1919 [Firefly]': WeaponType.Armor,
     'OQF 75MM [Churchill Mk.VII]': WeaponType.Armor,
     'COAXIAL BESA 7.92mm [Churchill Mk.VII]': WeaponType.Armor,
+    'HULL BESA 7.92mm [Churchill Mk.VII]': WeaponType.Armor,
 }
 
 US_WEAPONS = {

--- a/rcon/weapons.py
+++ b/rcon/weapons.py
@@ -122,6 +122,8 @@ BRITISH_WEAPONS = {
     'HULL BESA [Cromwell]': WeaponType.Armor,
     'QF 17-POUNDER [Firefly]': WeaponType.Armor,
     'COAXIAL M1919 [Firefly]': WeaponType.Armor,
+    'OQF 75MM [Churchill Mk.VII]': WeaponType.Armor,
+    'COAXIAL BESA 7.92mm [Churchill Mk.VII]': WeaponType.Armor,
 }
 
 US_WEAPONS = {


### PR DESCRIPTION
This PR adds `OQF 75MM [Churchill Mk.VII]` and `COAXIAL BESA 7.92mm [Churchill Mk.VII]` to the `BRITISH_WEAPONS` const in `weapons.py`.

Fixes #903 