### PR TITLE
Update docker-compose-common-components.yaml

### DIFF
--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -55,7 +55,7 @@ services:
     command: maintenance
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "if [ -e /code/maintenance-container-healthy ]; then echo 0; else echo 1; fi" ]
+      test: [ "CMD-SHELL", "-f /code/rconweb/maintenance-container-healthy ]" ]
       start_period: 30s
       interval: 15s
       timeout: 30s


### PR DESCRIPTION
Don't ask me why; the old health check was not failing on my local (PopOS docker engine, not docker desktop) machine even when the container was unhealthy.

It does fail with this method though.

This also corrects the path it should be checking for the file against.