### PR TITLE
Hotfix/watch killrate

### DIFF
--- a/rcon/user_config/watch_killrate.py
+++ b/rcon/user_config/watch_killrate.py
@@ -18,9 +18,9 @@ class WatchKillRateType(TypedDict):
     killrate_threshold_mg: float
     only_report_once_per_match: bool
     whitelist_flags: list[str]
-    whitelist_armor: bool
-    whitelist_artillery: bool
-    whitelist_mg: bool
+    ignore_armor: bool
+    ignore_artillery: bool
+    ignore_mg: bool
     author: str
     webhooks: list[WebhookMentionType]
 
@@ -37,9 +37,9 @@ class WatchKillRateUserConfig(BaseUserConfig):
     killrate_threshold_mg: float = Field(default=1.5)
     only_report_once_per_match: bool = Field(default=True)
     whitelist_flags: list[str] = Field(default_factory=list)
-    whitelist_armor: bool = Field(default=True)
-    whitelist_artillery: bool = Field(default=True)
-    whitelist_mg: bool = Field(default=True)
+    ignore_armor: bool = Field(default=True)
+    ignore_artillery: bool = Field(default=True)
+    ignore_mg: bool = Field(default=True)
     author: str = Field(default="CRCON Watch KillRate")
     webhooks: list[DiscordMentionWebhook] = Field(default_factory=list)
 
@@ -74,9 +74,9 @@ class WatchKillRateUserConfig(BaseUserConfig):
             killrate_threshold_mg=values.get("killrate_threshold_mg"),
             only_report_once_per_match=values.get("only_report_once_per_match"),
             whitelist_flags=values.get("whitelist_flags"),
-            whitelist_armor=values.get("whitelist_armor"),
-            whitelist_artillery=values.get("whitelist_artillery"),
-            whitelist_mg=values.get("whitelist_mg"),
+            ignore_armor=values.get("ignore_armor"),
+            ignore_artillery=values.get("ignore_artillery"),
+            ignore_mg=values.get("ignore_mg"),
             author=values.get("author"),
             webhooks=validated_webhooks,
         )


### PR DESCRIPTION
I had the logic in my brain flipped when we did the previous fix; we need to filter *out* weapon categories that have their own calculations so we can determine a players kill rate without those.

This was triggering incorrectly when players had (for instance) artillery kills that exceeded the base KPM threshold but not the artillery one.

* Change `whitelist_` fields to `ignore_` fields for clarity; these booleans are used to completely ignore that category of weapons and there has been user confusion
  * This does mean that the new fields will revert to their defaults :rotating_light:  **which means we need to announce this in the upgrade** :rotating_light: 
* Resolve a bug where the players filtered KPM was still including weapon categories that have their own unique kill rate thresholds (armor/artillery/mgs)
* Include the current map (will show game mode), player level, player class and loadout in the Discord embed
* Rounds the different KPM calculations to `2 decimal places` to match the base KPM precision level from player stats

I tested this on a local build with our server and appears to be working correctly.