### PR TITLE
Expose the webhook service loop sleep time as an env var

### DIFF
--- a/default.env
+++ b/default.env
@@ -40,7 +40,7 @@ TAGGED_VERSION=latest
 # -----------------------------
 # Database Details
 # -----------------------------
-# This is a database password you have to choose. It does not have to be memorable 
+# This is a database password you have to choose. It does not have to be memorable
 # as you will probably never access it directly, but make it strong.
 # Prohibited characters : % @ : / ? $ or !.
 # To be sure : only use alphanumerical characters (a-z, 0-9).
@@ -94,7 +94,7 @@ NB_API_THREADS=8
 # cookies and therefore login tokens are not shared amongst the different subdomains. This
 # value tells the RCON server to replace the domain on these cookies so that you can alter behaviors
 # such as adding a wildcard, etc.
-# 
+#
 # Refer to the Django documentation on how these settings behave:
 # https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-SESSION_COOKIE_DOMAIN
 # https://docs.djangoproject.com/en/5.1/ref/settings/#csrf-cookie-domain
@@ -131,6 +131,11 @@ HLL_WH_SERVICE_RL_TIME_WINDOW=600
 # webhooks somewhere besides Discord and implementing your own back pressure management
 HLL_WH_MAX_QUEUE_LENGTH=150
 
+# How long to pause the main event loop that watches for new webhook messages
+# You can set this to any number >= 0 but if you pick too large of a number
+# the service won't be able to process messages fast enough
+# The lower the number the more CPU time it will use
+HLL_WH_LOOP_SLEEP_TIME=0.006
 
 # -----------------------------
 # HTTPS (Ignore if not in use)

--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -93,6 +93,7 @@ services:
       HLL_WH_SERVICE_RL_REQUESTS_PER: ${HLL_WH_SERVICE_RL_REQUESTS_PER}
       HLL_WH_SERVICE_RL_TIME_WINDOW: ${HLL_WH_SERVICE_RL_TIME_WINDOW}
       HLL_WH_MAX_QUEUE_LENGTH: ${HLL_WH_MAX_QUEUE_LENGTH}
+      HLL_WH_LOOP_SLEEP_TIME: ${HLL_WH_LOOP_SLEEP_TIME}
     command: webhook_service
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
This exposes the sleep time for the webhook service loop as  `HLL_WH_LOOP_SLEEP_TIME` so that users can choose a value easily without rebuilding images if they would like to adjust it.

I tested this both with and without a value set to make sure that it works even if people don't update their `.env` file.

I set the default to `0.006` seconds which should cut down on CPU usage but still be responsive.

CPU usage seems to be quite low even with an idle loop (which is simply sleeping/checking redis for queue keys), although `docker stats` appears to show incorrect CPU stats compared to `btop` inside the container.

![image](https://github.com/user-attachments/assets/aa94a9f5-8c96-4d99-b87a-08d08ecdc50f)
