### PR TITLE
Use two concurrent jobs for parallel frontend/backend image building

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
-  docker:
+  backend:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +29,27 @@ jobs:
           tags: |
             cericmathey/hll_rcon_tool:${{  github.ref_name }}
             ${{ contains(github.ref_name, 'rc') && '' || 'cericmathey/hll_rcon_tool:latest' }}
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        if: ${{ ! contains(github.ref_name, 'rc') }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push frontend
         uses: docker/build-push-action@v5
         with:
@@ -39,13 +60,6 @@ jobs:
           tags: |
             cericmathey/hll_rcon_tool_frontend:${{  github.ref_name }}
             ${{ contains(github.ref_name, 'rc') && '' || 'cericmathey/hll_rcon_tool_frontend:latest' }}
-      - name: Update repo description
-        uses: peter-evans/dockerhub-description@v3
-        if: ${{ ! contains(github.ref_name, 'rc') }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: cericmathey/hll_rcon_tool
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v3
         if: ${{ ! contains(github.ref_name, 'rc') }}


### PR DESCRIPTION
A better implementation of: https://github.com/MarechJ/hll_rcon_tool/pull/975 thanks to @FlorianSW's suggestion.

Instead of splitting this into two separate github actions; instead we split the frontend/backend image building into two separate jobs so they will run in parallel with each other.

There is no reason we need these to build sequentially; this does mean that one build could fail and the other could succeed but that was the case before anyway I think.

In any event; a failed build can be easily restarted through GitHub even without access to the Docker Hub repository.

Builds should now only be as slow as the slowest of the two build processes; so we should have images roughly 2x as fast as before.