### PR TITLE
Update docker-compose-common-components.yaml

### DIFF
--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -51,6 +51,7 @@ services:
       HLL_DB_HOST: ${HLL_DB_HOST}
       HLL_DB_HOST_PORT: ${HLL_DB_HOST_PORT}
       HLL_DB_URL: postgresql://${HLL_DB_USER}:${HLL_DB_PASSWORD}@${HLL_DB_HOST}:${HLL_DB_HOST_PORT}/${HLL_DB_NAME}
+      HLL_REDIS_URL: redis://${HLL_REDIS_HOST}:${HLL_REDIS_HOST_PORT}/${HLL_REDIS_DB}
     command: maintenance
     restart: always
     healthcheck:


### PR DESCRIPTION
maintenance container couldn't connect to the redis one, due to a missing link to the redis url in env.