### PR TITLE
UI: Game Logs timezone, 24-hour format date pickers

### DIFF
--- a/rcongui/src/App.js
+++ b/rcongui/src/App.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import relativeTimePlugin from 'dayjs/plugin/relativeTime';
 import durationPlugin from 'dayjs/plugin/duration';
+import timezonePlugin from 'dayjs/plugin/timezone';
 import adminRouter from "./router"
 import { QueryClientProvider } from '@tanstack/react-query';
 import localforage from 'localforage';
@@ -19,7 +20,8 @@ const App = () => {
   dayjs.extend(relativeTimePlugin);
   dayjs.extend(durationPlugin);
   dayjs.extend(utc);
-
+  dayjs.extend(timezonePlugin);
+  
   // Configure LocalForage
   localforage.config({
     name: siteConfig.appName, // Name of the database

--- a/rcongui/src/components/form/core/ControlledDesktopDateTimePicker.jsx
+++ b/rcongui/src/components/form/core/ControlledDesktopDateTimePicker.jsx
@@ -28,6 +28,7 @@ export const ControlledDesktopDateTimePicker = ({
             inputRef={field.ref} // send input ref, so we can focus on input when error appear
             disabled={field.disabled}
             format='LLL'
+            ampm={false}
             {...props}
           />
         </LocalizationProvider>

--- a/rcongui/src/components/shared/card/LogsCard.jsx
+++ b/rcongui/src/components/shared/card/LogsCard.jsx
@@ -161,7 +161,7 @@ const LogsCard = ({ logs }) => {
                 <StyledListItem
                   key={index}
                 >
-                  <Box component="span" sx={{ width: 125, minWidth: 125 }}>{dayjs(log.timestamp).format(TIME_FORMAT)}</Box>
+                  <Box component="span" sx={{ width: 125, minWidth: 125 }}>{dayjs.utc(log.timestamp).tz(Intl.DateTimeFormat().resolvedOptions().timeZone).format(TIME_FORMAT)}</Box>
                   <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
                   <Message />
                 </StyledListItem>

--- a/rcongui/src/pages/records/game-logs/columns.jsx
+++ b/rcongui/src/pages/records/game-logs/columns.jsx
@@ -30,7 +30,7 @@ export const logsColumns = [
     header: SortableHeader("Time"),
     accessorKey: "event_time",
     cell: ({ row }) => {
-      return dayjs(row.original.event_time).format(TIME_FORMAT);
+      return dayjs.utc(row.original.event_time).tz(Intl.DateTimeFormat().resolvedOptions().timeZone).format(TIME_FORMAT);
     },
     meta: {
       variant: "time"

--- a/rcongui/src/pages/records/game-logs/index.jsx
+++ b/rcongui/src/pages/records/game-logs/index.jsx
@@ -42,6 +42,11 @@ import { DebouncedSearchInput } from "@/components/shared/DebouncedSearchInput";
 import downloadLogs from "./download";
 import DownloadIcon from "@mui/icons-material/Download";
 import { logActions } from "@/utils/lib";
+import timezonePlugin from "dayjs/plugin/timezone";
+import utcPlugin from "dayjs/plugin/utc";
+
+dayjs.extend(timezonePlugin);
+dayjs.extend(utcPlugin);
 
 /*
 IT'S POST REQUEST !!!
@@ -406,11 +411,12 @@ const GameLogsForm = ({ fields, onSubmit }) => {
 
             <LocalizationProvider dateAdapter={AdapterDayjs}>
               <DesktopDateTimePicker
-                value={formFields.from}
+                value={formFields?.from}
                 label="From time"
                 name="from"
                 onChange={handleDateChange("from")}
                 format="YYYY/MM/DD HH:mm"
+                ampm={false}
                 slotProps={{ textField: { fullWidth: true } }}
               />
             </LocalizationProvider>
@@ -421,7 +427,8 @@ const GameLogsForm = ({ fields, onSubmit }) => {
                 name="till"
                 onChange={handleDateChange("till")}
                 format="YYYY/MM/DD HH:mm"
-                value={formFields.till}
+                ampm={false}
+                value={formFields?.till}
                 slotProps={{ textField: { fullWidth: true } }}
               />
             </LocalizationProvider>

--- a/rcongui/src/pages/records/players/index.jsx
+++ b/rcongui/src/pages/records/players/index.jsx
@@ -330,7 +330,7 @@ export default function PlayersRecords() {
                 label="Last seen from"
                 name="last_seen_from"
                 format="MMMM DD, YYYY HH:mm"
-                timezone="UTC"
+                ampm={false}
                 slotProps={{
                   textField: { fullWidth: true },
                 }}
@@ -349,7 +349,7 @@ export default function PlayersRecords() {
                 label="Last seen till"
                 name="last_seen_till"
                 format="MMMM DD, YYYY HH:mm"
-                timezone="UTC"
+                ampm={false}
                 slotProps={{
                   textField: { fullWidth: true },
                 }}


### PR DESCRIPTION
- Add timezone plugin to dayjs in App.js and game-logs page
- Modify date-time pickers to use 24-hour format (ampm=false)
- Update game logs column to convert event time to local timezone
- Remove explicit UTC timezone setting in players records page