### PR TITLE
UI: Fix version in About modal

### DIFF
--- a/rcongui/src/components/layout/sidebar/About.jsx
+++ b/rcongui/src/components/layout/sidebar/About.jsx
@@ -60,7 +60,7 @@ export default function AboutDialog() {
     }
   }, [open])
 
-  const latestReleaseVersion = releases?.[0]?.tag_name ?? ''
+  const latestReleaseVersion = (releases?.[0]?.tag_name || releases?.[0]?.name)  ?? ''
   const isUpToDate = isNewerVersion(apiVersion.trim(), latestReleaseVersion.trim())
 
   return (


### PR DESCRIPTION
This should fix it. Either they changed the property name or there was some merge issue at some point or entirely my f up.
