### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-compile --no-cache-dir
 RUN pip install gunicorn daphne supervisor --no-compile --no-cache-dir
 COPY . .
-ENV PYTHONPATH /code/
+ENV PYTHONPATH=/code/
 RUN chmod +x entrypoint.sh
 RUN chmod +x manage.py
 RUN chmod +x rconweb/manage.py


### PR DESCRIPTION
`docker buildx bake` will throw these errors when used:

```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
```

* Updates Dockerfile to remove the legacy `ENV` format

This allows us to use newer build tools and there should be no downsides.