### PR TITLE
Hotfix/webhook service loop

### DIFF
--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -93,7 +93,7 @@ services:
       HLL_WH_SERVICE_RL_TIME_WINDOW: ${HLL_WH_SERVICE_RL_TIME_WINDOW}
       HLL_WH_MAX_QUEUE_LENGTH: ${HLL_WH_MAX_QUEUE_LENGTH}
     command: webhook_service
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: [ "CMD-SHELL", "if [ -e /code/webhook-service-healthy ]; then echo 0; else echo 1; fi" ]
       start_period: 30s
@@ -109,3 +109,8 @@ services:
       - ./logs:/logs/
     networks:
       - common
+    # This is not a CPU intensive container; but
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -30,7 +30,7 @@ from rcon.webhook_service import (
     WebhookMessage,
     WebhookMessageType,
     WebhookType,
-    enqueue_message,
+    enqueue_scoreboard_message,
     get_message_edit_404_failure,
 )
 
@@ -442,7 +442,7 @@ def send_message(
         )
     else:
         logger.info(f"enqueuing {wh.message_id=} {key=}")
-        enqueue_message(
+        enqueue_scoreboard_message(
             message=WebhookMessage(
                 discardable=True,
                 edit=True,
@@ -450,7 +450,8 @@ def send_message(
                 message_type=WebhookMessageType.SCOREBOARD,
                 server_number=SERVER_NUMBER,
                 payload=wh.json,
-            )
+            ),
+            message_key=key,
         )
 
 

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -30,7 +30,7 @@ from rcon.webhook_service import (
     WebhookMessage,
     WebhookMessageType,
     WebhookType,
-    enqueue_scoreboard_message,
+    enqueue_transient_message,
     get_message_edit_404_failure,
 )
 
@@ -442,7 +442,7 @@ def send_message(
         )
     else:
         logger.info(f"enqueuing {wh.message_id=} {key=}")
-        enqueue_scoreboard_message(
+        enqueue_transient_message(
             message=WebhookMessage(
                 discardable=True,
                 edit=True,
@@ -451,7 +451,7 @@ def send_message(
                 server_number=SERVER_NUMBER,
                 payload=wh.json,
             ),
-            message_key=key,
+            message_group_key=key,
         )
 
 

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -65,7 +65,7 @@ except (ValueError, TypeError):
     LOCAL_RL_RESET_AFTER = 3
 
 try:
-    LOCAL_RL_REQUESTS_PER = os.getenv("HLL_WH_SERVICE_RL_REQUESTS_PER", 5)
+    LOCAL_RL_REQUESTS_PER = int(os.getenv("HLL_WH_SERVICE_RL_REQUESTS_PER", 5))
 except (ValueError, TypeError):
     LOCAL_RL_REQUESTS_PER = 5
 

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -614,6 +614,7 @@ async def dequeue_message(
                 res.status_code,
                 message.model_dump(),
             )
+            return
 
         bucket_data.webhook_type = message.webhook_type
         bucket_data.id = res.headers[X_RATELIMIT_BUCKET]

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -366,7 +366,8 @@ def get_webhook_rate_limit_bucket(
     # between services once we expand to support other webhook types than Discord
     # but for now to simplify the service without having to pass in details
     # of the message that we don't know when we GET it, skip the webhook type
-    return red.hget(hash_name, f"{queue_id}")  # type: ignore
+    res: bytes = red.hget(hash_name, f"{queue_id}")  # type: ignore
+    return res.decode()
 
 
 def set_webhook_rate_limit_bucket(

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -638,7 +638,8 @@ async def dequeue_message(
         # we encounter an unknown status code so we can update this appropriately
         if res.status_code not in (200, 401, 403, 429):
             logger.error(
-                "Received HTTP %s from Discord: %s",
+                "Received HTTP %s from Discord, headers:%s: %s",
+                res.headers,
                 res.status_code,
                 message.model_dump(),
             )

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -369,7 +369,11 @@ def set_rate_limit_bucket_data(
     red: redis.StrictRedis, bucket: DiscordRateLimitData, prefix: str = BUCKET_ID
 ) -> None:
     """Set the data for a specific rate limit bucket"""
-    name = f"{prefix}:{bucket.webhook_type}:{bucket.id}"
+    # There is a very low but non 0 chance of colliding on rate limit bucket IDs
+    # between services once we expand to support other webhook types than Discord
+    # but for now to simplify the service without having to pass in details
+    # of the message that we don't know when we GET it, skip the webhook type
+    name = f"{prefix}:{bucket.id}"
     red.set(name, orjson.dumps(bucket.model_dump_json()))
 
 

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -543,6 +543,10 @@ async def dequeue_message(
             # Old style messages may still be in the redis queue and we can't GET those
             try:
                 raw_message: bytes = red.get(queue_id)  # type: ignore
+                # If we don't get a message at all; return
+                # this is validated by Pydantic later
+                if raw_message is None:
+                    return
                 red.delete(queue_id)
             except redis.exceptions.ResponseError:
                 # If we don't remove this; it will be stuck in the queue and block it forever

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -659,10 +659,10 @@ async def dequeue_message(
             logger.debug("Created %s for %s", lock, queue_id)
 
         if res.status_code == 429:
+            bucket_data.rate_limited = True
             update_bucket_rate_limit(
                 red=red, bucket_id=bucket_data.id, webhook_type=message.webhook_type
             )
-            bucket_data.rate_limited = True
             body = res.json()
             if body.get("global"):
                 # We're globally rate limited, parse out the relevant data and set it


### PR DESCRIPTION
tl;dr Treating the scoreboard messages as queue-able messages was a mistake; there is 0 value in older messages unlike things like audit or team kill ones. This converts those style messages to key/value pairs instead of a queue so we only store the most recent one.

Thanks to the fine people over at Independent Contractors (IC) I was able to test this fix on a CRCON install with 6 servers and it seems to be working much better.

* Change the webhook service restart policy from `always` to `unless-stopped` to allow people to turn it off if they desire
* Change the scoreboard messages from being a queue to being simple key/value pairs in Redis so that we only store the most recently queued update
* Change the sleep times to `0`; specifying a sleep time can prevent larger numbers of queues from being able to empty faster than they can be filled
* Limit the webhook service to use `1` CPU core; it is inherently limited by (relatively) slow network processes; this helps mitigate the CPU usage from looping so frequently from the sleep change
* Updates `get_webhook_service_summary` to account for the scoreboard message change and also includes those messages now
* Adds more HTTP error handling; we handle certain HTTP errors specifically (`400`, `401`, `403`, `404`, `429`) but back out early otherwise (for instance `500` series codes when Discord is having issues

There are still other things that we could do in the future to improve this; first and foremost refactoring this into something that handles this style of program better than Python, or using some other better message queue framework that would allow us to `block` until a message is received; start a task for that message and then `block` again.

That would prevent CPU utilization from being wasted simply looping waiting for a message to be enqueued; especially on empty servers.