### PR TITLE
Fix u.current.values().forEach is not a function

### DIFF
--- a/rcongui_public/src/pages/games/horizontal-games-list.tsx
+++ b/rcongui_public/src/pages/games/horizontal-games-list.tsx
@@ -91,7 +91,7 @@ export const HorizontalGamesList = ({ games }: { games: ScoreboardMaps }) => {
       { threshold: 0, root: scrollAreaRef.current }
     );
 
-    gameRefs.current.values().forEach((ref) => {
+    gameRefs.current.forEach((ref) => {
       if (ref) observer.observe(ref);
     });
 


### PR DESCRIPTION
Error appeared in Firefox 128 ESR and possibly other browsers
![Screenshot_2025-06-14_21-56-51](https://github.com/user-attachments/assets/f4986c3a-4509-4b44-9ded-f822428d6e6c)
