### PR TITLE
Maint/golang wh service

### DIFF
--- a/.github/workflows/build-docker-images-manual-tag-only.yml
+++ b/.github/workflows/build-docker-images-manual-tag-only.yml
@@ -40,6 +40,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: cericmathey/hll_rcon_tool_frontend:${{ github.event.inputs.tag }}
+      - name: Build and push webhook service
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile-webhook-service
+          context: ./webhook_service
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cericmathey/hll_rcon_tool_webhook_service:${{ github.event.inputs.tag }}
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v3
         with:
@@ -52,3 +60,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: cericmathey/hll_rcon_tool_frontend
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool_webhook_service

--- a/.github/workflows/docker-images-manual.yml
+++ b/.github/workflows/docker-images-manual.yml
@@ -40,6 +40,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: cericmathey/hll_rcon_tool_frontend:latest,cericmathey/hll_rcon_tool_frontend:${{ github.event.inputs.tag }}
+      - name: Build and push webhook service
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile-webhook-service
+          context: ./webhook_service
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cericmathey/hll_rcon_tool_webhook_service:latest,cericmathey/hll_rcon_tool_webhook_service:${{ github.event.inputs.tag }}
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v3
         with:
@@ -52,3 +60,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: cericmathey/hll_rcon_tool_frontend
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool_webhook_service

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -67,3 +67,34 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: cericmathey/hll_rcon_tool_frontend
+  webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push webhook service
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile-webhook-service
+          context: ./webhook_service
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            cericmathey/hll_rcon_tool_webhook_service:${{  github.ref_name }}
+            ${{ contains(github.ref_name, 'rc') && '' || 'cericmathey/hll_rcon_tool_webhook_service:latest' }}
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        if: ${{ ! contains(github.ref_name, 'rc') }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: cericmathey/hll_rcon_tool_webhook_service

--- a/default.env
+++ b/default.env
@@ -30,6 +30,7 @@ POSTGRES_IMAGE=postgres:12-alpine
 # this unless we host images on a different repository
 BACKEND_DOCKER_REPOSITORY=cericmathey/hll_rcon_tool
 FRONTEND_DOCKER_REPOSITORY=cericmathey/hll_rcon_tool_frontend
+WEBHOOK_SERVICE_DOCKER_REPOSITORY=cericmathey/hll_rcon_tool_webhook_service
 
 # This is the version of CRCON that will be pulled from Docker hub when you
 # pull images, leave this at `latest` to have the latest version, or
@@ -115,12 +116,10 @@ CSRF_COOKIE_DOMAIN=
 # -----------------------------
 # Don't touch this unless you know what you're doing.
 
-# This is the window size in seconds that we use to locally rate limit requests going out
-# to a webhook to reduce the number of external rate limits we're hit with
-HLL_WH_SERVICE_RL_RESET_SECS=3
-
-# This is the number of requests allowed every HLL_WH_SERVICE_RL_RESET_SECS seconds
-HLL_WH_SERVICE_RL_REQUESTS_PER=5
+# The maximum number of requests to attempt per second to Discord
+# You can tune this (Discord rate limit hearders will still apply)
+# to limit how often you get rate limited
+HLL_LOCAL_MAX_SENDS_PER_SEC=10
 
 # This is the length of time we track the number of external rate limits we've received
 HLL_WH_SERVICE_RL_TIME_WINDOW=600
@@ -131,11 +130,12 @@ HLL_WH_SERVICE_RL_TIME_WINDOW=600
 # webhooks somewhere besides Discord and implementing your own back pressure management
 HLL_WH_MAX_QUEUE_LENGTH=150
 
-# How long to pause the main event loop that watches for new webhook messages
-# You can set this to any number >= 0 but if you pick too large of a number
-# the service won't be able to process messages fast enough
-# The lower the number the more CPU time it will use
-HLL_WH_LOOP_SLEEP_TIME=0.006
+# This is the number of times an individual message will be retried if it fails before
+# it is dropped; some errors aren't recoverable and will always be dropped but this
+HLL_WH_MAX_RETRIES=5
+
+
+
 
 # -----------------------------
 # HTTPS (Ignore if not in use)

--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -72,32 +72,22 @@ services:
   # This is used to handle webhooks to discord (and other services in the future)
   webhook_service:
     build:
-      context: .
-      dockerfile: Dockerfile
-    image: ${BACKEND_DOCKER_REPOSITORY}:${TAGGED_VERSION}
+      context: ./webhook_service
+      dockerfile: Dockerfile-webhook-service
+    image: ${WEBHOOK_SERVICE_DOCKER_REPOSITORY}:${TAGGED_VERSION}
     environment:
-      HLL_WH_SERVICE_CONTAINER: true
       LOGGING_LEVEL: "INFO"
       LOGGING_PATH: /logs/
-      CONFIG_DIR: /config/
       HLL_REDIS_HOST: ${HLL_REDIS_HOST}
       HLL_REDIS_PORT: ${HLL_REDIS_HOST_PORT}
-      HLL_DB_USER: ${HLL_DB_USER}
-      HLL_DB_PASSWORD: ${HLL_DB_PASSWORD}
-      HLL_DB_NAME: ${HLL_DB_NAME}
-      HLL_DB_HOST: ${HLL_DB_HOST}
-      HLL_DB_HOST_PORT: ${HLL_DB_HOST_PORT}
-      HLL_DB_URL: postgresql://${HLL_DB_USER}:${HLL_DB_PASSWORD}@${HLL_DB_HOST}:${HLL_DB_HOST_PORT}/${HLL_DB_NAME}
-      # The local rate window limit parameters
-      HLL_WH_SERVICE_RL_RESET_SECS: ${HLL_WH_SERVICE_RL_RESET_SECS}
-      HLL_WH_SERVICE_RL_REQUESTS_PER: ${HLL_WH_SERVICE_RL_REQUESTS_PER}
+      HLL_LOCAL_MAX_SENDS_PER_SEC: ${HLL_LOCAL_MAX_SENDS_PER_SEC}
       HLL_WH_SERVICE_RL_TIME_WINDOW: ${HLL_WH_SERVICE_RL_TIME_WINDOW}
       HLL_WH_MAX_QUEUE_LENGTH: ${HLL_WH_MAX_QUEUE_LENGTH}
-      HLL_WH_LOOP_SLEEP_TIME: ${HLL_WH_LOOP_SLEEP_TIME}
-    command: webhook_service
+      HLL_WH_MAX_RETRIES: ${HLL_WH_MAX_RETRIES}
+    # command: webhook_service
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD-SHELL", "if [ -e /code/webhook-service-healthy ]; then echo 0; else echo 1; fi" ]
+      test: [ "CMD-SHELL", "test -f /app/webhook-service-healthy" ]
       start_period: 30s
       interval: 15s
       timeout: 30s
@@ -111,8 +101,3 @@ services:
       - ./logs:/logs/
     networks:
       - common
-    # This is not a CPU intensive container; but
-    deploy:
-      resources:
-        limits:
-          cpus: '1.0'

--- a/rcon/api_commands.py
+++ b/rcon/api_commands.py
@@ -1946,13 +1946,13 @@ class RconAPI(Rcon):
             id=id, title=title, content=content, category=category, author=by
         )
 
+    def get_all_webhook_queues(self) -> list[str]:
+        return webhook_service.get_queue_keys()
+
     def get_webhook_queue_overview(
         self, queue_id: str
     ) -> webhook_service.QueueStatus | None:
-        return webhook_service.get_queue_overview(queue_id=queue_id)
-
-    def get_all_webhook_queues(self) -> list[str]:
-        return webhook_service.get_all_queue_keys()
+        return webhook_service.get_webhook_queue_overview(queue_key=queue_id)
 
     def get_webhook_service_summary(self):
         """Return the overall status of the service
@@ -1966,26 +1966,6 @@ class RconAPI(Rcon):
         """Delete each queue; unprocessed messages may be lost depending on timing"""
         return webhook_service.reset_webhook_queues()
 
-    def reset_all_webhook_queues_for_server_number(
-        self, server_number: int | str
-    ) -> int:
-        """Delete each queue associated with the specified server number"""
-        return webhook_service.reset_all_queues_for_server_number(
-            server_number=server_number
-        )
-
     def reset_webhook_queue(self, queue_id: str) -> bool:
         """Delete the specified queue; returning if it deleted any entries"""
         return webhook_service.reset_queue(queue_id=queue_id)
-
-    def reset_webhook_queue_type(
-        self, webhook_type: webhook_service.WebhookType | str
-    ) -> int:
-        """Delete each queue of wh_type (discord, etc.) returning the number of deleted queues"""
-        return webhook_service.reset_queue_type(webhook_type=webhook_type)
-
-    def reset_webhook_message_type(
-        self, message_type: webhook_service.WebhookMessageType | str
-    ) -> int:
-        """Delete each queue of wh_type (discord, etc.) returning the number of deleted queues"""
-        return webhook_service.reset_message_type(message_type=message_type)

--- a/rcon/scoreboard.py
+++ b/rcon/scoreboard.py
@@ -292,7 +292,7 @@ def build_header_gamestate_embed(
                     gamestate["allied_score"], gamestate["axis_score"]
                 )
             # Not ideal but the match statement won't let us use the constant here
-            case "\u200B":
+            case "\u200b":
                 name = ""
                 value = EMPTY_EMBED
             case _:
@@ -412,6 +412,7 @@ def build_player_stats_embed(
 
 def create_initial_message(url: str, embed: DiscordEmbed) -> str:
     wh = DiscordWebhook(url=url)
+    logger.info(f"{url=}")
     wh.add_embed(embed)
     wh.execute()
     return wh.message_id
@@ -432,8 +433,14 @@ def send_message(
     # The first run through when a message is deleted will cause a 404
     # but subsequent sends should create a new one and this avoids us having to
     # make a synch GET request to Discord for every message we want to send
-    if not message_id or get_message_edit_404_failure(message_id=message_id):
+    logger.info(f"{message_id=}")
+    if (
+        not message_id
+        or message_id == "0"
+        or get_message_edit_404_failure(message_id=message_id)
+    ):
         message_id = create_initial_message(url=wh.url, embed=embed)
+        logger.info(f"Created initial message: {message_id}")
         save_message_id(
             session=session,
             webhook_url=wh.url,

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -22,128 +22,6 @@ from rcon.utils import get_server_number
 
 logger = getLogger(__name__)
 
-# TODO: we can't expire redis list items; but we could maybe use
-# a sorted set in the future so we can expire individual items
-# to prevent indefinite growth without a max length,
-# right now the lists are trimmed
-# when adding new elements to prevent indefinite growth
-
-# TODO: Support editing existing messages; this can only add
-# new ones, so we can't use it for scorebot yet
-
-TRANSIENT_IDENTIFIER = "transient_identifier"
-TRANSIENT_IDENTIFIER_BYTES = b"transient_identifier"
-
-PREFIX = "whs"
-BUCKET_ID = f"{PREFIX}"
-WH_ID_TO_RATE_LIMIT_BUCKET = f"{PREFIX}:wh_id_rl_bucket"
-BUCKET_RL = f"{PREFIX}:rl"
-BUCKET_RL_COUNT = f"{BUCKET_RL}:count"
-
-GLOBAL_RATE_LIMIT = f"{PREFIX}:global_rl"
-GLOBAL_RATE_LIMIT_RESET_AFTER = f"{GLOBAL_RATE_LIMIT}:reset_after"
-# Track HTTP 401/403 errors by webhook ID
-WEBHOOK_ERRORS = f"{PREFIX}:errors"
-
-# Track failed message (HTTP 404 errors) by message ID
-MESSAGE_DOES_NOT_EXIST = f"{PREFIX}:message_404"
-
-DEFAULT_GLOBAL_RETRY_AFTER_SECS = 5 * 60
-
-# Discord response headers
-X_RATELIMIT_BUCKET = "x-ratelimit-bucket"
-X_RATELIMIT_REMAINING = "x-ratelimit-remaining"
-X_RATELIMIT_LIMIT = "x-ratelimit-limit"
-X_RATELIMIT_RESET = "x-ratelimit-reset"
-X_RATELIMIT_RESET_AFTER = "x-ratelimit-reset-after"
-
-
-# Allow users to tune their local rate limit window if they really want to
-try:
-    LOCAL_RL_RESET_AFTER = int(os.getenv("HLL_WH_SERVICE_RL_RESET_SECS"))
-except (ValueError, TypeError):
-    LOCAL_RL_RESET_AFTER = 3
-
-try:
-    LOCAL_RL_REQUESTS_PER = int(os.getenv("HLL_WH_SERVICE_RL_REQUESTS_PER", 5))
-except (ValueError, TypeError):
-    LOCAL_RL_REQUESTS_PER = 5
-
-# Tracks the number of rate limited requests in the last N seconds
-try:
-    BUCKET_RL_COUNT_RESET_SECS = int(os.getenv("HLL_WH_SERVICE_RL_RESET_SECS"))
-except (ValueError, TypeError):
-    BUCKET_RL_COUNT_RESET_SECS = 60 * 10
-
-
-# We trim the queues (redis list) after adding messages so we don't exceed this length
-# which is unlikely to happen in normal circumstances except the kill feed if turned on
-# which will rapidly accumulate messages faster than we can send them to Discord
-# If we trim from the left; we lose messages that we're retrying but are older, if we
-# trim from the right; we lose newer messages
-# We choose to trim from the left in the interest of losing older (less relevant?) messages
-try:
-    WH_MAX_QUEUE_LENGTH = int(os.getenv("HLL_WH_MAX_QUEUE_LENGTH"))
-except (ValueError, TypeError):
-    WH_MAX_QUEUE_LENGTH = 150
-
-try:
-    HLL_WH_LOOP_SLEEP_TIME = float(os.getenv("HLL_WH_LOOP_SLEEP_TIME"))
-except (ValueError, TypeError):
-    HLL_WH_LOOP_SLEEP_TIME = 0.006
-
-# Global datastructures to support associating hooks with locks
-_RATE_LIMIT_BUCKETS: defaultdict[str, asyncio.Lock | None] = defaultdict(lambda: None)
-_SHARED_LOCK: asyncio.Lock | None = None
-
-
-def set_message_edit_404_failure(
-    red: redis.StrictRedis,
-    message_id: str,
-    prefix: str = MESSAGE_DOES_NOT_EXIST,
-    value: bool = True,
-    ttl=120,
-) -> None:
-    """Set a flag in redis for a message ID to communicate back to a sender that the message does not exist"""
-    red.set(f"{prefix}:{message_id}", b"1" if value else b"0", ex=ttl)
-
-
-def get_message_edit_404_failure(
-    message_id: str,
-    red: redis.StrictRedis | None = None,
-    prefix: str = MESSAGE_DOES_NOT_EXIST,
-) -> bool:
-    """Check if a specific message ID received an HTTP 404 error from Discord"""
-    # Allows easier usage for enqueing from different services/sections of CRCON
-    if red is None:
-        url = construct_redis_url(db_number=0)
-        red = get_redis_client(redis_url=url, decode_responses=False, global_pool=True)
-    return red.get(f"{prefix}:{message_id}") == b"1"
-
-
-def clear_queue_by_message_id(red: redis.StrictRedis, queue_id: str, message_id: str):
-    """Delete all messages from a queue that have message_id
-
-    This allows us to remove all queued edits to a message ID that no longer exists
-    """
-
-    # Traverse the list and identify all the values that contain message_id
-    # and then LREM them
-    for raw_message in red.lrange(queue_id, 0, -1):
-        message = unpack_message(raw_message=raw_message)
-        if message_id == message.payload["message_id"]:
-            red.lrem(queue_id, 0, raw_message)
-
-
-def get_shared_lock() -> asyncio.Lock:
-    """Singleton instance for our shared lock that is used before a rate limit bucket is determined"""
-    global _SHARED_LOCK
-    if _SHARED_LOCK is None:
-        _SHARED_LOCK = asyncio.Lock()
-        logger.debug("Creating shared lock %s", _SHARED_LOCK)
-
-    return _SHARED_LOCK
-
 
 class WebhookType(StrEnum):
     """The type of service the webhook is for (discord, etc.)"""
@@ -176,52 +54,13 @@ class WebhookMessageType(StrEnum):
     OTHER = "other"
 
 
-@dataclass
-class QueueParts:
-    """The individual components of a queue ID key"""
-
-    prefix: str
-    server_number: str
-    wh_type: WebhookType
-    msg_type: WebhookMessageType
-    id: str
-
-
-@dataclass
-class TransientMessageParts:
-    """The individual components of a transient message key"""
-
-    prefix: str
-    server_number: str
-    wh_type: WebhookType
-    msg_type: WebhookMessageType
-    id: str
-    message_group_key: str
-
-
 class QueueStatus(TypedDict):
     """Overview of a message queue"""
 
-    server_number: int
-    id: str
-    webhook_type: WebhookType
-    message_type: WebhookMessageType
+    webhook_id: str
     length: int
-    rate_limit_bucket: str | None
-    rate_limited: bool
-    redis_key: str
-
-
-class TransientMessageStatus(TypedDict):
-    """Overview of a transient message"""
-
-    server_number: int
-    id: str
-    webhook_type: WebhookType
-    message_type: WebhookMessageType
-    rate_limit_bucket: str | None
-    rate_limited: bool
-    message_key: str
+    errors: DiscordErrorResponse
+    window_rate_limits: int
     redis_key: str
 
 
@@ -261,239 +100,11 @@ class WebhookMessage(BaseModel):
     )
 
 
-class DiscordRateLimitData(BaseModel):
-    """Discord rate limit header data"""
-
-    webhook_type: WebhookType | None = Field(default=None)
-    id: str | None = Field(default=None)
-    remaining_requests: int | None = Field(default=None)
-    reset_after_secs: int | None = Field(default=None)
-    reset_timestamp: int | None = Field(default=None)
-    rate_limited: bool = Field(default=False)
-
-
-def update_bucket_rate_limit(
-    red: redis.StrictRedis,
-    bucket_id: str,
-    webhook_type: WebhookType,
-    prefix: str = BUCKET_RL_COUNT,
-    reset_seconds: int = BUCKET_RL_COUNT_RESET_SECS,
-):
-    """If a bucket is rate limited; set a key in a Redis hash that will expire
-
-    This allows us to easily track the number of rate limits in the last N seconds
-    by simply counting the number of entries in the hash
-    """
-    hash_name = f"{prefix}:{webhook_type}:{bucket_id}"
-    # We can set this to whatever; we're just counting the number of hash entries
-    # but using the timestamp should make it unique
-    key = str(datetime.now().timestamp())
-    value = "1"
-    red.hset(hash_name, key, value)
-    red.hexpire(hash_name, reset_seconds, key)
-
-
-def count_bucket_rate_limits(
-    red: redis.StrictRedis, bucket_id: str, prefix: str = BUCKET_RL_COUNT
-) -> int:
-    """The rate limit bucket hash length; the number of times it was rate limited in the window"""
-    hash_name = f"{prefix}:{bucket_id}"
-    return red.hlen(hash_name)  # type: ignore
-
-
-def is_bucket_local_rate_limited(
-    red: redis.StrictRedis,
-    bucket_id: str,
-    webhook_type: WebhookType | None,
-    seconds: int = LOCAL_RL_RESET_AFTER,
-    requests_per: int = LOCAL_RL_REQUESTS_PER,
-    prefix: str = BUCKET_RL,
-) -> bool:
-    """Track our local rate limit (fixed window) per bucket to reduce external rate limiting
-
-    This uses a fixed window rate limit algorithm
-    """
-    key = f"{prefix}:{webhook_type}:{bucket_id}"
-    limited: bool = True
-    try:
-        res: bytes = red.get(key)  # type: ignore
-        value = int(res.decode())
-    except (TypeError, AttributeError):
-        value = 0
-
-    if value < requests_per:
-        pipe = red.pipeline()
-        limited = False
-        pipe.incr(key)
-        pipe.expire(key, seconds)
-        pipe.execute()
-
-    return limited
-
-
-def is_globally_rate_limited(red: redis.StrictRedis) -> bool:
-    """Check Redis to determine if we are globally rate limited"""
-    limit = get_global_rate_limit_reset_after(red=red)
-
-    return limit is not None
-
-
-def get_global_rate_limit_reset_after(red: redis.StrictRedis) -> datetime | None:
-    """Return the datetime the global rate limit expires at if any"""
-    limit: datetime | None = None
-
-    try:
-        raw: bytes = red.get(GLOBAL_RATE_LIMIT_RESET_AFTER)  # type: ignore
-        limit = datetime.fromtimestamp(float(raw.decode()))
-    except (AttributeError, TypeError) as e:
-        logger.debug("Unable to parse the global rate limit reset after time: %s", e)
-
-    return limit
-
-
-def set_global_rate_limit_reset_after(red: redis.StrictRedis, limit: float) -> None:
-    """Set the timestamp the global rate limit expires in Redis"""
-    seconds = limit - datetime.now().timestamp()
-    if seconds > 0:
-        pipe = red.pipeline()
-        pipe.set(GLOBAL_RATE_LIMIT_RESET_AFTER, limit)
-        pipe.expire(GLOBAL_RATE_LIMIT_RESET_AFTER, time=int(seconds))
-        pipe.execute()
-
-
-def get_webhook_rate_limit_bucket(
-    red: redis.StrictRedis,
-    queue_id: str,
-    hash_name: str = WH_ID_TO_RATE_LIMIT_BUCKET,
-) -> str | None:
-    """Get the Discord rate limit bucket a webhook is associated with"""
-    # There is a very low but non 0 chance of colliding on queue IDs
-    # between services once we expand to support other webhook types than Discord
-    # but for now to simplify the service without having to pass in details
-    # of the message that we don't know when we GET it, skip the webhook type
-    res: bytes = red.hget(hash_name, f"{queue_id}")  # type: ignore
-    return res.decode() if res else None
-
-
-def set_webhook_rate_limit_bucket(
-    red: redis.StrictRedis,
-    bucket_id: str,
-    queue_id: str,
-    hash_name: str = WH_ID_TO_RATE_LIMIT_BUCKET,
-) -> None:
-    """Associate a queue ID with its rate limit bucket"""
-    logger.debug("Setting %s to %s", queue_id, bucket_id)
-    red.hset(hash_name, queue_id, bucket_id)
-
-
-def get_rate_limit_bucket_data(
-    red: redis.StrictRedis, bucket_id: str, prefix: str = BUCKET_ID
-) -> DiscordRateLimitData:
-    """Return the data for a specific rate limit bucket"""
-    name = f"{prefix}:{bucket_id}"
-    raw_value = red.get(name)
-    if raw_value is None:
-        return DiscordRateLimitData()
-    else:
-        return DiscordRateLimitData.model_validate_json(orjson.loads(raw_value))  # type: ignore
-
-
-def set_rate_limit_bucket_data(
-    red: redis.StrictRedis, bucket: DiscordRateLimitData, prefix: str = BUCKET_ID
-) -> None:
-    """Set the data for a specific rate limit bucket"""
-    # There is a very low but non 0 chance of colliding on rate limit bucket IDs
-    # between services once we expand to support other webhook types than Discord
-    # but for now to simplify the service without having to pass in details
-    # of the message that we don't know when we GET it, skip the webhook type
-    name = f"{prefix}:{bucket.id}"
-    red.set(name, orjson.dumps(bucket.model_dump_json()))
-
-
-def get_bucket_lock(
-    red: redis.StrictRedis,
-    bucket_id: str,
-) -> tuple[DiscordRateLimitData, asyncio.Lock | None]:
-    """Get the lock for a rate limit bucket"""
-    bucket_data = get_rate_limit_bucket_data(red=red, bucket_id=bucket_id)
-
-    global _RATE_LIMIT_BUCKETS
-    return bucket_data, _RATE_LIMIT_BUCKETS[bucket_id]
-
-
-def set_bucket_data(
-    red: redis.StrictRedis, bucket: DiscordRateLimitData, lock: asyncio.Lock
-) -> None:
-    """Set the bucket data and lock using the bucket ID"""
-    logger.debug("Updating bucket data: %s", bucket)
-    global _RATE_LIMIT_BUCKETS
-
-    if bucket.id:
-        _RATE_LIMIT_BUCKETS[bucket.id] = lock
-        set_rate_limit_bucket_data(red=red, bucket=bucket)
-    else:
-        logger.error("Received a None bucket ID: %s", bucket)
-
-
-def set_webhook_error(
-    red: redis.StrictRedis,
-    webhook_id: str,
-    webhook_type: WebhookType,
-    auth_401: bool = False,
-    auth_403: bool = False,
-    _404: bool = False,
-    prefix: str = WEBHOOK_ERRORS,
-):
-    """Store the last error received for a webhook; cleared after a successful request"""
-    key = f"{prefix}:{webhook_type}:{webhook_id}"
-    # can't send a bool to redis
-    payload: DiscordErrorResponse = {
-        "http_401": int(auth_401),  # type: ignore
-        "http_403": int(auth_403),  # type: ignore
-        "http_404": int(_404),  # type: ignore
-    }
-    red.hset(key, mapping=payload)  # type: ignore
-
-
-def get_webhook_error(
-    red: redis.StrictRedis,
-    webhook_id: str,
-    webhook_type: WebhookType,
-    prefix: str = WEBHOOK_ERRORS,
-) -> DiscordErrorResponse:
-    """Retrieve the current webhook error response for a webhook"""
-    # TODO: likely have to tweak this when we support other webhook types in the future
-    key = f"{prefix}:{webhook_type}:{webhook_id}"
-    raw: dict[bytes, int] = red.hgetall(key)  # type: ignore
-    values: DiscordErrorResponse = {
-        "http_401": True if raw.get(b"http_401") == b"1" else False,
-        "http_403": True if raw.get(b"http_403") == b"1" else False,
-        "http_404": True if raw.get(b"http_404") == b"1" else False,
-    }
-    return values
-
-
-def clear_webhook_errors(
-    red: redis.StrictRedis, webhook_id: str, webhook_type: WebhookType
-):
-    """Reset the errors (HTTP 401/403) for a webhook ID"""
-    # TODO: likely have to tweak this when we support other webhook types in the future
-    set_webhook_error(
-        red=red,
-        webhook_id=webhook_id,
-        webhook_type=webhook_type,
-        auth_401=False,
-        auth_403=False,
-    )
-
-
 def enqueue_transient_message(
     message: WebhookMessage,
     message_group_key: str,
     red: redis.StrictRedis | None = None,
-    prefix: str = PREFIX,
-    transient_identifier: str = TRANSIENT_IDENTIFIER,
-    ttl: int = 120,
+    key: str = "discord_webhook_transient:channel",
 ):
     """Accept a WebhookMessage and message_group_key to only store the most recent update
 
@@ -509,23 +120,18 @@ def enqueue_transient_message(
     if red is None:
         url = construct_redis_url(db_number=0)
         red = get_redis_client(redis_url=url, decode_responses=False, global_pool=True)
-
-    # Scoreboard messages are inherently temporary since they change often;
-    # there is no point in retaining old messages
-    # So instead of using a list as a message queue; save the payload at
-    # a unique key for this message group key (e.g. header/gamestate, map rotation, player stats)
-    # overwriting anything that was there before so only the most recently queued
-    # update is used
-    key = f"{prefix}:{get_server_number()}:{transient_identifier}:{message.webhook_type}:{message.message_type}:{message.payload['webhook_id']}:{message_group_key}"
-    red.set(key, orjson.dumps(message.model_dump_json()), ex=ttl)
+    red.publish(key, message.model_dump_json())
 
 
 def enqueue_message(
-    message: WebhookMessage, red: redis.StrictRedis | None = None, prefix: str = PREFIX
+    message: WebhookMessage,
+    red: redis.StrictRedis | None = None,
+    key: str = "discord_webhook_queue:input",
 ):
     """Accept a WebhookMessage and insert it in Redis
 
-    Queues are independently tracked by the webhook ID (Discord snowflake)
+    The webhook service will route it to the appropriate queue after determining
+    the rate limit bucket
     """
     logger.debug("Enqueuing %s", message)
 
@@ -536,435 +142,154 @@ def enqueue_message(
 
     if not isinstance(message, WebhookMessage):
         raise ValueError(f"{message} must be a WebhookMessage instance")
-
-    # Because we use lists; each type of message gets its own queue so that we can
-    # more efficiently purge types of messages (for instance all kill log lines)
-    # without having to scan/decode every element in a list which might be thousands
-    # of elements long
-    queue_id = f"{prefix}:{get_server_number()}:{message.webhook_type}:{message.message_type}:{message.payload['webhook_id']}"
-    red.rpush(queue_id, orjson.dumps(message.model_dump_json()))
-
-
-def construct_webhook(
-    payload: DiscordWebhookDict, webhook_type: WebhookType
-) -> AsyncDiscordWebhook:
-    if webhook_type == WebhookType.DISCORD:
-        unpacked: DiscordWebhookDict = payload  # type: ignore
-        wh = AsyncDiscordWebhook(**unpacked)
-    else:
-        raise TypeError(f"{webhook_type} is an unsupported webhook type")
-
-    return wh
+    red.rpush(key, orjson.dumps(message.model_dump_json()))
+    # Keep our queue from growing unbounded in case the service is down
+    # but without having to force users to update their compose files to
+    # pass in the actual value; if someone's desired queue size is this large
+    # they should know what they're doing and can come fix this on their own build
+    red.ltrim(key, 0, 1000)
 
 
-def unpack_message(raw_message: bytes) -> WebhookMessage:
-    message = WebhookMessage.model_validate_json(orjson.loads(raw_message))
-    return message
+def get_message_edit_404_failure(
+    message_id: str,
+    red: redis.StrictRedis | None = None,
+    prefix: str = "discord_webhook:message_404",
+) -> bool:
+    """Check if a specific message ID received an HTTP 404 error from Discord"""
+    # Allows easier usage for enqueing from different services/sections of CRCON
+    if red is None:
+        url = construct_redis_url(db_number=0)
+        red = get_redis_client(redis_url=url, decode_responses=False, global_pool=True)
+    return red.get(f"{prefix}:{message_id}") == b"1"
 
 
-async def dequeue_message(
+def count_bucket_rate_limits(
     red: redis.StrictRedis,
-    client: httpx.AsyncClient,
-    queue_id: str,
-    bucket_data: DiscordRateLimitData | None,
-    lock: asyncio.Lock,
-):
-    """Parse a dequeued message from redis, validate and send to Discord, requeuing if needed"""
-
-    if bucket_data is None:
-        bucket_data = DiscordRateLimitData()
-
-    async def _dequeue_message(
-        red: redis.StrictRedis,
-        client: httpx.AsyncClient,
-        queue_id: str,
-        bucket_data: DiscordRateLimitData,
-        lock: asyncio.Lock,
-    ):
-        logger.debug("Dequeueing from %s", queue_id)
-
-        # Transient messages are stored as key/value pairs and not a list
-        if TRANSIENT_IDENTIFIER in queue_id:
-            # Old style messages may still be in the redis queue and we can't GET those
-            try:
-                raw_message: bytes = red.getdel(queue_id)  # type: ignore
-                # If we don't get a message at all; return
-                if raw_message is None:
-                    return
-            except redis.exceptions.ResponseError:
-                # If we don't remove this; it will be stuck in the queue and block it forever
-                # until the redis cache is otherwise cleared
-                logger.warning(f"Discarding wrong message type: {queue_id}")
-                red.lpop(queue_id)
-                return
-        else:
-            raw_message: bytes = red.lpop(queue_id)  # type: ignore
-
-        # If we somehow get a `None` message; log it and return gracefully
-        try:
-            message = unpack_message(raw_message=raw_message)
-        except orjson.JSONDecodeError as e:
-            logger.error(f"{raw_message=} {queue_id=} {bucket_data}")
-            logger.exception(e)
-            return
-
-        wh = construct_webhook(
-            payload=message.payload, webhook_type=message.webhook_type
-        )
-
-        if message.edit:
-            res: httpx.Response = await wh.edit(client=client)
-        else:
-            res: httpx.Response = await wh.execute(client=client)  # type: ignore
-
-        # If a webhook ID is incorrect it will return 401 which we already handle
-        # but if a message ID doesn't exist it will return 404 and not have rate
-        # limit headers
-        # Technically we could make this fixable and re-enqueue the messages but
-        # the only thing we do edits for are the scoreboard and those messages
-        # are inherently transient; so we will set the error status for the webhook ID
-        # and drop the message
-        if res.status_code == 404:
-            logger.error(
-                f"Received HTTP 404 from the webhook with webhook ID: {message.payload.get('webhook_id')} message ID: {message.payload.get('message_id')} purging the queue for this message ID"
-            )
-            # Mark this specific message ID as a 404 failure
-            set_message_edit_404_failure(
-                red=red, message_id=message.payload["message_id"]
-            )
-            clear_queue_by_message_id(
-                red=red, queue_id=queue_id, message_id=message.payload["message_id"]
-            )
-            # Flag this webhook as having an error
-            set_webhook_error(
-                red=red,
-                webhook_id=wh.webhook_id,
-                webhook_type=message.webhook_type,
-                _404=True,
-            )
-
-            return
-
-        # 400 is rather rare; but if someone has misconfigured a URL
-        # e.g. a URL that looks like this https://discord.com/api/webhooks/.../...
-        # it will occur
-        if res.status_code == 400:
-            logger.error("%s is not a valid webhook URL", wh.url)
-            return
-
-        # We handle these status codes below; we want an error message if
-        # we encounter an unknown status code so we can update this appropriately
-        if res.status_code not in (200, 401, 403, 429):
-            logger.error(
-                "Received HTTP %s from Discord, headers:%s: %s",
-                res.headers,
-                res.status_code,
-                message.model_dump(),
-            )
-            return
-
-        bucket_data.webhook_type = message.webhook_type
-        bucket_data.id = res.headers[X_RATELIMIT_BUCKET]
-        bucket_data.remaining_requests = int(res.headers[X_RATELIMIT_REMAINING])
-        bucket_data.reset_after_secs = int(res.headers[X_RATELIMIT_RESET_AFTER])
-        bucket_data.reset_timestamp = math.ceil(
-            datetime.now().timestamp() + bucket_data.reset_after_secs
-        )
-
-        if lock == get_shared_lock():
-            # Once we get a response for a webhook we know what rate limit bucket it's in and we can
-            # associate it with a lock so that all shared limits use the same lock and don't process
-            # concurrently
-            # TODO: what if we add another webhook after that then shares a rate limit bucket with one
-            # that's already been created, will it find it?
-            lock = asyncio.Lock()
-            logger.debug("Created %s for %s", lock, queue_id)
-
-        if res.status_code == 429:
-            bucket_data.rate_limited = True
-            update_bucket_rate_limit(
-                red=red, bucket_id=bucket_data.id, webhook_type=message.webhook_type
-            )
-            body = res.json()
-            if body.get("global"):
-                # We're globally rate limited, parse out the relevant data and set it
-                # This can get stepped on in multiple tasks because it isn't locked
-                try:
-                    retry_after_secs = float(body.get("retry_after"))
-                except TypeError:
-                    retry_after_secs = DEFAULT_GLOBAL_RETRY_AFTER_SECS
-                    logger.error(
-                        "Unable to parse retry_after: %s, falling back to %s seconds",
-                        body.get("retry_after"),
-                        retry_after_secs,
-                    )
-                discord_message = body.get("message")
-                logger.warning(
-                    "Your IP is currently globally rate limited by discord: Retrying after %s, %s",
-                    datetime.now() + timedelta(seconds=retry_after_secs),
-                    discord_message,
-                )
-                set_global_rate_limit_reset_after(
-                    red=red,
-                    limit=(
-                        datetime.now() + timedelta(seconds=math.ceil(retry_after_secs))
-                    ).timestamp(),
-                )
-
-            logger.warning(
-                "Rate limited HTTP %s for %s %s resets after %s",
-                res.status_code,
-                wh.webhook_id,
-                message.webhook_type,
-                datetime.fromtimestamp(bucket_data.reset_timestamp),
-            )
-
-            if not message.discardable:
-                logger.info(
-                    "Re-enqueing webhook ID: %s due to rate limit",
-                    message.payload["webhook_id"],
-                )
-                message.retry_attempts += 1
-                red.lpush(queue_id, orjson.dumps(message.model_dump_json()))  # type: ignore
-                red.ltrim(queue_id, 0, WH_MAX_QUEUE_LENGTH - 1)
-        elif res.status_code == 401:
-            set_webhook_error(
-                red=red,
-                webhook_id=wh.webhook_id,
-                webhook_type=message.webhook_type,
-                auth_401=True,
-            )
-            logger.error(
-                "%s does not appear to be a valid webhook (unknown ID); check the URL",
-                wh.url,
-            )
-        elif res.status_code == 403:
-            set_webhook_error(
-                red=red,
-                webhook_id=wh.webhook_id,
-                webhook_type=message.webhook_type,
-                auth_403=True,
-            )
-            logger.error(
-                "%s does not appear to be a valid webhook (invalid token); check the URL",
-                wh.url,
-            )
-        elif res.status_code == 200:
-            bucket_data.rate_limited = False
-            clear_webhook_errors(
-                red=red,
-                webhook_id=wh.webhook_id,
-                webhook_type=message.webhook_type,
-            )
-        else:
-            logger.error(
-                f"Received edit={message.edit} discardable={message.discardable} {res.status_code} for: {wh.json}"
-            )
-
-        set_bucket_data(red=red, bucket=bucket_data, lock=lock)
-        set_webhook_rate_limit_bucket(
-            red=red,
-            queue_id=queue_id,
-            bucket_id=bucket_data.id,
-        )
-
-    async with lock:
-        try:
-            await _dequeue_message(
-                red=red,
-                client=client,
-                queue_id=queue_id,
-                bucket_data=bucket_data,
-                lock=lock,
-            )
-            logger.debug("finished with %s", lock)
-        except pydantic.ValidationError as e:
-            logger.exception(e)
+    bucket_id: str,
+    hash_name: str = "discord_webhook_bucket_rl_count",
+) -> int:
+    """The rate limit bucket hash length; the number of times it was rate limited in the window"""
+    hash_name = f"{hash_name}:{bucket_id}"
+    return red.hlen(hash_name)  # type: ignore
 
 
-def get_all_queue_keys(
-    red: redis.StrictRedis | None = None, prefix: str = PREFIX
-) -> list[str]:
-    """Retrieve every queue key in redis that matches the service prefix"""
-    logger.debug("Getting all queue IDs from %s", PREFIX)
-    if red is None:
-        red = get_redis_client(decode_responses=False, global_pool=True)
-
-    queue_ids: list[str] = [
-        queue_id.decode()
-        for queue_id in red.scan_iter(match=f"{prefix}*", _type="list")
-    ]
-    return queue_ids
-
-
-def get_all_transient_message_keys(
-    red: redis.StrictRedis | None = None, prefix: str = PREFIX
-) -> list[str]:
-    """Retrieve each transient message key which acts as a queue_id"""
-    # Transient messages are stored as individual key/value pairs instead of a list
-    transient_message_keys: list[str] = [
-        queue_id.decode()
-        for queue_id in red.scan_iter(match=f"{prefix}*", _type="string")
-        if TRANSIENT_IDENTIFIER_BYTES in queue_id
-    ]
-
-    return transient_message_keys
-
-
-def get_all_queue_keys_and_lengths(
-    red: redis.StrictRedis, prefix: str = PREFIX
-) -> list[tuple[str, int]]:
-    """Return each queue key and the number of elements in its queue"""
-    return [(queue_id, red.llen(queue_id)) for queue_id in get_all_queue_keys(red=red, prefix=prefix)]  # type: ignore
-
-
-def get_all_queue_keys_not_empty(
-    red: redis.StrictRedis, prefix: str = PREFIX
-) -> list[str]:
-    """Scan for all the queues (identified by prefix)"""
-    logger.debug("Getting all queue IDs with items from %s", PREFIX)
-    populated_queues = [queue_id for queue_id in get_all_queue_keys(red=red, prefix=prefix) if red.llen(queue_id) > 0]  # type: ignore
-    populated_transient_messages = get_all_transient_message_keys(
-        red=red, prefix=prefix
-    )
-    return populated_queues + populated_transient_messages
-
-
-def get_transient_message_overview(
-    queue_id: str,
-    red: redis.StrictRedis | None,
-) -> TransientMessageStatus | None:
-    parts = _split_transient_message_key(queue_id=queue_id)
-
-    if not parts:
-        return
-
-    if red is None:
-        red = get_redis_client(decode_responses=False, global_pool=True)
-
-    bucket_data: DiscordRateLimitData | None = None
-    bucket_id = get_webhook_rate_limit_bucket(red=red, queue_id=queue_id)
-    if bucket_id:
-        bucket_data = get_rate_limit_bucket_data(red=red, bucket_id=bucket_id)
-
-    overview: TransientMessageStatus = {
-        "server_number": int(parts.server_number),
-        "id": parts.id,
-        "webhook_type": parts.wh_type,
-        "message_type": parts.msg_type,
-        "rate_limit_bucket": bucket_id,
-        "rate_limited": bucket_data.rate_limited if bucket_data else False,
-        "message_key": parts.message_group_key,
-        "redis_key": queue_id,
+def get_webhook_error(
+    red: redis.StrictRedis,
+    webhook_id: str,
+    webhook_type: WebhookType,
+    prefix: str = "discord_webhook_queue:webhook_id_errors",
+) -> DiscordErrorResponse:
+    """Retrieve the current webhook error response for a webhook"""
+    # TODO: likely have to tweak this when we support other webhook types in the future
+    key = f"{prefix}:{webhook_type}:{webhook_id}"
+    raw: dict[bytes, int] = red.hgetall(key)  # type: ignore
+    values: DiscordErrorResponse = {
+        "http_401": True if raw.get(b"http_401") == b"1" else False,
+        "http_403": True if raw.get(b"http_403") == b"1" else False,
+        "http_404": True if raw.get(b"http_404") == b"1" else False,
     }
-    return overview
+    return values
 
 
-def get_queue_overview(
-    queue_id: str, red: redis.StrictRedis | None = None
-) -> QueueStatus | None:
+def get_webhook_rl_buckets(
+    red: redis.StrictRedis | None, bucket_hash: str = "discord_webhook:webhook_buckets"
+) -> dict[str, str]:
+    if red is None:
+        red = get_redis_client(decode_responses=False, global_pool=True)
+
+    # webhookID : bucketID
+    bucket_ids = red.hgetall(bucket_hash)
+    return {k.decode(): v.decode() for k, v in bucket_ids.items()}
+
+
+def get_queue_keys(
+    red: redis.StrictRedis | None = None,
+    prefix: str = "discord_webhook_queue:bucket",
+) -> list[str]:
+    """Return all the queue keys from Redis (queues are by rl bucket)"""
+    logger.debug("Getting all queue IDs from %s", prefix)
+    if red is None:
+        red = get_redis_client(decode_responses=False, global_pool=True)
+
+    # webhookID : bucketID
+    bucket_ids = get_webhook_rl_buckets(red)
+    # The fully formed queue ID by RL bucket
+    queue_keys: list[str] = [f"{prefix}:{value}" for value in set(bucket_ids.values())]
+    return queue_keys
+
+
+def get_webhook_ids(red: redis.StrictRedis | None) -> list[str]:
+    """Return all the webhook IDs stored in Redis"""
+    if red is None:
+        red = get_redis_client(decode_responses=False, global_pool=True)
+    # webhookID : bucketID
+    bucket_ids = get_webhook_rl_buckets(red)
+    return [key for key in bucket_ids.keys()]
+
+
+def get_queue_length(queue_id: str, red: redis.StrictRedis | None = None) -> int:
     """Return a summary of a queue if it exists"""
-    parts = _split_queue_id(queue_id=queue_id)
-
-    if not parts:
-        return
-
     if red is None:
         red = get_redis_client(decode_responses=False, global_pool=True)
 
     length: int = red.llen(queue_id)  # type: ignore
-    bucket_data: DiscordRateLimitData | None = None
-    bucket_id = get_webhook_rate_limit_bucket(red=red, queue_id=queue_id)
-    if bucket_id:
-        bucket_data = get_rate_limit_bucket_data(red=red, bucket_id=bucket_id)
+    return length
 
-    overview: QueueStatus = {
-        "server_number": int(parts.server_number),
-        "id": parts.id,
-        "webhook_type": parts.wh_type,
-        "message_type": parts.msg_type,
+
+def get_webhook_queue_overview(
+    queue_key: str,
+    rl_bucket_to_webhook_id: dict[str, str] | None = None,
+    red: redis.StrictRedis | None = None,
+) -> QueueStatus:
+    if red is None:
+        red = get_redis_client(decode_responses=False, global_pool=True)
+
+    if rl_bucket_to_webhook_id is None:
+        rl_bucket_to_webhook_id = get_webhook_rl_buckets(red)
+    _, _, rl_bucket = queue_key.split(":")
+    length = get_queue_length(queue_key, red)
+    webhook_id = rl_bucket_to_webhook_id[rl_bucket]
+    errors = get_webhook_error(red, webhook_id, WebhookType.DISCORD)
+
+    return {
+        "webhook_id": webhook_id,
         "length": length,
-        "rate_limit_bucket": bucket_data.id if bucket_data else None,
-        "rate_limited": bucket_data.rate_limited if bucket_data else False,
-        "redis_key": queue_id,
+        "errors": errors,
+        "window_rate_limits": count_bucket_rate_limits(red, rl_bucket),
+        "redis_key": queue_key,
     }
-    return overview
-
-
-def get_next_queue_id(queue_ids: list[str]) -> str | None:
-    """Get the next queue to process (if any) and re-add queue to the end"""
-    logger.debug("Getting a random queue ID from %s", queue_ids)
-    # People can add/remove webhooks in CRCON at any point, after we've scanned Redis
-    # for queues, pick one at random instead of trying to track the previous one we did
-    # this should be random enough that over time no queue gets priority and if any
-    # one queue has a weird error, we shouldn't get stuck trying to reprocess it
-    return random.choice(queue_ids) if queue_ids else None
 
 
 def webhook_service_summary(red: redis.StrictRedis | None = None):
-    """Return a queue overview for all queues, by server number, webhook type and message type"""
+    """Return a queue overview for all queues"""
     if red is None:
         red = get_redis_client(decode_responses=False, global_pool=True)
 
-    # Get the global rate limit status/expiration
-    # Get each queue, by webhook type (discord, etc.) and the number of messages
-
     data = {}
-
     data["is_globally_rate_limited"] = is_globally_rate_limited(red=red)
     data["global_rate_limit_reset_after"] = get_global_rate_limit_reset_after(red=red)
 
-    queue_ids = get_all_queue_keys(red=red)
-    queues: defaultdict[int, dict[str, dict[str, list[QueueStatus]]]] = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(list))
-    )
-    for qid in queue_ids:
-        overview: QueueStatus | None = get_queue_overview(red=red, queue_id=qid)
-        if overview:
-            queues[overview["server_number"]][overview["webhook_type"]][
-                overview["message_type"]
-            ].append(overview)
+    data["input_queue"] = {
+        "length": get_queue_length("discord_webhook_queue:input", red),
+        "redis_key": "discord_webhook_queue:input",
+    }
 
-    data["queues"] = queues
+    data["first_time_queue"] = {
+        "length": get_queue_length("discord_webhook_queue:first_time", red),
+        "redis_key": "discord_webhook_queue:first_time",
+    }
 
-    transient_messages: defaultdict[
-        int, dict[str, dict[str, list[TransientMessageStatus]]]
-    ] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-    for key in get_all_transient_message_keys(red=red):
-        transient_message_overview: TransientMessageStatus | None = (
-            get_transient_message_overview(red=red, queue_id=key)
+    data["queues"] = list()
+    bucket_ids = get_webhook_rl_buckets(red)
+    rl_bucket_to_webhook_id = {v: k for k, v in bucket_ids.items()}
+    queue_keys = get_queue_keys(red)
+    logger.info(f"{queue_keys=}")
+    for qkey in queue_keys:
+        data["queues"].append(
+            get_webhook_queue_overview(qkey, rl_bucket_to_webhook_id, red)
         )
 
-        if transient_message_overview:
-            transient_messages[transient_message_overview["server_number"]][
-                transient_message_overview["webhook_type"]
-            ][transient_message_overview["message_type"]].append(
-                transient_message_overview
-            )
-
-    data["transient_messages"] = transient_messages
     return data
-
-
-def reset_all_queues_for_server_number(
-    server_number: int | str, red: redis.StrictRedis | None = None
-) -> int:
-    """Delete each queue associated with the specified server number"""
-    if red is None:
-        red = get_redis_client(decode_responses=False, global_pool=True)
-
-    queue_ids = get_all_queue_keys(red=red)
-    deleted: int = 0
-    for queue_id in queue_ids:
-        try:
-            parts = _split_queue_id(queue_id=queue_id)
-            # server numbers should be ints; but redis keys are strings
-            if parts and parts.server_number == str(server_number):
-                deleted += red.delete(queue_id)  # type: ignore
-        except ValueError:
-            logger.error("Unable to parse %s received an invalid key", queue_id)
-
-    return deleted
 
 
 def reset_webhook_queues(red: redis.StrictRedis | None = None) -> int:
@@ -972,7 +297,7 @@ def reset_webhook_queues(red: redis.StrictRedis | None = None) -> int:
     if red is None:
         red = get_redis_client(decode_responses=False, global_pool=True)
 
-    keys = get_all_queue_keys(red=red)
+    keys = get_queue_keys(red=red)
     return red.delete(*keys)  # type: ignore
 
 
@@ -987,207 +312,23 @@ def reset_queue(queue_id: str, red: redis.StrictRedis | None = None) -> bool:
     return red.delete(queue_id) != 0  # type: ignore
 
 
-def reset_queue_type(
-    webhook_type: WebhookType | str, red: redis.StrictRedis | None = None
-) -> int:
-    """Delete each queue of wh_type (discord, etc.) returning the number of deleted queues"""
-    if red is None:
-        red = get_redis_client(decode_responses=False, global_pool=True)
+def is_globally_rate_limited(red: redis.StrictRedis) -> bool:
+    """Check Redis to determine if we are globally rate limited"""
+    limit = get_global_rate_limit_reset_after(red=red)
 
-    if isinstance(webhook_type, str):
-        webhook_type = WebhookType(webhook_type)
-
-    queue_ids = get_all_queue_keys(red=red)
-    deleted: int = 0
-    for queue_id in queue_ids:
-        parts = _split_queue_id(queue_id)
-        if parts and parts.wh_type == webhook_type:
-            deleted += red.delete(queue_id)  # type: ignore
-
-    return deleted
+    return limit is not None
 
 
-def reset_message_type(
-    message_type: WebhookMessageType | str, red: redis.StrictRedis | None = None
-) -> int:
-    """Delete each queue of wh_type (discord, etc.) returning the number of deleted queues"""
-    if red is None:
-        red = get_redis_client(decode_responses=False, global_pool=True)
+def get_global_rate_limit_reset_after(
+    red: redis.StrictRedis, key: str = "discord_webhook:global_rate_limited"
+) -> datetime | None:
+    """Return the datetime the global rate limit expires at if any"""
+    limit: datetime | None = None
 
-    if isinstance(message_type, str):
-        message_type = WebhookMessageType(message_type)
-
-    queue_ids = get_all_queue_keys(red=red)
-    deleted: int = 0
-    for queue_id in queue_ids:
-        parts = _split_queue_id(queue_id)
-        if parts and parts.msg_type == message_type:
-            deleted += red.delete(queue_id)  # type: ignore
-
-    return deleted
-
-
-def _split_queue_id(queue_id: str) -> QueueParts | None:
-    """Parse a queue ID int its component parts (prefix, server number, webhook type, message type and ID)"""
     try:
-        prefix, server_number, wh_type, msg_type, qid = queue_id.split(":")
-        return QueueParts(
-            prefix=prefix,
-            server_number=server_number,
-            wh_type=WebhookType(wh_type),
-            msg_type=WebhookMessageType(msg_type),
-            id=qid,
-        )
-    except ValueError:
-        logger.error("Unable to parse %s received an invalid key", queue_id)
-        return
+        raw: bytes = red.get(key)  # type: ignore
+        limit = datetime.fromtimestamp(float(raw.decode()))
+    except (AttributeError, TypeError) as e:
+        logger.debug("Unable to parse the global rate limit reset after time: %s", e)
 
-
-def _split_transient_message_key(queue_id: str) -> TransientMessageParts | None:
-    try:
-        prefix, server_number, _, wh_type, msg_type, qid, message_key = queue_id.split(
-            ":"
-        )
-        return TransientMessageParts(
-            prefix=prefix,
-            server_number=server_number,
-            wh_type=WebhookType(wh_type),
-            msg_type=WebhookMessageType(msg_type),
-            id=qid,
-            message_group_key=message_key,
-        )
-    except ValueError:
-        logger.error("Unable to parse %s received an invalid key", queue_id)
-        return
-
-
-async def main():
-
-    # Essentially we want to connect to redis, monitor the set of queues of discord messages
-    # by webhook queue
-    # and (within the max concurrent process limit) block, get the next queue to process
-    # and dequeue a message off the queue (adding this queue to the end of the queue of queues)
-    # create a new process and pass it the data from the queue so it can construct/send the
-    # webhook
-    # this lets each webhook process 1 message at a time in order (unfair to webhooks that send infrequently)
-
-    # if the webhook is rate limited and it isn't an ephemeral message;
-    # re-queue the message (at the end of the queue so it is re-processed immediately-ish
-    # Also check for other errors like excessively long messages, anything that would block
-    # discord from accepting it and mitigate it if possible
-    # global rate limits, so forth
-
-    # if it is ephemeral and we're rate limited; we just drop the message no big deal
-
-    # Grab the top message off each queue and send them off
-
-    logger.info(f"Starting webhook service {HLL_WH_LOOP_SLEEP_TIME=}")
-    url = construct_redis_url()
-    red = get_redis_client(redis_url=url, decode_responses=False, global_pool=True)
-
-    client = httpx.AsyncClient()
-    lock: asyncio.Lock | None = None
-    continue_logged = False
-
-    # Create a file to use for the docker health check
-    from pathlib import Path
-
-    path = Path("/code") / Path("webhook-service-healthy")
-    path.touch()
-
-    while True:
-        # Check each loop to pick up new queues that have been added since last iteration
-        queue_ids = get_all_queue_keys_not_empty(red=red)
-
-        # Keep each message queue under its max, dropping the oldest messages first
-        for queue_id in queue_ids:
-            # Can't trim transient messages which are stored as simple KEY/VALUE pairs
-            if TRANSIENT_IDENTIFIER not in queue_id:
-                red.ltrim(queue_id, 0, WH_MAX_QUEUE_LENGTH - 1)
-
-        logger.debug("queue_ids=%s", queue_ids)
-        queue_id: str | None = get_next_queue_id(queue_ids=queue_ids)
-        logger.debug("queue_id=%s", queue_id)
-        bucket_data: DiscordRateLimitData | None = None
-
-        if queue_id:
-            bucket_id: str | None = get_webhook_rate_limit_bucket(
-                red=red, queue_id=queue_id
-            )
-            # If we don't know the rate limit bucket; use the shared one further below
-            if bucket_id:
-                bucket_data, lock = get_bucket_lock(red=red, bucket_id=bucket_id)
-                if lock and lock.locked():
-                    logger.debug("%s locked", lock)
-                    await asyncio.sleep(HLL_WH_LOOP_SLEEP_TIME)
-                    continue
-                ts = int(datetime.now(tz=timezone.utc).timestamp())
-
-                # Even with Discords headers, and using a local rate limit, I still have issues with
-                # hooks getting rate limited during testing, if we rate limit a bucket, pad it an extra
-                # second before re-using it to reduce the chance of further rate limits
-                if (
-                    is_globally_rate_limited(red=red)
-                    or (
-                        bucket_data.rate_limited
-                        and bucket_data.reset_timestamp is not None
-                        and ts <= bucket_data.reset_timestamp + 1
-                    )
-                    or is_bucket_local_rate_limited(
-                        red=red,
-                        bucket_id=bucket_id,
-                        webhook_type=bucket_data.webhook_type,
-                    )
-                ):
-                    if not continue_logged:
-                        logger.debug(
-                            "Skipping %s due to rate limit now=%s reset_after=%s",
-                            queue_id,
-                            ts,
-                            bucket_data.reset_timestamp,
-                        )
-                        continue_logged = True
-                    continue
-
-            continue_logged = False
-            logger.debug("Starting asyncio task for %s", queue_id)
-            if lock is None or lock == get_shared_lock():
-                logger.debug("using shared lock")
-                lock = get_shared_lock()
-                task = asyncio.create_task(
-                    dequeue_message(
-                        red=red,
-                        client=client,
-                        queue_id=queue_id,
-                        bucket_data=bucket_data,
-                        lock=lock,
-                    )
-                )
-                logger.debug("Waiting for %s", task)
-                await task
-            else:
-                logger.debug("using bucket lock")
-                task = asyncio.create_task(
-                    dequeue_message(
-                        red=red,
-                        client=client,
-                        queue_id=queue_id,
-                        bucket_data=bucket_data,
-                        lock=lock,
-                    )
-                )
-
-        # If we never await something we never allow any of the tasks to run
-        # but sleeping a specific amount of time can prevent queues from emptying
-        # faster than CRCON can fill them up
-        # however sleeping `0` seconds  gives the event loop an opportunity for
-        # tasks to run; this does cause CPU usage to increase because this loop
-        # runs far more often; we've limited the CPU usage by default to 1 core in
-        # the webhook service definition in `docker-compose-common-components.yaml`
-        # https://docs.python.org/3/library/asyncio-task.html#sleeping
-        await asyncio.sleep(HLL_WH_LOOP_SLEEP_TIME)
-
-
-if __name__ == "__main__":
-    # main()
-    asyncio.run(main())
+    return limit

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -609,10 +609,7 @@ ENDPOINT_PERMISSIONS: dict[Callable, list[str] | set[str] | str] = {
     rcon_api.get_all_webhook_queues: "api.can_view_webhook_queues",
     rcon_api.get_webhook_service_summary: "api.can_view_webhook_queues",
     rcon_api.reset_webhook_queues: "api.can_change_webhook_queues",
-    rcon_api.reset_all_webhook_queues_for_server_number: "api.can_change_webhook_queues",
     rcon_api.reset_webhook_queue: "api.can_change_webhook_queues",
-    rcon_api.reset_webhook_queue_type: "api.can_change_webhook_queues",
-    rcon_api.reset_webhook_message_type: "api.can_change_webhook_queues",
 }
 
 PREFIXES_TO_EXPOSE = [
@@ -860,10 +857,7 @@ RCON_ENDPOINT_HTTP_METHODS: dict[Callable, list[str]] = {
     rcon_api.get_all_webhook_queues: ["GET"],
     rcon_api.get_webhook_service_summary: ["GET"],
     rcon_api.reset_webhook_queues: ["POST"],
-    rcon_api.reset_all_webhook_queues_for_server_number: ["POST"],
     rcon_api.reset_webhook_queue: ["POST"],
-    rcon_api.reset_webhook_queue_type: ["POST"],
-    rcon_api.reset_webhook_message_type: ["POST"],
 }
 
 # Check to make sure that ENDPOINT_HTTP_METHODS and ENDPOINT_PERMISSIONS have the same endpoints

--- a/webhook_service/Dockerfile-webhook-service
+++ b/webhook_service/Dockerfile-webhook-service
@@ -1,0 +1,22 @@
+# Use official Go image as base
+FROM golang:1.24 AS builder
+WORKDIR /app
+
+# Copy go.mod and go.sum first (for caching dependencies)
+COPY go.mod go.sum ./
+RUN go mod download
+RUN go mod tidy
+COPY . .
+RUN go build -o webhook-service *.go
+
+# Final stage
+FROM golang:1.24
+WORKDIR /app
+
+# Copy the built binary from builder
+COPY --from=builder /app/webhook-service .
+
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/webhook_service/entrypoint.sh
+++ b/webhook_service/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# entrypoint.sh
+
+exec ./webhook-service

--- a/webhook_service/go.mod
+++ b/webhook_service/go.mod
@@ -1,0 +1,10 @@
+module github.com/MarechJ/hll_rcon_tool/webhook_service
+
+go 1.24.0
+
+require github.com/redis/go-redis/v9 v9.7.1
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/webhook_service/go.sum
+++ b/webhook_service/go.sum
@@ -1,0 +1,10 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/redis/go-redis/v9 v9.7.1 h1:4LhKRCIduqXqtvCUlaq9c8bdHOkICjDMrr1+Zb3osAc=
+github.com/redis/go-redis/v9 v9.7.1/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=

--- a/webhook_service/main.go
+++ b/webhook_service/main.go
@@ -1,0 +1,864 @@
+/*
+	The current Python web service is very inefficient because it polls.
+
+	Here's the goal of our new solution; use a master queue for messages.
+
+	Listen to the queue in a blocking fashion for CPU efficiency.
+
+	When we receive a message; examine it and determine if we already know
+	the Discord RL bucket for it; and if so send it to the queue for
+	that bucket.
+
+	If we don't; send it to the shared queue and once we've established the
+	RL bucket after a successful request to Discord; future messages will go
+	to the appropriate queue.
+
+	Each queue will also BLOP for efficiency and process one message at a time;
+	the key/value pairs for transient messages (scoreboard at this point)
+	will be managed by checking a set of key names and starting a worker task
+	for that key name
+
+	Workers for
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var maxQueueSize int64
+var maxMsgReattempts int
+var localRateLimit int
+var rateLimitWindowSize time.Duration
+var webhookIDPattern *regexp.Regexp
+var workerLookup map[string]*BucketWorker
+var logger *Logger
+
+type Logger struct {
+	debug   *log.Logger
+	info    *log.Logger
+	warning *log.Logger
+	error   *log.Logger
+	level   string
+}
+
+func (l *Logger) Debug(msg string) {
+	if l.level == "DEBUG" {
+		l.debug.Println(msg)
+	}
+}
+
+func (l *Logger) Info(msg string) {
+	if l.level == "DEBUG" || l.level == "INFO" {
+		l.info.Println(msg)
+	}
+}
+
+func (l *Logger) Warning(msg string) {
+	if l.level == "DEBUG" || l.level == "INFO" || l.level == "WARNING" {
+		l.warning.Println(msg)
+	}
+}
+
+func (l *Logger) Error(msg string) {
+	l.error.Println(msg)
+}
+
+func init() {
+	var err error
+
+	logPath := os.Getenv("LOGGING_PATH")
+	fmt.Print(logPath)
+	if logPath == "" {
+		logPath = "yourlogpathisnotset.log"
+	} else {
+		logPath = filepath.Join(logPath, "webhook_service.log")
+	}
+	logLevel := strings.ToUpper(os.Getenv("LOGGING_LEVEL"))
+	if logLevel == "" {
+		logLevel = "INFO"
+	}
+	file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to open log file: %v", err))
+	}
+	tag := getGitTag()
+
+	// Create logger instances with different prefixes
+	baseFlags := log.LstdFlags | log.Lshortfile
+	logger = &Logger{
+		debug:   log.New(file, "["+tag+"] [DEBUG] ", baseFlags),
+		info:    log.New(file, "["+tag+"] [INFO] ", baseFlags),
+		warning: log.New(file, "["+tag+"] [WARNING] ", baseFlags),
+		error:   log.New(file, "["+tag+"] [ERROR] ", baseFlags),
+		level:   logLevel,
+	}
+
+	maxQueueSize, err = strconv.ParseInt(os.Getenv("HLL_WH_MAX_QUEUE_LENGTH"), 10, 64)
+	if err != nil {
+		maxQueueSize = 150
+	}
+
+	var maxReattempts int
+	maxReattempts, err = strconv.Atoi(os.Getenv("HLL_WH_MAX_RETRIES"))
+	if err != nil {
+		maxMsgReattempts = 5
+	} else {
+		maxMsgReattempts = maxReattempts
+	}
+
+	var maxSends int
+	maxSends, err = strconv.Atoi(os.Getenv("HLL_LOCAL_MAX_SENDS_PER_SEC"))
+	if err != nil {
+		localRateLimit = 45
+	} else {
+		localRateLimit = maxSends
+	}
+
+	var windowSize int
+	windowSize, err = strconv.Atoi(os.Getenv("HLL_WH_SERVICE_RL_TIME_WINDOW"))
+	if err != nil {
+		rateLimitWindowSize = time.Duration(600 * int(time.Second))
+	} else {
+		rateLimitWindowSize = time.Duration(windowSize * int(time.Second))
+	}
+
+	webhookIDPattern = regexp.MustCompile(`webhooks/([0-9]+)/`)
+	workerLookup = make(map[string]*BucketWorker)
+}
+
+const (
+	inputQueue                 = "discord_webhook_queue:input"
+	firstTimeQueue             = "discord_webhook_queue:first_time"
+	bucketQueuePrefix          = "discord_webhook_queue:bucket:"
+	webhookErrors              = "discord_webhook_queue:webhook_id_errors"
+	transientChannel           = "discord_webhook_transient:channel"
+	message_404                = "discord_webhook:message_404"
+	bucketsHash                = "discord_webhook:webhook_buckets"
+	bucketRateLimitCountHash   = "discord_webhook_bucket_rl_count"
+	discordGloballyRateLimited = "discord_webhook:global_rate_limited"
+)
+
+// WebhookType represents the type of webhook service
+type WebhookType string
+
+const (
+	WebhookTypeDiscord WebhookType = "discord"
+)
+
+// WebhookMessageType represents the underlying type of a webhook message
+type WebhookMessageType string
+
+const (
+	WebhookMessageTypeLogLine     WebhookMessageType = "log_line"
+	WebhookMessageTypeLogLineChat WebhookMessageType = "log_line_chat"
+	WebhookMessageTypeLogLineKill WebhookMessageType = "log_line_kill"
+	WebhookMessageTypeTeamkill    WebhookMessageType = "log_line_teamkill"
+	WebhookMessageTypeAdminPing   WebhookMessageType = "admin_ping"
+	WebhookMessageTypeScoreboard  WebhookMessageType = "scoreboard"
+	WebhookMessageTypeAudit       WebhookMessageType = "audit"
+	WebhookMessageTypeOther       WebhookMessageType = "other"
+)
+
+// DiscordWebhookDict represents the payload for a Discord webhook
+type DiscordWebhookDict struct {
+	URL             string               `json:"url"`
+	WebhookID       string               `json:"webhook_id"`
+	MessageID       *string              `json:"message_id,omitempty"`
+	AllowedMentions *AllowedMentionsDict `json:"allowed_mentions,omitempty"`
+	Content         *string              `json:"content,omitempty"`
+	Embeds          []DiscordEmbedDict   `json:"embeds,omitempty"`
+}
+
+// Override unmarshaling so we can ignore extra fields
+func (d *DiscordWebhookDict) UnmarshalJSON(data []byte) error {
+	type Alias DiscordWebhookDict
+	aux := struct {
+		*Alias
+		Extra map[string]any `json:"-"` // Catch-all for unknown fields
+	}{
+		Alias: (*Alias)(d),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AllowedMentionsDict specifies which mentions are allowed
+type AllowedMentionsDict struct {
+	Parse       []string `json:"parse,omitempty"`
+	Roles       []string `json:"roles,omitempty"`
+	Users       []string `json:"users,omitempty"`
+	RepliedUser *bool    `json:"replied_user,omitempty"`
+}
+
+// EmbedFooterDict represents an embed footer
+type EmbedFooterDict struct {
+	Text         string  `json:"text"`
+	IconURL      *string `json:"icon_url,omitempty"`
+	ProxyIconURL *string `json:"proxy_icon_url,omitempty"`
+}
+
+// EmbedImageDict represents an embed image
+type EmbedImageDict struct {
+	URL      string  `json:"url"`
+	ProxyURL *string `json:"proxy_url,omitempty"`
+	Height   *int    `json:"height,omitempty"`
+	Width    *int    `json:"width,omitempty"`
+}
+
+// EmbedThumbnailDict represents an embed thumbnail
+type EmbedThumbnailDict struct {
+	URL      string  `json:"url"`
+	ProxyURL *string `json:"proxy_url,omitempty"`
+	Height   *int    `json:"height,omitempty"`
+	Width    *int    `json:"width,omitempty"`
+}
+
+// EmbedVideoDict represents an embed video
+type EmbedVideoDict struct {
+	URL      *string `json:"url,omitempty"`
+	ProxyURL *string `json:"proxy_url,omitempty"`
+	Height   *int    `json:"height,omitempty"`
+	Width    *int    `json:"width,omitempty"`
+}
+
+// EmbedProviderDict represents an embed provider
+type EmbedProviderDict struct {
+	Name *string `json:"name,omitempty"`
+	URL  *string `json:"url,omitempty"`
+}
+
+// EmbedAuthorDict represents an embed author
+type EmbedAuthorDict struct {
+	Name         string  `json:"name"`
+	URL          *string `json:"url,omitempty"`
+	IconURL      *string `json:"icon_url,omitempty"`
+	ProxyIconURL *string `json:"proxy_icon_url,omitempty"`
+}
+
+// EmbedFieldDict represents an embed field
+type EmbedFieldDict struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline *bool  `json:"inline,omitempty"`
+}
+
+type DiscordEmbedDict struct {
+	Title       *string             `json:"title,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	URL         *string             `json:"url,omitempty"`
+	Timestamp   *string             `json:"timestamp,omitempty"` // ISO 8601 string
+	Color       *int                `json:"color,omitempty"`
+	Footer      *EmbedFooterDict    `json:"footer,omitempty"`
+	Image       *EmbedImageDict     `json:"image,omitempty"`
+	Thumbnail   *EmbedThumbnailDict `json:"thumbnail,omitempty"`
+	Video       *EmbedVideoDict     `json:"video,omitempty"`
+	Provider    *EmbedProviderDict  `json:"provider,omitempty"`
+	Author      *EmbedAuthorDict    `json:"author,omitempty"`
+	Fields      []EmbedFieldDict    `json:"fields,omitempty"`
+}
+
+// Message represents the incoming message structure from Redis
+type Message struct {
+	ServerNumber  int                `json:"server_number"`
+	Discardable   bool               `json:"discardable"`
+	Edit          bool               `json:"edit"`
+	SentAt        time.Time          `json:"sent_at"`
+	RetryAttempts int                `json:"retry_attempts"`
+	PayloadType   *string            `json:"payload_type,omitempty"`
+	WebhookType   WebhookType        `json:"webhook_type"`
+	MessageType   WebhookMessageType `json:"message_type"`
+	Payload       DiscordWebhookDict `json:"payload"`
+	MessageNumber int
+}
+
+func (m *Message) String() string {
+	return fmt.Sprintf("S#: %d Discard: %t Edit: %t Msg#: %d",
+		m.ServerNumber, m.Discardable, m.Edit, m.MessageNumber)
+}
+
+// Tracks bucket specific rate limits
+type RateLimitState struct {
+	BucketID    string
+	Remaining   int
+	Limit       int
+	ResetTime   time.Time
+	ResetAfter  time.Duration
+	RateLimited bool
+	mu          sync.Mutex
+}
+
+func (r *RateLimitState) String() string {
+	return fmt.Sprintf("ID: %s Remaining: %d Limit: %d ResetTime: %s ResetAfter: %d RateLimited: %t",
+		r.BucketID, r.Remaining, r.Limit, r.ResetTime, r.ResetAfter, r.RateLimited)
+}
+
+// Tracks our local rate limit window
+var localRateLimitState struct {
+	Requests int
+	Window   time.Time
+	mu       sync.Mutex
+}
+
+// Manages a rate limit bucket
+type BucketWorker struct {
+	QueueKey  string
+	rdb       *redis.Client
+	ctx       context.Context
+	rateLimit *RateLimitState
+}
+
+func NewBucketWorker(bucketID string, rdb *redis.Client) *BucketWorker {
+	return &BucketWorker{
+		QueueKey:  bucketQueuePrefix + bucketID,
+		rdb:       rdb,
+		ctx:       context.Background(),
+		rateLimit: &RateLimitState{BucketID: bucketID},
+	}
+}
+
+func GetWorker(bucket string, mu *sync.Mutex) (*BucketWorker, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	worker, exists := workerLookup[bucket]
+	return worker, exists
+}
+
+func SetWorker(bucket string, worker *BucketWorker, mu *sync.Mutex) {
+	mu.Lock()
+	defer mu.Unlock()
+	workerLookup[bucket] = worker
+}
+
+// Keeps us under `HLL_LOCAL_MAX_SENDS_PER_SEC` across all requests
+func CheckLocalRateLimit(requests int, now time.Time) error {
+	localRateLimitState.mu.Lock()
+	defer localRateLimitState.mu.Unlock()
+
+	// If it's been more than 1 second since our last request; reset the window
+	if now.Sub(localRateLimitState.Window) >= time.Second {
+		localRateLimitState.Requests = requests
+		localRateLimitState.Window = now
+	}
+
+	// Don't exceed our configured max requests per second
+	if localRateLimitState.Requests >= localRateLimit {
+		localRateLimitState.mu.Unlock()
+		return fmt.Errorf("local rate limit exceeded")
+	}
+
+	localRateLimitState.Requests++
+	return nil
+}
+
+func GetWorkerRateLimitSleepTime(rateLimit *RateLimitState) time.Duration {
+	rateLimit.mu.Lock()
+	defer rateLimit.mu.Unlock()
+
+	if rateLimit.RateLimited {
+		return time.Until(rateLimit.ResetTime)
+	}
+
+	return 0
+}
+
+// Makes the HTTP request to Discord and updates rate limit state
+func SendWebhook(rdb *redis.Client, msg *Message, rateLimit *RateLimitState) (string, error) {
+	now := time.Now()
+	if err := CheckLocalRateLimit(0, now); err != nil {
+		return "", err
+	}
+
+	// Extract what we need to make our POST request to Discord
+	payload := map[string]any{}
+	if msg.Payload.Content != nil {
+		payload["content"] = *msg.Payload.Content
+	}
+	if len(msg.Payload.Embeds) > 0 {
+		payload["embeds"] = msg.Payload.Embeds
+	}
+	if msg.Payload.AllowedMentions != nil {
+		payload["allowed_mentions"] = msg.Payload.AllowedMentions
+	}
+
+	var jsonPayload []byte
+	var err error
+	jsonPayload, err = json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal error: %v", err)
+	}
+
+	var resp *http.Response
+
+	if msg.Edit {
+		resp, err = ExecuteWebhook("PATCH", jsonPayload, fmt.Sprintf("%s/messages/%s", msg.Payload.URL, *msg.Payload.MessageID))
+	} else {
+		resp, err = ExecuteWebhook("POST", jsonPayload, msg.Payload.URL)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	// If we didn't get a 429 or a 500 series error; flag the message so it will be dropped
+	// 200s went through; all the other status codes are unrecoverable
+	if resp.StatusCode != http.StatusTooManyRequests || resp.StatusCode < 500 {
+		msg.Discardable = true
+	}
+
+	// Flag the webhook if we get these specific errors
+	// Not checking the error; if we got this far it's a URL with a parseable ID
+	webhookID, _ := ExtractWebhookID(msg.Payload.URL)
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		SetWebhookError(rdb, webhookID, true, false, false)
+	case http.StatusForbidden:
+		SetWebhookError(rdb, webhookID, false, true, false)
+	case http.StatusNotFound:
+		SetWebhookError(rdb, webhookID, false, false, true)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		ctx := context.Background()
+		str := fmt.Sprintf("%s:%s", message_404, *msg.Payload.MessageID)
+		rdb.Set(ctx, str, true, 0)
+		if msg.Payload.MessageID != nil {
+			return "", fmt.Errorf("HTTP 404 for %s", *msg.Payload.MessageID)
+		} else {
+			return "", fmt.Errorf("HTTP 404; no message ID included")
+		}
+	} else if resp.StatusCode == 400 || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return "", fmt.Errorf("%s is not a valid webhook URL", msg.Payload.URL)
+
+	} else if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusTooManyRequests {
+		ClearWebhookError(rdb, webhookID)
+		// These responses will contain valid rate limit headers
+		bucket := resp.Header.Get("X-RateLimit-Bucket")
+		rateLimit.mu.Lock()
+		defer rateLimit.mu.Unlock()
+
+		if remaining, err := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining")); err == nil {
+			rateLimit.Remaining = remaining
+		}
+		if limit, err := strconv.Atoi(resp.Header.Get("X-RateLimit-Limit")); err == nil {
+			rateLimit.Limit = limit
+		}
+		if reset, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64); err == nil {
+			rateLimit.ResetTime = time.Unix(reset, 0)
+			// Pad the reset time two seconds because Discord are liars and following their header
+			// responses exactly will still cause excessive 429s
+			rateLimit.ResetTime = rateLimit.ResetTime.Add(time.Duration(2.0 * float64(time.Second)))
+
+		}
+		if resetAfter, err := strconv.ParseFloat(resp.Header.Get("X-RateLimit-Reset-After"), 64); err == nil {
+			// Pad the reset time two seconds because Discord are liars and following their header
+			// responses exactly will still cause excessive 429s
+			rateLimit.ResetAfter = time.Duration((resetAfter + 2.0) * float64(time.Second))
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			UpdateBucketRateLimitCount(rdb, bucket)
+			logger.Warning(fmt.Sprintf("HTTP %d for %s", resp.StatusCode, bucket))
+			rateLimit.RateLimited = true
+			if resp.Header.Get("X-RateLimit-Global") != "" {
+				// Set the global rate limit flag in Redis so it can be retrieved by the API
+				// we don't explicitly check it because each worker will flag itself as rate limited
+				logger.Warning(fmt.Sprintf("Global rate limit hit, pausing for %v", rateLimit.ResetAfter))
+				SetGloballyRateLimited(rdb, rateLimit.ResetTime, rateLimit.ResetAfter)
+				// Force wait by maxing out the requests in our local window
+				CheckLocalRateLimit(localRateLimit, time.Now())
+			}
+			return bucket, fmt.Errorf("rate limited until %v", rateLimit.ResetTime)
+		}
+
+		rateLimit.RateLimited = false
+		return bucket, nil
+	} else {
+		return "", fmt.Errorf("unhandled HTTP status %d", resp.StatusCode)
+	}
+}
+
+// ProcessQueue handles a bucket queue with retries
+func (bw *BucketWorker) ProcessQueue(rdb *redis.Client) {
+	for {
+		bw.rateLimit.mu.Lock()
+		now := time.Now()
+		// Reset rate limit state if ResetTime has passed
+		if now.After(bw.rateLimit.ResetTime) {
+			bw.rateLimit.RateLimited = false
+			// Discord will tell us the actual number remaining after the next request
+			// but give it at least 1 request so it can make the next request
+			bw.rateLimit.Remaining = 1
+			bw.rateLimit.ResetTime = time.Time{}
+			bw.rateLimit.ResetAfter = 0
+			// logger.Printf("Bucket %s rate limit reset",  bw.rateLimit.BucketID)
+		}
+
+		// We're safe to sleep this particular rate limit bucket without impacting other threads
+		// because if Discord is rate limiting us; any other worker (transient messages)
+		// can't process anyway; Discord would just reject it
+		if bw.rateLimit.RateLimited || bw.rateLimit.Remaining <= 0 {
+			wait := time.Until(bw.rateLimit.ResetTime)
+			bw.rateLimit.mu.Unlock()
+			if wait > 0 {
+				logger.Info(fmt.Sprintf("Bucket %s waiting %v", bw.rateLimit.BucketID, wait))
+				time.Sleep(wait)
+			}
+			continue
+		}
+		bw.rateLimit.mu.Unlock()
+
+		// Grab our next message off the quueue
+		results, err := bw.rdb.BLPop(bw.ctx, 5*time.Second, bw.QueueKey).Result()
+		if err == redis.Nil {
+			continue
+		} else if err != nil {
+			logger.Error(fmt.Sprintf("Error popping from %s: %v", bw.QueueKey, err))
+			continue
+		}
+
+		var msg Message
+		if err := json.Unmarshal([]byte(results[1]), &msg); err != nil {
+			logger.Error(fmt.Sprintf("Unmarshal error: %v, JSON: %s", err, results[1]))
+			continue
+		}
+		msg.MessageNumber = rand.Int()
+
+		// We retry rate limited messages N times instead of re-enqueuing them which can slow down
+		// processing other messages; but doesn't let an unhandled bad message block a queue forever
+		// and if we're getting an error on this message; we would very likely have errors on the remaining
+		// messages anyway
+		for attempts := 0; attempts < maxMsgReattempts && !msg.Discardable; attempts++ {
+			_, err := SendWebhook(rdb, &msg, bw.rateLimit)
+			if err == nil {
+				break
+			}
+
+			logger.Info(fmt.Sprintf("Retry %d for %d in bucket %s: %v", attempts+1, msg.MessageNumber, bw.rateLimit.BucketID, err))
+			if attempts == 2 {
+				logger.Warning(fmt.Sprintf("Dropped after 3 retries: %s", msg.Payload.URL))
+				break
+			}
+			wait := GetWorkerRateLimitSleepTime(bw.rateLimit)
+			if wait > 0 {
+				time.Sleep(wait)
+			} else {
+				// We failed to send for some reason other than rate limiting
+				// back off before attempting again
+				time.Sleep(time.Second * 2 * time.Duration(attempts+1))
+			}
+		}
+	}
+}
+
+func ExecuteWebhook(method string, payload []byte, url string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, fmt.Errorf("request error: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	return resp, nil
+}
+
+// ProcessFirstTime discovers buckets for unknown webhooks
+func ProcessFirstTime(rdb *redis.Client, mu *sync.Mutex) {
+	ctx := context.Background()
+	for {
+		results, err := rdb.BLPop(ctx, 0, firstTimeQueue).Result()
+		if err != nil {
+			logger.Error(fmt.Sprintf("First-time pop error: %v", err))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		var msg Message
+		rawMessage := []byte(results[1])
+		if err := json.Unmarshal(rawMessage, &msg); err != nil {
+			logger.Error(fmt.Sprintf("First-time unmarshal error: %v, JSON: %s", err, rawMessage))
+			continue
+		}
+
+		webhookID, err := ExtractWebhookID(msg.Payload.URL)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Could not parse webhook ID from: %s:%s", msg.Payload.URL, err))
+			continue
+		}
+
+		// If we've already seen this webhookID and know the bucket, insert it
+		// into the appropriate queue instead of sending here
+		bucket, err := rdb.HGet(ctx, bucketsHash, webhookID).Result()
+		if err != redis.Nil {
+			queueKey := bucketQueuePrefix + bucket
+			var msgBytes []byte
+			msgBytes, _ = json.Marshal(msg)
+			rdb.RPush(ctx, queueKey, msgBytes)
+			rdb.LTrim(ctx, queueKey, 0, maxQueueSize-1)
+			continue
+		}
+
+		// Our retry logic here does block the first time queue but this should be
+		// fairly rare; after any successful attempt messages will be routed to the
+		// appropriate queue; and there aren't that many unique places CRCON dispatches
+		// webhooks from
+		rateLimit := &RateLimitState{}
+		for attempts := 0; attempts < maxMsgReattempts && (!msg.Discardable); attempts++ {
+			bucket, err = SendWebhook(rdb, &msg, rateLimit)
+			if err == nil {
+				rdb.HSet(ctx, bucketsHash, webhookID, bucket)
+				// Start worker if new bucket
+				if _, exists := GetWorker(bucket, mu); !exists {
+					// Make a new worker but use the response we got from Discord
+					// for the first time the message was sent
+					worker := NewBucketWorker(bucket, rdb)
+					worker.rateLimit.RateLimited = rateLimit.RateLimited
+					worker.rateLimit.Remaining = rateLimit.Remaining
+					worker.rateLimit.ResetAfter = rateLimit.ResetAfter
+					worker.rateLimit.ResetTime = rateLimit.ResetTime
+					SetWorker(bucket, worker, mu)
+					go worker.ProcessQueue(rdb)
+				}
+			} else {
+				logger.Error(fmt.Sprintf("First-time send error: %v", err))
+				if rateLimit.RateLimited {
+					wait := GetWorkerRateLimitSleepTime(rateLimit)
+					time.Sleep(wait)
+				} else {
+					// We had some sort of (non rate limiting error) trying to send this message
+					// back off before attempting again
+					time.Sleep(time.Second * 2 * time.Duration(attempts+1))
+				}
+			}
+		}
+		queueKey := bucketQueuePrefix + bucket
+		rdb.LTrim(ctx, queueKey, 0, maxQueueSize-1)
+	}
+}
+
+func ProcessTransient(rdb *redis.Client, msg Message, mu *sync.Mutex) {
+	webhookID, err := ExtractWebhookID(msg.Payload.URL)
+	if err != nil {
+		logger.Error(fmt.Sprintf("could not parse webhook ID from: %s:%s", msg.Payload.URL, err))
+		return
+	}
+
+	ctx := context.Background()
+	bucket, err := rdb.HGet(ctx, bucketsHash, webhookID).Result()
+	var worker *BucketWorker
+	if err != redis.Nil {
+		worker, _ = GetWorker(bucket, mu)
+	}
+
+	if worker == nil {
+		worker = NewBucketWorker(bucket, rdb)
+		SetWorker(bucket, worker, mu)
+	}
+
+	// No need to try reattempts; these messages are inherently discardable
+	bucket, err = SendWebhook(rdb, &msg, worker.rateLimit)
+	if err != nil {
+		logger.Error(fmt.Sprintf("transient message send error for %s: %v", msg.Payload.WebhookID, err))
+	}
+	rdb.HSet(ctx, bucketsHash, webhookID, bucket)
+}
+
+// Subscribe to transient messages via pub/sub
+func SubscribeTransients(rdb *redis.Client, mu *sync.Mutex) {
+	ctx := context.Background()
+	pubsub := rdb.Subscribe(ctx, transientChannel)
+	defer pubsub.Close()
+
+	logger.Info(fmt.Sprintf("Subscribing to: %s", transientChannel))
+	for msg := range pubsub.Channel() {
+		var transientMsg Message
+		if err := json.Unmarshal([]byte(msg.Payload), &transientMsg); err != nil {
+			logger.Error(fmt.Sprintf("transient unmarshal error: %v, JSON: %s", err, msg.Payload))
+			continue
+		}
+		go ProcessTransient(rdb, transientMsg, mu)
+	}
+}
+
+func main() {
+	logger.Info("Starting service")
+	rdb := SetupRedis()
+
+	// For the Docker health check
+	path := filepath.Join("/app", "webhook-service-healthy")
+	logger.Info(path)
+	exec.Command("touch", path).Start()
+
+	// A context is required to work with redis
+	ctx := context.Background()
+	var mu sync.Mutex
+
+	// Monitor the input queue and dispatch messages to the appropriate queue worker
+	go func() {
+		for {
+			results, err := rdb.BLPop(ctx, 0, inputQueue).Result()
+			if err != nil {
+				logger.Error(fmt.Sprintf("Input pop error: %v", err))
+				time.Sleep(time.Second)
+				continue
+			}
+
+			var msg Message
+			var rawStr string
+			rawMessage := []byte(results[1])
+			// This is stupid but we have to get the raw JSON string into a string before we can
+			// unmarshal it into our struct because of how it's encoded from CRCON
+			if err := json.Unmarshal(rawMessage, &rawStr); err == nil {
+				if err := json.Unmarshal([]byte(rawStr), &msg); err != nil {
+					logger.Error(fmt.Sprintf("unmarshal error: %v, JSON: %s", err, rawStr))
+					time.Sleep(time.Second)
+					continue
+				}
+			} else {
+				logger.Error(fmt.Sprintf("Input unmarshal error: %v, JSON: %s", err, rawMessage))
+				time.Sleep(time.Second)
+				continue
+			}
+
+			// Check to see if we already know this webhook's rate limit bucket
+			// We check by webhook ID since multiple webhooks can share the same bucket
+			webhookID, err := ExtractWebhookID(msg.Payload.URL)
+			if err != nil {
+				logger.Error(fmt.Sprintf("Could not parse webhook ID from: %s:%s", msg.Payload.URL, err))
+				continue
+			}
+			bucket, err := rdb.HGet(ctx, bucketsHash, webhookID).Result()
+			var msgBytes []byte
+			msgBytes, _ = json.Marshal(msg)
+			if err == redis.Nil {
+				// Unknown webhook, send to first-time queue
+				rdb.RPush(ctx, firstTimeQueue, msgBytes)
+				rdb.LTrim(ctx, firstTimeQueue, 0, maxQueueSize-1)
+			} else {
+				// Known bucket, send to bucket queue
+				queueKey := bucketQueuePrefix + bucket
+				rdb.RPush(ctx, queueKey, msgBytes)
+				rdb.LTrim(ctx, queueKey, 0, maxQueueSize-1)
+
+				// Start workers if new bucket
+				if _, exists := GetWorker(bucket, &mu); !exists {
+					worker := NewBucketWorker(bucket, rdb)
+					SetWorker(bucket, worker, &mu)
+					go worker.ProcessQueue(rdb)
+				}
+			}
+		}
+	}()
+
+	go ProcessFirstTime(rdb, &mu)
+	go SubscribeTransients(rdb, &mu)
+
+	// Keep running
+	select {}
+}
+
+// SetupRedis initializes the Redis client
+func SetupRedis() *redis.Client {
+	logger.Info("Initializing redis")
+	host := os.Getenv("HLL_REDIS_HOST")
+	if host == "" {
+		panic("HLL_REDIS_HOST not set")
+	}
+
+	portStr := os.Getenv("HLL_REDIS_PORT")
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port <= 0 {
+		panic("HLL_REDIS_PORT not set or invalid")
+	}
+
+	addr := fmt.Sprintf("%s:%d", host, port)
+	return redis.NewClient(&redis.Options{
+		Addr: addr,
+		DB:   0, // CRCON uses DB #0 as a global shared database for all game servers
+	})
+}
+
+func ExtractWebhookID(url string) (string, error) {
+	matches := webhookIDPattern.FindStringSubmatch(url)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("no webhook ID found in URL")
+	}
+	return matches[1], nil
+}
+
+func SetGloballyRateLimited(rdb *redis.Client, resetTime time.Time, resetAfter time.Duration) {
+	ctx := context.Background()
+	val := strconv.FormatInt(resetTime.Unix(), 10)
+	rdb.Set(ctx, discordGloballyRateLimited, val, resetAfter)
+}
+
+// Add a hash entry anytime a bucket is rate limited so we can count
+// the number of rate limits within the user configured window size
+// and return it from the API
+func UpdateBucketRateLimitCount(rdb *redis.Client, bucket string) {
+	ctx := context.Background()
+	hashName := fmt.Sprintf("%s:%s", bucketRateLimitCountHash, bucket)
+	key := strconv.FormatInt(time.Now().Unix(), 10)
+	rdb.HSet(ctx, hashName, key, true)
+	rdb.HExpire(ctx, hashName, rateLimitWindowSize, key)
+}
+
+// Flag a webhook error in Redis so the status is available to the API
+// these are cleared on a successful request to Discord
+func SetWebhookError(rdb *redis.Client, webhookID string, http_401, http_403, http_404 bool) {
+	ctx := context.Background()
+	key := fmt.Sprintf("%s:%s", webhookErrors, webhookID)
+	payload := map[string]bool{
+		"http_401": http_401,
+		"http_403": http_403,
+		"http_404": http_404,
+	}
+	rdb.HSet(ctx, key, payload)
+}
+
+func ClearWebhookError(rdb *redis.Client, webhookID string) {
+	ctx := context.Background()
+	key := fmt.Sprintf("%s:%s", webhookErrors, webhookID)
+	payload := map[string]bool{
+		"http_401": false,
+		"http_403": false,
+		"http_404": false,
+	}
+	rdb.HSet(ctx, key, payload)
+}
+
+func getGitTag() string {
+	// Run git describe --tags
+	cmd := exec.Command("git", "describe", "--tags")
+	output, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	// Convert to string and trim whitespace
+	return strings.TrimSpace(string(output))
+}

--- a/webhook_service/main.go
+++ b/webhook_service/main.go
@@ -15,10 +15,19 @@
 
 	Each queue will also BLOP for efficiency and process one message at a time;
 	the key/value pairs for transient messages (scoreboard at this point)
-	will be managed by checking a set of key names and starting a worker task
-	for that key name
+	are done with redis pub/sub which naturally handles dropping unhandled messages
+	if nobody is listening and also is CPU efficient with blocking and waiting for
+	messages to arrive
 
-	Workers for
+	Workers for each rate limit bucket handle their rate limits/sleeping when they
+	need to wait for Discord
+
+	We also maintain a local rate limit window (configurable by .env vars) so people
+	can do some tuning on their end
+
+	If we become globally rate limited by Discord each worker will discover that and
+	sleep the appropriate amount; which isn't necessarily ideal but does simplify the
+	code some
 */
 
 package main


### PR DESCRIPTION
I rewrote the Python webhook service in Go so we can be more CPU efficient.

We're now blocking instead of polling for both queued messages and transient messages (which use redis pub/sub).

I've used this locally a decent amount and as far as I can tell works properly; I'm not able to test it on our main server at the moment because we're on the VIP branch and don't want to complicate things.

I'm a novice at Go so by all means tear this bit apart; I kind of just slapped it together and did the minimum amount of work I could do to get it to work properly.

I noticed I still have some debug logging added in which I will strip; I don't think this is ready for release until we get someone more experienced with Go to at least give it a skim.