### PR TITLE
Update Dockerfile-frontend

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -1,4 +1,4 @@
-ARG buildImage=node:20-buster-slim
+ARG buildImage=node:20-bookworm-slim
 
 FROM $buildImage AS adminbuild
 


### PR DESCRIPTION
Debian Buster repo has been decommited, apt commands can't reach it anymore.

This isn't a prob in "vanilla" CRCONs, as this dockerfile is only used when building new Docker images.

I successfully built Docker images using the new "bookworm" Debian release.