### PR TITLE
align virtual match end and lookout for two MATCH STARTs to the same …

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -322,7 +322,9 @@ def handle_new_match_start(rcon: Rcon, struct_log):
             if maps_history[0]["end"] is None and maps_history[0]["name"]:
                 maps_history.save_map_end(
                     old_map=maps_history[0]["name"],
-                    end_timestamp=int(struct_log["timestamp_ms"] / 1000) - 100,
+                    # after a match ended and a new match started, there is a cooldown of 2 minutes, where stats are shown,
+                    # etc. Apply this as the most likely match end time.
+                    end_timestamp=int(struct_log["timestamp_ms"] / 1000) - 120,
                 )
 
         maps_history.save_new_map(

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -322,9 +322,7 @@ def handle_new_match_start(rcon: Rcon, struct_log):
             if maps_history[0]["end"] is None and maps_history[0]["name"]:
                 maps_history.save_map_end(
                     old_map=maps_history[0]["name"],
-                    # after a match ended and a new match started, there is a cooldown of 2 minutes, where stats are shown,
-                    # etc. Apply this as the most likely match end time.
-                    end_timestamp=int(struct_log["timestamp_ms"] / 1000) - 120,
+                    end_timestamp=int(struct_log["timestamp_ms"] / 1000),
                 )
 
         maps_history.save_new_map(

--- a/rcon/workers.py
+++ b/rcon/workers.py
@@ -160,8 +160,9 @@ def record_stats_from_map(
     match_started = get_historical_logs_records(
         sess,
         from_=map_.start,
-        # to catch the possibly second MATCH START event, add a random 30 seconds to the end date of the match
-        till=map_.end + datetime.timedelta(seconds=30),
+        # to catch the possibly second MATCH START event, add 2 minutes (cooldown after a match ended in-game, where stats
+        # are shown) + 10 seconds random margin to make sure the next game started.
+        till=map_.end + datetime.timedelta(seconds=130),
         time_sort="asc",
         action="MATCH STARTED",
         exact_action=True,

--- a/rcon/workers.py
+++ b/rcon/workers.py
@@ -160,9 +160,9 @@ def record_stats_from_map(
     match_started = get_historical_logs_records(
         sess,
         from_=map_.start,
-        # to catch the possibly second MATCH START event, add 2 minutes (cooldown after a match ended in-game, where stats
-        # are shown) + 10 seconds random margin to make sure the next game started.
-        till=map_.end + datetime.timedelta(seconds=130),
+        # to catch the possibly second MATCH START event. The match end will be the time of the MATCH START event, 30 seconds
+        # is just a random safety margin.
+        till=map_.end + datetime.timedelta(seconds=30),
         time_sort="asc",
         action="MATCH STARTED",
         exact_action=True,


### PR DESCRIPTION
…timeframe

This should fix cases where a match was ended by a set_game_layout call, and where stats were not calculated as there is no MATCH END event and no MATCH START event in the timeframe where we were looking before.