### PR TITLE
Test for presence of scoreboard volume on startup

### DIFF
--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -31,6 +31,7 @@ from rcon.webhook_service import (
     WebhookMessageType,
     WebhookType,
     enqueue_message,
+    get_message_edit_404_failure,
 )
 
 if TYPE_CHECKING:
@@ -425,10 +426,13 @@ def send_message(
 ):
     wh.message_id = message_id
     wh.add_embed(embed)
-    # When a message doesn't exist; or we have no message IDs we have to
-    # create/send one; persist the ID and then enqueue future updates
-    # through the webhook service
-    if not message_id or not wh.message_exists():
+
+    # Check if the WH has flagged this as a bad (HTTP 404) message ID
+    # or if we don't have a message ID in the database
+    # The first run through when a message is deleted will cause a 404
+    # but subsequent sends should create a new one and this avoids us having to
+    # make a synch GET request to Discord for every message we want to send
+    if not message_id or get_message_edit_404_failure(message_id=message_id):
         message_id = create_initial_message(url=wh.url, embed=embed)
         save_message_id(
             session=session,

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -53,11 +53,6 @@ MESSAGE_KEYS = (
 )
 SERVER_NUMBER = int(get_server_number())
 
-DB_PATH = pathlib.Path("./scoreboard.db")
-ENGINE: Engine = create_engine(
-    f"sqlite:///file:{DB_PATH}?mode=rwc&uri=true", echo=False
-)
-
 
 class Base(DeclarativeBase):
     pass
@@ -464,13 +459,13 @@ def run():
 
     try:
         if config.public_scoreboard_url is None:
-            logger.error(
+            logger.fatal(
                 "Your Public Scoreboard URL is not configured, set it and restart the Scoreboard service."
             )
             sys.exit(-1)
 
         if not config.hooks:
-            logger.error(
+            logger.fatal(
                 "You do not have any Discord webhooks configured, set some and restart the Scoreboard service."
             )
             sys.exit(-1)
@@ -572,6 +567,19 @@ def run():
 
 
 if __name__ == "__main__":
+    VOLUME_PATH = pathlib.Path("/scoreboard_db")
+
+    if not VOLUME_PATH.exists():
+        logger.fatal(
+            "Your scoreboard volume is not configured correctly in your compose.yaml file."
+        )
+        sys.exit(-1)
+
+    DB_PATH = pathlib.Path("/scoreboard_db") / pathlib.Path("./scoreboard.db")
+    ENGINE: Engine = create_engine(
+        f"sqlite:///file:{DB_PATH}?mode=rwc&uri=true", echo=False
+    )
+
     try:
         logger.info("Attempting to start scorebot")
         Base.metadata.create_all(ENGINE)

--- a/rcon/user_config/scoreboard.py
+++ b/rcon/user_config/scoreboard.py
@@ -89,7 +89,6 @@ class ScoreboardConfigType(TypedDict):
     # Map Rotation (own message)
     map_rotation_include_server_name: bool
     map_rotation_time_between_refreshes: int
-    show_map_rotation: bool
     current_map_format: str
     next_map_format: str
     other_map_format: str
@@ -255,53 +254,112 @@ def seed_default_player_stat_displays():
 
 class ScoreboardUserConfig(BaseUserConfig):
     # TODO: update descriptions
-    public_scoreboard_url: HttpUrl | None = Field(default=None)
-    hooks: list[DiscordWebhook] = Field(default_factory=list)
+    public_scoreboard_url: HttpUrl | None = Field(
+        default=None, description="The URL of your public scoreboard/stats site"
+    )
+    hooks: list[DiscordWebhook] = Field(
+        default_factory=list,
+        description="The Discord webhooks to post the scoreboard to",
+    )
 
-    header_gamestate_enabled: bool = Field(default=True)
-    map_rotation_enabled: bool = Field(default=True)
-    player_stats_enabled: bool = Field(default=True)
+    header_gamestate_enabled: bool = Field(
+        default=True, description="Enable/disable the header/gamestate overview message"
+    )
+    map_rotation_enabled: bool = Field(
+        default=True, description="Enable/disable the map rotation message"
+    )
+    player_stats_enabled: bool = Field(
+        default=True, description="Enable/disable the player stats message"
+    )
 
-    footer_last_refreshed_text: str = Field(default="Last Refreshed")
+    footer_last_refreshed_text: str = Field(
+        default="Last Refreshed",
+        description="The text in each message footer showing the last time the message was updated",
+    )
 
     # Header / Gamestate (own message)
-    header_gamestate_include_server_name: bool = Field(default=True)
-    header_gamestate_time_between_refreshes: int = Field(default=5)
-    quick_connect_url: AnyUrl | None = Field(default=None)
-    battlemetrics_url: HttpUrl | None = Field(default=None)
-    show_map_image: bool = Field(default=True)
-    objective_score_format_generic: str = Field(default="Allied {0}: Axis {1}")
+    header_gamestate_include_server_name: bool = Field(
+        default=True,
+        description="Whether to include the server name in the title of the message",
+    )
+    header_gamestate_time_between_refreshes: int = Field(
+        default=5, description="How often (in seconds) to send updates to Discord"
+    )
+    quick_connect_url: AnyUrl | None = Field(
+        default=None, description="The steam quick connect URL for your game server"
+    )
+    battlemetrics_url: HttpUrl | None = Field(
+        default=None, description="A link to your servers page on BattleMetrics"
+    )
+    show_map_image: bool = Field(
+        default=True, description="Enable/disable the image of the current map"
+    )
+    objective_score_format_generic: str = Field(
+        default="Allied {0}: Axis {1}",
+        description="A fallback format for showing the current objective score",
+    )
     objective_score_format_ger_v_us: str = Field(
-        default="<:icoT_US:1060219985215094804> {0} : <:icoT_GER:1060219972871278602> {1}"
+        default="<:icoT_US:1060219985215094804> {0} : <:icoT_GER:1060219972871278602> {1}",
+        description="US versus German emojis",
     )
     objective_score_format_ger_v_sov: str = Field(
-        default="<:icoT_RUS:1060217170455433286> {0} : <:icoT_GER:1060219972871278602> {1}"
+        default="<:icoT_RUS:1060217170455433286> {0} : <:icoT_GER:1060219972871278602> {1}",
+        description="Soviet versus German emojis",
     )
     objective_score_format_ger_v_uk: str = Field(
-        default="<:icoT_UK:1114060867068235807> {0} : <:icoT_GER:1060219972871278602> {1}"
+        default="<:icoT_UK:1114060867068235807> {0} : <:icoT_GER:1060219972871278602> {1}",
+        description="UK versus German emojis",
     )
     header_gamestate_embeds: list[HeaderGameStateEmbedConfig] = Field(
-        default_factory=seed_default_header_gamestate_displays
+        default_factory=seed_default_header_gamestate_displays,
+        description="A list of the fields to include in the header/gamestate message; use `EMPTY` to help space them as desired.",
     )
 
     # Map Rotation (own message)
-    map_rotation_include_server_name: bool = Field(default=True)
-    map_rotation_time_between_refreshes: int = Field(default=30)
-    show_map_rotation: bool = Field(default=True)
-    current_map_format: str = Field(default="🟩 {1}. **{0}**")
-    next_map_format: str = Field(default="🟨 {1}. {0}")
-    other_map_format: str = Field(default="⬛ {1}. {0}")
-    show_map_legend: bool = Field(default=True)
-    map_rotation_title_text: str = Field(default="Map Rotation")
-    map_legend: str = Field(default=MAP_LEGEND)
+    map_rotation_include_server_name: bool = Field(
+        default=True,
+        description="Whether to include the server name in the title of the map rotation message",
+    )
+    map_rotation_time_between_refreshes: int = Field(
+        default=30, description="How often (in seconds) to send updates to Discord"
+    )
+    current_map_format: str = Field(
+        default="🟩 {1}. **{0}**",
+        description="How to format the current map in Discord",
+    )
+    next_map_format: str = Field(
+        default="🟨 {1}. {0}", description="How to format the next map in Discord"
+    )
+    other_map_format: str = Field(
+        default="⬛ {1}. {0}",
+        description="How to format any map that isn't the next or current in Discord",
+    )
+    show_map_legend: bool = Field(
+        default=True, description="Enable/disable the map rotation legend"
+    )
+    map_rotation_title_text: str = Field(
+        default="Map Rotation", description="The title of the map rotation message"
+    )
+    map_legend: str = Field(
+        default=MAP_LEGEND,
+        description="The text to show when the map rotation legend is enabled",
+    )
 
     # Player Stats (own message)
-    player_stats_include_server_name: bool = Field(default=True)
+    player_stats_include_server_name: bool = Field(
+        default=True,
+        description="Whether to include the server name in the title of the player stats message",
+    )
     player_stats_title_text: str = Field(default="Player Stats")
-    player_stats_time_between_refreshes: int = Field(default=5)
-    player_stats_num_to_display: int = Field(default=5)
+    player_stats_time_between_refreshes: int = Field(
+        default=5, description="How often (in seconds) to send updates to Discord"
+    )
+    player_stats_num_to_display: int = Field(
+        default=5, ge=1, description="How many players to show per stat type"
+    )
     player_stat_embeds: list[PlayerStatEmbedConfig] = Field(
-        default_factory=seed_default_player_stat_displays
+        default_factory=seed_default_player_stat_displays,
+        description="A list of the fields to include in player stats message; use `EMPTY` to help space them as desired.",
     )
 
     @field_serializer("quick_connect_url", "battlemetrics_url", "public_scoreboard_url")
@@ -373,7 +431,6 @@ class ScoreboardUserConfig(BaseUserConfig):
             map_rotation_time_between_refreshes=values.get(
                 "map_rotation_time_between_refreshes"
             ),
-            show_map_rotation=values.get("show_map_rotation"),
             current_map_format=values.get("current_map_format"),
             next_map_format=values.get("next_map_format"),
             other_map_format=values.get("other_map_format"),

--- a/rcon/user_config/scoreboard.py
+++ b/rcon/user_config/scoreboard.py
@@ -3,7 +3,14 @@ from enum import StrEnum
 from logging import getLogger
 from typing import Final, Literal, Optional, Self, TypedDict
 
-from pydantic import BaseModel, Field, HttpUrl, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    HttpUrl,
+    field_serializer,
+    field_validator,
+    AnyUrl,
+)
 
 from rcon.types import PlayerStatsEnum
 from rcon.user_config.legacy_scorebot import ScorebotUserConfig
@@ -247,6 +254,7 @@ def seed_default_player_stat_displays():
 
 
 class ScoreboardUserConfig(BaseUserConfig):
+    # TODO: update descriptions
     public_scoreboard_url: HttpUrl | None = Field(default=None)
     hooks: list[DiscordWebhook] = Field(default_factory=list)
 
@@ -259,7 +267,7 @@ class ScoreboardUserConfig(BaseUserConfig):
     # Header / Gamestate (own message)
     header_gamestate_include_server_name: bool = Field(default=True)
     header_gamestate_time_between_refreshes: int = Field(default=5)
-    quick_connect_url: HttpUrl | None = Field(default=None)
+    quick_connect_url: AnyUrl | None = Field(default=None)
     battlemetrics_url: HttpUrl | None = Field(default=None)
     show_map_image: bool = Field(default=True)
     objective_score_format_generic: str = Field(default="Allied {0}: Axis {1}")


### PR DESCRIPTION
* Checks for the presence of the scoreboard volume on startup and log/exit if it isn't present. 
  * This makes defining the volume in the `compose.yaml` file mandatory now.
* Handles HTTP 404 errors (message edits) more gracefully and will purge the message queue of remaining messages on failure
* Properly accept steam quick connect URLs for the scoreboard
* Include descriptions in the scoreboard fields
* Remove `show_map_rotation` field which was unused (superseded by a different field anyway)

I tested locally and made sure that the volume is accessible on the host file system and that data is still persisted even when the container is torn down/created again.

