### PR TITLE
Split the docker build github action into frontend/backend

### DIFF
--- a/.github/workflows/.github/workflows/docker-images-frontend.yml
+++ b/.github/workflows/.github/workflows/docker-images-frontend.yml
@@ -1,0 +1,39 @@
+name: build-docker-images-frontend
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push frontend
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile-frontend
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            cericmathey/hll_rcon_tool_frontend:${{  github.ref_name }}
+            ${{ contains(github.ref_name, 'rc') && '' || 'cericmathey/hll_rcon_tool_frontend:latest' }}
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        if: ${{ ! contains(github.ref_name, 'rc') }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool_frontend

--- a/.github/workflows/docker-images-backend.yml
+++ b/.github/workflows/docker-images-backend.yml
@@ -29,16 +29,6 @@ jobs:
           tags: |
             cericmathey/hll_rcon_tool:${{  github.ref_name }}
             ${{ contains(github.ref_name, 'rc') && '' || 'cericmathey/hll_rcon_tool:latest' }}
-      - name: Build and push frontend
-        uses: docker/build-push-action@v5
-        with:
-          file: Dockerfile-frontend
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            cericmathey/hll_rcon_tool_frontend:${{  github.ref_name }}
-            ${{ contains(github.ref_name, 'rc') && '' || 'cericmathey/hll_rcon_tool_frontend:latest' }}
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v3
         if: ${{ ! contains(github.ref_name, 'rc') }}
@@ -46,10 +36,3 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: cericmathey/hll_rcon_tool
-      - name: Update repo description
-        uses: peter-evans/dockerhub-description@v3
-        if: ${{ ! contains(github.ref_name, 'rc') }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: cericmathey/hll_rcon_tool_frontend


### PR DESCRIPTION
This splits the action that runs when we push a tag to build a release into an action for the frontend and an action for the backend.

There is no reason we need these to build sequentially; this does mean that one build could fail and the other could succeed but that was the case before anyway I think.

In any event; a failed build can be easily restarted through GitHub even without access to the Docker Hub repository.

Builds should now only be as slow as the slowest of the two build processes; so we should have images roughly 2x as fast as before.