### PR TITLE
Hotfix/webhook service

### DIFF
--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -6,7 +6,7 @@ services:
     command: redis-server /usr/local/etc/redis/redis.conf
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      test: [ "CMD-SHELL", "redis-cli ping | grep PONG" ]
       interval: 15s
       timeout: 30s
       retries: 5
@@ -15,6 +15,8 @@ services:
       - ./config:/usr/local/etc/redis
     networks:
       - common
+    ports:
+      - 127.0.0.1:${HLL_REDIS_HOST_PORT:-6379}:6379
   postgres:
     image: ${POSTGRES_IMAGE}
     environment:
@@ -27,8 +29,7 @@ services:
       HLL_DB_USER: ${HLL_DB_USER}
     restart: always
     healthcheck:
-      test:
-        ["CMD", "pg_isready", "-U", "${HLL_DB_USER}", "-d", "${HLL_DB_NAME}"]
+      test: [ "CMD", "pg_isready", "-U", "${HLL_DB_USER}", "-d", "${HLL_DB_NAME}" ]
       interval: 15s
       timeout: 30s
       retries: 5
@@ -55,11 +56,7 @@ services:
     command: maintenance
     restart: always
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "if [ -e /code/maintenance-container-healthy ]; then echo 0; else echo 1; fi",
-        ]
+      test: [ "CMD-SHELL", "if [ -e /code/maintenance-container-healthy ]; then echo 0; else echo 1; fi" ]
       start_period: 30s
       interval: 15s
       timeout: 30s
@@ -95,13 +92,9 @@ services:
       HLL_WH_SERVICE_RL_TIME_WINDOW: ${HLL_WH_SERVICE_RL_TIME_WINDOW}
       HLL_WH_MAX_QUEUE_LENGTH: ${HLL_WH_MAX_QUEUE_LENGTH}
     command: webhook_service
-    restart: no
+    restart: always
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "if [ -e /code/webhook-service-healthy ]; then echo 0; else echo 1; fi",
-        ]
+      test: [ "CMD-SHELL", "if [ -e /code/webhook-service-healthy ]; then echo 0; else echo 1; fi" ]
       start_period: 30s
       interval: 15s
       timeout: 30s

--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -15,8 +15,6 @@ services:
       - ./config:/usr/local/etc/redis
     networks:
       - common
-    ports:
-      - 127.0.0.1:${HLL_REDIS_HOST_PORT:-6379}:6379
   postgres:
     image: ${POSTGRES_IMAGE}
     environment:

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -106,6 +106,7 @@ class DiscordErrorResponse(TypedDict):
 
     http_401: bool
     http_403: bool
+    http_404: bool
 
 
 class WebhookMessageType(StrEnum):
@@ -358,6 +359,7 @@ def set_webhook_error(
     webhook_type: WebhookType,
     auth_401: bool = False,
     auth_403: bool = False,
+    _404: bool = False,
     prefix: str = WEBHOOK_ERRORS,
 ):
     """Store the last error received for a webhook; cleared after a successful request"""
@@ -366,6 +368,7 @@ def set_webhook_error(
     payload: DiscordErrorResponse = {
         "http_401": int(auth_401),  # type: ignore
         "http_403": int(auth_403),  # type: ignore
+        "http_404": int(_404),  # type: ignore
     }
     red.hset(key, mapping=payload)  # type: ignore
 
@@ -383,6 +386,7 @@ def get_webhook_error(
     values: DiscordErrorResponse = {
         "http_401": True if raw.get(b"http_401") == b"1" else False,
         "http_403": True if raw.get(b"http_403") == b"1" else False,
+        "http_404": True if raw.get(b"http_404") == b"1" else False,
     }
     return values
 
@@ -460,6 +464,25 @@ async def dequeue_message(
         else:
             res: httpx.Response = await wh.execute(client=client)  # type: ignore
 
+        # If a webhook ID is incorrect it will return 401 which we already handle
+        # but if a message ID doesn't exist it will return 404 and not have rate
+        # limit headers
+        # Technically we could make this fixable and re-enqueue the messages but
+        # the only thing we do edits for are the scoreboard and those messages
+        # are inherently transient; so we will set the error status for the webhook ID
+        # and drop the message
+        if res.status_code == 404:
+            set_webhook_error(
+                red=red,
+                webhook_id=wh.webhook_id,
+                webhook_type=message.webhook_type,
+                _404=True,
+            )
+            logger.error(
+                f"Received HTTP 404 from the webhook with webhook ID: {message.payload.get('webhook_id')} message ID: {message.payload.get('message_id')} discarding the message"
+            )
+            return
+
         bucket_data.webhook_type = message.webhook_type
         bucket_data.id = res.headers[X_RATELIMIT_BUCKET]
         bucket_data.remaining_requests = int(res.headers[X_RATELIMIT_REMAINING])
@@ -467,9 +490,6 @@ async def dequeue_message(
         bucket_data.reset_timestamp = math.ceil(
             datetime.now().timestamp() + bucket_data.reset_after_secs
         )
-
-        bucket_id = bucket_data.id[-4:] if bucket_data and bucket_data.id else "N/A"
-        rem_reqs = bucket_data.remaining_requests if bucket_data else None
 
         if lock == get_shared_lock():
             # Once we get a response for a webhook we know what rate limit bucket it's in and we can

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -31,7 +31,6 @@ logger = getLogger(__name__)
 # new ones, so we can't use it for scorebot yet
 
 PREFIX = "whs"
-QUEUE_IDS = f"{PREFIX}:queue_ids"
 BUCKET_ID = f"{PREFIX}"
 WH_ID_TO_RATE_LIMIT_BUCKET = f"{PREFIX}:wh_id_rl_bucket"
 BUCKET_RL = f"{PREFIX}:rl"
@@ -403,10 +402,7 @@ def clear_webhook_errors(
 
 
 def enqueue_message(
-    message: WebhookMessage,
-    red: redis.StrictRedis | None = None,
-    prefix: str = PREFIX,
-    queue_ids_key: str = QUEUE_IDS,
+    message: WebhookMessage, red: redis.StrictRedis | None = None, prefix: str = PREFIX
 ):
     """Accept a WebhookMessage and insert it in Redis
 
@@ -424,14 +420,9 @@ def enqueue_message(
 
     # Because we use lists; each type of message gets its own queue so that we can
     # more efficiently purge types of messages (for instance all kill log lines)
-    # without having to decode every element in a list which might be thousands
+    # without having to scan/decode every element in a list which might be thousands
     # of elements long
     queue_id = f"{prefix}:{get_server_number()}:{message.webhook_type}:{message.message_type}:{message.payload['webhook_id']}"
-    # Add this queue ID to our set of queue IDs so it can be selected later without SCANning
-    # TODO: This set never has elements removed from it, people do not often change webhooks
-    # so it is inherently going to stay relatively small but we should add a way to
-    # trim deprecated keys
-    red.sadd(queue_ids_key, queue_id)
     red.rpush(queue_id, orjson.dumps(message.model_dump_json()))
 
 
@@ -591,31 +582,34 @@ async def dequeue_message(
 
 
 def get_all_queue_keys(
-    red: redis.StrictRedis | None = None, queue_id_keys: str = QUEUE_IDS
+    red: redis.StrictRedis | None = None, prefix: str = PREFIX
 ) -> list[str]:
-    """Retrieve every queue key in redis from our queue ID set"""
+    """Retrieve every queue key in redis that matches the service prefix"""
     logger.debug("Getting all queue IDs from %s", PREFIX)
     if red is None:
         red = get_redis_client(decode_responses=False, global_pool=True)
 
-    return [q.decode() for q in red.smembers(queue_id_keys)]  # type: ignore
+    queue_ids: list[str] = [
+        queue_id.decode()
+        for queue_id in red.scan_iter(match=f"{prefix}*", _type="list")
+    ]
+    return queue_ids
 
 
 def get_all_queue_keys_and_lengths(
-    red: redis.StrictRedis, queue_id_keys: str = QUEUE_IDS
+    red: redis.StrictRedis, prefix: str = PREFIX
 ) -> list[tuple[str, int]]:
     """Return each queue key and the number of elements in its queue"""
-    return [(queue_id, red.llen(queue_id)) for queue_id in get_all_queue_keys(red=red, queue_id_keys=queue_id_keys)]  # type: ignore
+    return [(queue_id, red.llen(queue_id)) for queue_id in get_all_queue_keys(red=red, prefix=prefix)]  # type: ignore
 
 
 def get_all_queue_keys_not_empty(
-    red: redis.StrictRedis,
-    queue_id_keys: str = QUEUE_IDS,
+    red: redis.StrictRedis, prefix: str = PREFIX
 ) -> list[str]:
-    """Return all queues with elements from the set of queue_id_keys"""
+    """Scan for all the queues (identified by prefix)"""
     logger.debug("Getting all queue IDs with items from %s", PREFIX)
 
-    return [queue_id for queue_id in get_all_queue_keys(red=red, queue_id_keys=queue_id_keys) if red.llen(queue_id) > 0]  # type: ignore
+    return [queue_id for queue_id in get_all_queue_keys(red=red, prefix=prefix) if red.llen(queue_id) > 0]  # type: ignore
 
 
 def get_queue_overview(


### PR DESCRIPTION
* Set the webhook service to always restart
* Correct our `SCAN` method to use `scan_iter`; previously we were not updating the cursor and always scanning from the same starting location which would fail when not all of the keys could be returned in one pass
* Handle HTTP 404 errors for non-existent messages