### PR TITLE
UI: add space to blacklist record footer

### DIFF
--- a/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
+++ b/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
@@ -204,8 +204,7 @@ const BlacklistRecordTile = ({
         <Grid
           container
           justifyContent="space-around"
-          spacing={0}
-          
+          spacing={1}
         >
           <Grid>
             <Tooltip title={createdAt.format("LLLL")} arrow>

--- a/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
+++ b/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
@@ -166,8 +166,6 @@ const BlacklistRecordTile = ({
                     if (navigator.clipboard === undefined) {
                       alert(`This feature only works if your rcon uses HTTPS.`);
                       return;
-                    }
-                    if (navigator.clipboard === undefined) {
                     } else {
                       navigator.clipboard.writeText(text).then(
                         function () {

--- a/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
+++ b/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
@@ -165,7 +165,6 @@ const BlacklistRecordTile = ({
                     const text = getReportTemplate();
                     if (navigator.clipboard === undefined) {
                       alert(`This feature only works if your rcon uses HTTPS.`);
-                      return;
                     } else {
                       navigator.clipboard.writeText(text).then(
                         function () {

--- a/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
+++ b/rcongui/src/components/Blacklist/BlacklistRecordGrid.js
@@ -309,7 +309,7 @@ const BlacklistRecordGrid = ({
       (<Fragment>
         <Grid container>
           <Grid size={12}>
-            <ImageList cols={size} cellHeight={210} spacing={12}>
+              <ImageList cols={size} spacing={12}>
               {records.map((record) => {
                 return (
                   <ImageListItem

--- a/rcongui/src/pages/records/blacklists/index.jsx
+++ b/rcongui/src/pages/records/blacklists/index.jsx
@@ -207,7 +207,7 @@ const BlacklistRecords = () => {
       </Grid>
       <Grid size={12}>
         <MyPagination
-          pageSize={searchQuery.pageSize}
+          pageSize={searchQuery.page_size}
           page={page}
           setPage={setPage}
           total={totalRecords}
@@ -223,7 +223,7 @@ const BlacklistRecords = () => {
       </Grid>
       <Grid size={12}>
         <MyPagination
-          pageSize={searchQuery.pageSize}
+          pageSize={searchQuery.page_size}
           page={page}
           setPage={setPage}
           total={totalRecords}


### PR DESCRIPTION
Hi, 
this is a suggestion for the blacklist footer to better tell the two infos apart. 

I added spacing to the blacklist footer grid and fixed some ide and console warnings on the way. 


old: <img width="274" alt="Screenshot 2025-03-25 at 21 33 14" src="https://github.com/user-attachments/assets/bba88763-3966-489e-9bad-b00b6b6f2d58" />
new:  <img width="298" alt="Screenshot 2025-03-25 at 21 33 02" src="https://github.com/user-attachments/assets/322a1941-c2bd-48e7-aeb0-e7e404b8cc5a" />
