### PR TITLE
Fix admin player ID registration bugs

### DIFF
--- a/rconweb/api/apps.py
+++ b/rconweb/api/apps.py
@@ -1,6 +1,18 @@
 from django.apps import AppConfig
+from rcon.cache_utils import invalidates
 
 
-# TODO: this isn't used anywhere
 class ApiConfig(AppConfig):
     name = "api"
+
+    def ready(self):
+        from rcon.audit import set_registered_mods
+
+        # Can't import from rconweb.api until Django is ready
+        from .auth import get_moderators_accounts
+
+        # Invalidate the cache on start up because you can modify Django
+        # records while CRCON is offline (through the CLI, etc.)
+        with invalidates(get_moderators_accounts):
+            # Register active admin accounts on startup for the ingame/online mods feature
+            set_registered_mods(get_moderators_accounts())


### PR DESCRIPTION
This fixes two separate issues with admin accounts that are associated with player ID records.

Django accounts that are associated with a player ID are used for the in game/online (logged into CRCON) features which can be used in various places such as automatically enabling/disabling player vote kicks in game.

CRCON users can mark Django accounts as either `active` or not; however previously we would register *all* Django accounts with a player ID; regardless of their active status.

This means that people with disabled but not deleted accounts would still be counted in game.

* Only register mods where the account `is_active`

The second issue is that the call to get registered mods was cached for `1 hour` but not invalidated anywhere. The update calls were used anytime a `User` or `SteamPlayer` model instance was modified, but it would take up to `1 hour` for this effect to be noticed.

It's also possible (but unlikely) that people are modifying accounts outside of the Django admin site; such as through the Django Python shell and when that happens the cache isn't invalidated either; so the cache is invalidated on startup.

* Invalidate `get_moderators_accounts` on startup and whenever a record is modified