### PR TITLE
FIX -- reset_watch_killrate_cooldown() needs arguments to call the @on_match_start constructor

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -272,7 +272,7 @@ def remind_vote_map(rcon: Rcon, struct_log):
 
 
 @on_match_start
-def reset_watch_killrate_cooldown():
+def reset_watch_killrate_cooldown(rcon: Rcon, struct_log: StructuredLogLineWithMetaData):
     """Reset the last reported time cache for new matches"""
     from rcon.watch_killrate import reset_cache
 


### PR DESCRIPTION
FIX -- reset_watch_killrate_cooldown() needs arguments to call the @on_match_start constructor

Without arguments :
```
Traceback (most recent call last):
  File "/code/rcon/logs/loop.py", line 348, in process_hooks
    hook(self.rcon, log)
TypeError: reset_watch_killrate_cooldown() takes 0 positional arguments but 2 were given
```

With arguements :
```
[2025-02-28 16:26:24,585][INFO][LvL1][v11.4.5] rcon.logs.loop loop.py:process_hooks:344 | Triggered rcon.hooks.reset_watch_killrate_cooldown on [6.03 sec (1740759977)] MATCH START MORTAIN Warfare
```