### PR TITLE
UI: add tooltips to tables and images

### DIFF
--- a/rcongui/src/components/game/Points.jsx
+++ b/rcongui/src/components/game/Points.jsx
@@ -27,6 +27,7 @@ const Points = ({ value, type, direction = "left" }) => {
             width={16}
             height={16}
             alt={type}
+            title={type}
           />
         </SquareIcon>
         <NumberText>{value ? value.toFixed(0) : 0}</NumberText>
@@ -45,6 +46,7 @@ const Points = ({ value, type, direction = "left" }) => {
             width={16}
             height={16}
             alt={type}
+            title={type}
           />
         </SquareIcon>
       </>

--- a/rcongui/src/components/game/Team.jsx
+++ b/rcongui/src/components/game/Team.jsx
@@ -104,6 +104,7 @@ export const TeamDesktop = ({ data }) => {
                 src={roleSrc(role)}
                 width={16}
                 height={16}
+                title={role}
               />
             </SquareIcon>
             <NumberText>{count}</NumberText>

--- a/rcongui/src/components/table/styles.jsx
+++ b/rcongui/src/components/table/styles.jsx
@@ -153,7 +153,7 @@ export const Action = styled("div", {
 
 export const TextButton = styled((props) => (
   <span role="button" tabIndex={0} {...props} />
-))(({ theme }) => ({
+))(() => ({
   cursor: "pointer",
   width: "fit-content",
   "&:hover": {

--- a/rcongui/src/components/table/styles.jsx
+++ b/rcongui/src/components/table/styles.jsx
@@ -175,10 +175,10 @@ export const HeaderButton = styled((props) => (
 }));
 
 export const SortableHeader =
-  (text) =>
+  (text, title) =>
   ({ column }) => {
     return (
-      <HeaderButton onClick={column.getToggleSortingHandler()}>
+      <HeaderButton onClick={column.getToggleSortingHandler()} title={title || ""}>
         {text}
         {column.getIsSorted() &&
           (column.getIsSorted() === "asc" ? (

--- a/rcongui/src/pages/stats/games/[gameId]/game-columns.jsx
+++ b/rcongui/src/pages/stats/games/[gameId]/game-columns.jsx
@@ -63,7 +63,7 @@ export const columns = [
   },
   {
     id: "country",
-    header: SortableHeader("🌎"),
+    header: SortableHeader("🌎", "Country"),
     accessorKey: "steaminfo.country",
     cell: ({ row }) => {
       return row.original.steaminfo?.country && row.original.steaminfo?.country !== "private" ? (
@@ -76,7 +76,7 @@ export const columns = [
   },
   {
     id: "actions",
-    header: "🛠️",
+    header: <span title="Actions">🛠️</span>,
     accessorKey: "actions",
     cell: ({ row }) => {
       return (
@@ -98,7 +98,7 @@ export const columns = [
   },
   {
     id: "name",
-    header: SortableHeader("Name"),
+    header: SortableHeader("Name", "Name"),
     accessorKey: "player",
     cell: ({ row }) => {
       return (
@@ -137,7 +137,7 @@ export const columns = [
   },
   {
     id: "kd",
-    header: SortableHeader("K/D"),
+    header: SortableHeader("K/D","Kills/Deaths"),
     accessorKey: "kill_death_ratio",
     cell: ({ row }) => {
       return <>{row.original.kill_death_ratio}</>;
@@ -148,7 +148,7 @@ export const columns = [
   },
   {
     id: "kpm",
-    header: SortableHeader("K/M"),
+    header: SortableHeader("K/M","Kills/Minute"),
     accessorKey: "kills_per_minute",
     cell: ({ row }) => {
       return <>{row.original.kills_per_minute}</>;
@@ -159,7 +159,7 @@ export const columns = [
   },
   {
     id: "kills",
-    header: SortableHeader("Kills"),
+    header: SortableHeader("Kills","Kills"),
     accessorKey: "kills",
     cell: ({ row }) => {
       return <>{row.original.kills}</>;
@@ -170,7 +170,7 @@ export const columns = [
   },
   {
     id: "deaths",
-    header: SortableHeader("Deaths"),
+    header: SortableHeader("Deaths","Deaths"),
     accessorKey: "deaths",
     cell: ({ row }) => {
       return <>{row.original.deaths}</>;
@@ -181,7 +181,7 @@ export const columns = [
   },
   {
     id: "tk",
-    header: SortableHeader("TKs"),
+    header: SortableHeader("TKs","Team Kills"),
     accessorKey: "teamkills",
     cell: ({ row }) => {
       return <>{row.original.teamkills}</>;
@@ -192,7 +192,7 @@ export const columns = [
   },
   {
     id: "tk_streak",
-    header: SortableHeader("TK Streak"),
+    header: SortableHeader("TK Streak","Team Kills Streak"),
     accessorKey: "teamkills_streak",
     cell: ({ row }) => {
       return <>{row.original.teamkills_streak}</>;
@@ -203,7 +203,7 @@ export const columns = [
   },
   {
     id: "td",
-    header: SortableHeader("TDs"),
+    header: SortableHeader("TDs","Deaths by Teammates"),
     accessorKey: "deaths_by_tk",
     cell: ({ row }) => {
       return <>{row.original.deaths_by_tk}</>;
@@ -214,7 +214,7 @@ export const columns = [
   },
   {
     id: "td_streak",
-    header: SortableHeader("TD Streak"),
+    header: SortableHeader("TD Streak","Deaths by Teammates Streak"),
     accessorKey: "deaths_by_tk_streak",
     cell: ({ row }) => {
       return <>{row.original.deaths_by_tk_streak}</>;
@@ -225,7 +225,7 @@ export const columns = [
   },
   {
     id: "time",
-    header: SortableHeader("Time"),
+    header: SortableHeader("Time","Time Played"),
     accessorKey: "time_seconds",
     aggregationFn: "mean",
     cell: ({ row }) => {

--- a/rcongui/src/pages/stats/live-sessions/columns.jsx
+++ b/rcongui/src/pages/stats/live-sessions/columns.jsx
@@ -80,7 +80,7 @@ export const columns = [
   {
     accessorKey: "team",
     id: "team",
-    header: SortableHeader("T"),
+    header: SortableHeader("T", "Team"),
     cell: ({ row }) => {
       return (
         <Center>
@@ -89,6 +89,7 @@ export const columns = [
               src={`/icons/teams/${teamToNation(row.original.team)}.webp`}
               width={16}
               height={16}
+              title={row.original.team}
             />
           </Square>
         </Center>
@@ -100,7 +101,7 @@ export const columns = [
   },
   {
     id: "unit",
-    header: SortableHeader("U"),
+    header: SortableHeader("U","Unit"),
     accessorKey: "unit_name",
     // Group by unit name and team
     // getGroupingValue: (row) => `${row.original.unit_name ?? "-"}-${row.original.team}`,
@@ -121,7 +122,7 @@ export const columns = [
   },
   {
     id: "role",
-    header: SortableHeader("R"),
+    header: SortableHeader("R","Role"),
     accessorKey: "role",
     cell: ({ row }) => {
       const src = row.getCanExpand() ? `/icons/roles/${row.original.type ?? row.original.role}.png` : `/icons/roles/${row.original.role}.png`;
@@ -138,6 +139,7 @@ export const columns = [
                   src={src}
                   width={16}
                   height={16}
+                  title={row.original.type ?? row.original.role}
                 />
               </Square>
             </Center>
@@ -149,7 +151,7 @@ export const columns = [
   },
   {
     id: "level",
-    header: SortableHeader("LVL"),
+    header: SortableHeader("LVL","Level"),
     accessorKey: "level",
     aggregationFn: "mean",
     cell: ({ row }) => {
@@ -165,7 +167,7 @@ export const columns = [
   },
   {
     id: "actions",
-    header: "🛠️",
+    header: <span title="Actions">🛠️</span>,
     accessorKey: "actions",
     cell: ({ row }) => {
       if (row.getCanExpand()) return (
@@ -200,7 +202,7 @@ export const columns = [
   },
   {
     id: "name",
-    header: SortableHeader("Name"),
+    header: SortableHeader("Name","Name"),
     accessorKey: "name",
     cell: ({ row }) => {
       return (
@@ -219,7 +221,7 @@ export const columns = [
   },
   {
     id: "kills",
-    header: SortableHeader("K"),
+    header: SortableHeader("K","Kills"),
     accessorKey: "kills",
     aggregationFn: "sum",
     cell: ({ row }) => {
@@ -235,7 +237,7 @@ export const columns = [
   },
   {
     id: "deaths",
-    header: SortableHeader("D"),
+    header: SortableHeader("D","Deaths"),
     accessorKey: "deaths",
     aggregationFn: "sum",
     cell: ({ row }) => {
@@ -251,7 +253,7 @@ export const columns = [
   },
   {
     id: "combat",
-    header: SortableHeader("C"),
+    header: SortableHeader("C","Combat Score"),
     accessorKey: "combat",
     aggregationFn: "sum",
     cell: ({ row }) => {
@@ -267,7 +269,7 @@ export const columns = [
   },
   {
     id: "offense",
-    header: SortableHeader("O"),
+    header: SortableHeader("O", "Offense Score"),
     accessorKey: "offense",
     aggregationFn: "sum",
     cell: ({ row }) => {
@@ -283,7 +285,7 @@ export const columns = [
   },
   {
     id: "defense",
-    header: SortableHeader("D"),
+    header: SortableHeader("D", "Defense Score"),
     accessorKey: "defense",
     aggregationFn: "sum",
     cell: ({ row }) => {
@@ -299,7 +301,7 @@ export const columns = [
   },
   {
     id: "support",
-    header: SortableHeader("S"),
+    header: SortableHeader("S", "Support Score"),
     accessorKey: "support",
     aggregationFn: "sum",
     cell: ({ row }) => {
@@ -315,7 +317,7 @@ export const columns = [
   },
   {
     id: "time",
-    header: SortableHeader("Time"),
+    header: SortableHeader("Time", "Current Playtime"),
     accessorKey: "profile.current_playtime_seconds",
     aggregationFn: "mean",
     cell: ({ row }) => {

--- a/rcongui/src/pages/stats/live-sessions/columns.jsx
+++ b/rcongui/src/pages/stats/live-sessions/columns.jsx
@@ -89,6 +89,7 @@ export const columns = [
               src={`/icons/teams/${teamToNation(row.original.team)}.webp`}
               width={16}
               height={16}
+              alt={row.original.team}
               title={row.original.team}
             />
           </Square>
@@ -139,6 +140,7 @@ export const columns = [
                   src={src}
                   width={16}
                   height={16}
+                  alt={row.original.type ?? row.original.role}
                   title={row.original.type ?? row.original.role}
                 />
               </Square>

--- a/rcongui/src/pages/views/live/players-columns.jsx
+++ b/rcongui/src/pages/views/live/players-columns.jsx
@@ -105,6 +105,7 @@ export const columns = [
               src={`/icons/teams/${teamToNation(row.original.team)}.webp`}
               width={16}
               height={16}
+              alt={row.original.team}
               title={row.original.team}
             />
           </Square>
@@ -151,6 +152,7 @@ export const columns = [
               src={`/icons/roles/${row.original.role}.png`}
               width={16}
               height={16}
+              alt={row.original.role}
               title={row.original.role}
             />
           </Square>

--- a/rcongui/src/pages/views/live/players-columns.jsx
+++ b/rcongui/src/pages/views/live/players-columns.jsx
@@ -96,7 +96,7 @@ export const columns = [
   {
     accessorKey: "team",
     id: "team",
-    header: SortableHeader("T"),
+    header: SortableHeader("T", "Team"),
     cell: ({ row }) => {
       return (
         <Center>
@@ -105,6 +105,7 @@ export const columns = [
               src={`/icons/teams/${teamToNation(row.original.team)}.webp`}
               width={16}
               height={16}
+              title={row.original.team}
             />
           </Square>
         </Center>
@@ -116,7 +117,7 @@ export const columns = [
   },
   {
     id: "unit",
-    header: SortableHeader("U"),
+    header: SortableHeader("U", "Unit"),
     accessorKey: "unit_name",
     // Group by unit name and team
     // getGroupingValue: (row) => `${row.original.unit_name ?? "-"}-${row.original.team}`,
@@ -135,7 +136,7 @@ export const columns = [
   },
   {
     id: "role",
-    header: SortableHeader("R"),
+    header: SortableHeader("R", "Role"),
     accessorKey: "role",
     cell: ({ row }) => {
       return (
@@ -150,6 +151,7 @@ export const columns = [
               src={`/icons/roles/${row.original.role}.png`}
               width={16}
               height={16}
+              title={row.original.role}
             />
           </Square>
         </Center>
@@ -161,7 +163,7 @@ export const columns = [
   },
   {
     id: "level",
-    header: SortableHeader("LVL"),
+    header: SortableHeader("LVL", "Level"),
     accessorKey: "level",
     aggregationFn: "mean",
     cell: ({ row }) => {
@@ -177,7 +179,7 @@ export const columns = [
   },
   {
     id: "kills",
-    header: SortableHeader("KILLS"),
+    header: SortableHeader("KILLS", "Kills"),
     accessorKey: "kills",
     cell: ({ row }) => {
       return <>{row.original.kills}</>;
@@ -185,7 +187,7 @@ export const columns = [
   },
   {
     id: "kpm",
-    header: SortableHeader("KPM"),
+    header: SortableHeader("KPM", "Kills/Min"),
     accessorFn: (row) => {
       const kills = row.kills;
       const playtime = row.profile.current_playtime_seconds;
@@ -198,7 +200,7 @@ export const columns = [
   },
   {
     id: "actions",
-    header: "🛠️",
+    header: <span title="Actions">🛠️</span>,
     accessorKey: "actions",
     cell: ({ row }) => {
       return (
@@ -224,7 +226,7 @@ export const columns = [
   },
   {
     id: "platform",
-    header: SortableHeader("🖥️"),
+    header: SortableHeader("🖥️", "Platform"),
     accessorFn: (row) => (isSteamPlayer(row) ? "Steam" : "Xbox"),
     cell: ({ row }) => {
       const isSteam = isSteamPlayer(row.original)
@@ -245,7 +247,7 @@ export const columns = [
   },
   {
     id: "name",
-    header: SortableHeader("Name"),
+    header: SortableHeader("Name", "Name"),
     accessorKey: "name",
     cell: ({ row }) => {
       const { openWithId } = usePlayerSidebar();
@@ -278,7 +280,7 @@ export const columns = [
   },
   {
     id: "warnings",
-    header: SortableHeader("⚠️"),
+    header: SortableHeader("⚠️", "Has recently received action"),
     accessorKey: "profile.received_actions",
     cell: ({ row }) => {
       return hasRecentWarnings(row.original.profile.received_actions) ? (
@@ -297,7 +299,7 @@ export const columns = [
   },
   {
     id: "watchlist",
-    header: SortableHeader("👁️"),
+    header: SortableHeader("👁️", "On watchlist"),
     accessorKey: "profile.watchlist",
     cell: ({ row }) => {
       return row.original.profile?.watchlist &&
@@ -308,7 +310,7 @@ export const columns = [
   },
   {
     id: "country",
-    header: SortableHeader("🌎"),
+    header: SortableHeader("🌎", "Country"),
     accessorKey: "country",
     cell: ({ row }) => {
       return row.original.country && row.original.country !== "private" ? (
@@ -359,7 +361,7 @@ export const columns = [
   },
   {
     id: "visits",
-    header: SortableHeader("VISITS"),
+    header: SortableHeader("VISITS","Number of player visits"),
     accessorKey: "profile.sessions_count",
     cell: ({ row }) => {
       return <>{row.original.profile.sessions_count}</>;
@@ -367,7 +369,7 @@ export const columns = [
   },
   {
     id: "time",
-    header: SortableHeader("TIME"),
+    header: SortableHeader("TIME","Current Playtime"),
     accessorKey: "profile.current_playtime_seconds",
     aggregationFn: "mean",
     cell: ({ row }) => {

--- a/rcongui/src/pages/views/team/team-section.jsx
+++ b/rcongui/src/pages/views/team/team-section.jsx
@@ -41,6 +41,7 @@ const PlayerInfo = ({ player, onProfileClick }) => (
         alt={player.role}
         width={16}
         height={16}
+        title={player.role}
       />
     ) : (
       <Typography sx={{ width: 16, height: 16, textAlign: "center" }}>
@@ -148,6 +149,7 @@ const SquadNameInfo = ({ squad, showIcon = true }) => (
         alt={squad.type}
         width={16}
         height={16}
+        title={squad.type}
       />
     )}
     <Typography
@@ -166,6 +168,7 @@ const SquadNameInfo = ({ squad, showIcon = true }) => (
       <img
         src="/icons/ping.webp"
         alt="No Leader"
+        title="Unit has no leader"
         width={16}
         height={16}
         style={{ opacity: 0.7 }}

--- a/rcongui/src/pages/views/team/team-section.jsx
+++ b/rcongui/src/pages/views/team/team-section.jsx
@@ -282,7 +282,7 @@ export const TeamSection = ({
       <Box>
         <SquadHeader
           selected={players.every((p) => selectedPlayers.has(p.player_id))}
-          onClick={(e) =>
+          onClick={(_) =>
             onToggleSquad(
               players,
               players.every((p) => selectedPlayers.has(p.player_id))
@@ -468,7 +468,7 @@ export const TeamSection = ({
                         selected={squad.players.every((p) =>
                           selectedPlayers.has(p.player_id)
                         )}
-                        onClick={(e) =>
+                        onClick={(_) =>
                           onToggleSquad(
                             squad.players,
                             squad.players.every((p) =>


### PR DESCRIPTION
Here's a suggestion for more readability within the UI.

I added some tooltips to the Header of the Tables in some of the pages for easier orientation when new to the UI. Some of them may seem self explanatory but I added them for consistency anyway. 


<img width="680" alt="image" src="https://github.com/user-attachments/assets/5a91a0a2-f335-42bd-85c3-b50e9a1536a4" />




  <img width="390" alt="image" src="https://github.com/user-attachments/assets/9aa7e4c2-db8b-4a11-a59d-4bb24c626c25" />


