### PR TITLE
Feat: Go to map in the rotation

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -544,8 +544,8 @@ class ServerCtl:
     def set_welcome_message(self, message) -> str:
         return self._str_request(f"say {message}", log_info=True, can_fail=False)
 
-    def set_map(self, map_name: str) -> str:
-        return self._str_request(f"map {map_name}", log_info=True)
+    def set_map(self, map_name: str, map_ordinal: int = 1) -> str:
+        return self._str_request(f"map {map_name} {map_ordinal}", log_info=True)
 
     def get_current_map_sequence(self) -> list[str]:
         return self._str_request("listcurrentmapsequence").split("\n")[:-1]

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -896,10 +896,10 @@ class Rcon(ServerCtl):
 
         return self.next_map
 
-    def set_map(self, map_name: str) -> None:
+    def set_map(self, map_name: str, map_ordinal: int = 1) -> None:
         with invalidates(Rcon.get_map, Rcon.get_next_map):
             try:
-                res = super().set_map(map_name)
+                res = super().set_map(map_name, map_ordinal)
                 if res != SUCCESS:
                     raise CommandFailedError(res)
             except CommandFailedError:
@@ -907,7 +907,7 @@ class Rcon(ServerCtl):
                 self.add_map_to_rotation(
                     map_name, maps[len(maps) - 1], maps.count(maps[len(maps) - 1])
                 )
-                if res := super().set_map(map_name) != SUCCESS:
+                if res := super().set_map(map_name, map_ordinal) != SUCCESS:
                     raise CommandFailedError(res)
 
     @ttl_cache(ttl=10)

--- a/rcongui/src/hooks/useMapChange.js
+++ b/rcongui/src/hooks/useMapChange.js
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useGlobalStore } from "@/stores/global-state";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  Box,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { toast } from "react-toastify";
+import {
+  mapsManagerMutationOptions,
+  mapsManagerQueryKeys,
+} from "@/pages/settings/maps/queries";
+import { MapDetailsCardCompact } from "@/pages/settings/maps/MapDetailsCard";
+
+export const useMapChange = () => {
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [mapToConfirm, setMapToConfirm] = useState(null);
+  const serverState = useGlobalStore((state) => state.serverState);
+  const queryClient = useQueryClient();
+
+  const { mutate: changeMap } = useMutation({
+    ...mapsManagerMutationOptions.changeMap,
+    onSuccess: (response) => {
+      const mapName = response.arguments.map_name;
+      queryClient.invalidateQueries({
+        queryKey: mapsManagerQueryKeys.gameState,
+      });
+      toast.success(`Map has been changed to ${mapName}`, {
+        toastId: `map-change-success`,
+      });
+    },
+    onError: (error) => {
+      toast.error(
+        <div>
+          <span>{error.name}</span>
+          <p>{error.message}</p>
+        </div>,
+        {
+          toastId: "map-change-error",
+        }
+      );
+    },
+  });
+
+  const openMapChangeDialog = (mapLayer, mapOrdinal = 1) => {
+    setMapToConfirm({ mapLayer, mapOrdinal });
+    setConfirmDialogOpen(true);
+  };
+
+  const handleConfirmMapChange = () => {
+    if (mapToConfirm) {
+      setConfirmDialogOpen(false);
+      changeMap({
+        mapId: mapToConfirm.mapLayer.id,
+        mapOrdinal: mapToConfirm.mapOrdinal,
+      });
+    }
+  };
+
+  const MapChangeDialog = () => (
+    <Dialog
+      open={confirmDialogOpen}
+      onClose={() => setConfirmDialogOpen(false)}
+      fullWidth
+      maxWidth="xs"
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle>
+        <div>Set current map: {mapToConfirm?.mapLayer?.pretty_name}</div>
+        <div>Server: {serverState?.name || "this server"}</div>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This will set a 60 seconds timer and override the current active map.
+        </DialogContentText>
+        {mapToConfirm && (
+          <Box
+            sx={{
+              mt: 2,
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              p: 2,
+              borderRadius: 1,
+              border: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <MapDetailsCardCompact mapLayer={mapToConfirm.mapLayer} />
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setConfirmDialogOpen(false)} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleConfirmMapChange}
+          color="primary"
+          variant="contained"
+          startIcon={<CheckCircleIcon />}
+        >
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+
+  return { MapChangeDialog, openMapChangeDialog };
+};

--- a/rcongui/src/pages/settings/maps/MapListBuilder.jsx
+++ b/rcongui/src/pages/settings/maps/MapListBuilder.jsx
@@ -109,6 +109,8 @@ export function MapListBuilder({
     setMapSelection(selectedMaps.map(withSelectionId));
   };
 
+  const changesMade = !_.isEqual(selectedMaps.map(m => m.id), mapSelection.map(m => m.id))
+
   return (
     <>
       <Grid container spacing={1}>
@@ -189,6 +191,7 @@ export function MapListBuilder({
               onClear={clearSelection}
               setMaps={setMapSelection}
               onReset={handleSelectionReset}
+              unsavedChanges={changesMade}
               // must come from parent element
               onSave={handleSelectionSave}
               isDisabled={isSaveDisabled}

--- a/rcongui/src/pages/settings/maps/list/index.jsx
+++ b/rcongui/src/pages/settings/maps/list/index.jsx
@@ -1,68 +1,15 @@
 import { useRouteLoaderData } from "react-router-dom";
 import { useState } from "react";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  Button,
-  Box,
-} from "@mui/material";
+import { Box } from "@mui/material";
 import { MapList } from "../MapList";
 import { MapChangeListItem } from "../MapListItem";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import { MapDetailsCardCompact } from "../MapDetailsCard";
-import { useGlobalStore } from "@/stores/global-state";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { mapsManagerMutationOptions, mapsManagerQueryKeys } from "../queries";
-import { toast } from "react-toastify";
 import { MapFilter } from "../MapFilter";
+import { useMapChange } from "@/hooks/useMapChange";
 
 const MapListPage = () => {
   const { maps } = useRouteLoaderData("maps");
-  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
-  const [mapToConfirm, setMapToConfirm] = useState(null);
   const [filteredMapOptions, setFilteredMapOptions] = useState(maps);
-  const serverState = useGlobalStore((state) => state.serverState);
-  const queryClient = useQueryClient();
-
-  const { mutate: changeMap } = useMutation({
-    ...mapsManagerMutationOptions.changeMap,
-    onSuccess: (response) => {
-      const mapName = response.arguments.map_name;
-      queryClient.invalidateQueries({
-        queryKey: mapsManagerQueryKeys.gameState,
-      });
-      toast.success(`Map has been changed to ${mapName}`, {
-        toastId: `map-change-success`,
-      });
-      setConfirmDialogOpen(false);
-    },
-    onError: (error) => {
-      toast.error(
-        <div>
-          <span>{error.name}</span>
-          <p>{error.message}</p>
-        </div>,
-        {
-          toastId: "map-change-error",
-        }
-      );
-      setConfirmDialogOpen(false);
-    },
-  });
-
-  const handleChangeMapClick = (mapLayer) => {
-    setMapToConfirm(mapLayer);
-    setConfirmDialogOpen(true);
-  };
-
-  const handleConfirmMapChange = () => {
-    if (mapToConfirm) {
-      changeMap(mapToConfirm.mapId || mapToConfirm.id);
-    }
-  };
+  const { MapChangeDialog, openMapChangeDialog } = useMapChange();
 
   const handleFilterChange = (filteredMaps) => {
     setFilteredMapOptions(filteredMaps);
@@ -74,7 +21,7 @@ const MapListPage = () => {
         sx={{
           height: "fit-content",
           py: 2,
-          maxWidth: theme => theme.breakpoints.values.md,
+          maxWidth: (theme) => theme.breakpoints.values.md,
         }}
       >
         <MapFilter maps={maps} onFilterChange={handleFilterChange} />
@@ -84,60 +31,12 @@ const MapListPage = () => {
             <MapChangeListItem
               mapLayer={mapLayer}
               key={mapLayer.id}
-              onClick={handleChangeMapClick}
+              onClick={() => openMapChangeDialog(mapLayer)}
             />
           )}
         />
       </Box>
-      {/* Confirmation Dialog */}
-      <Dialog
-        open={confirmDialogOpen}
-        onClose={() => setConfirmDialogOpen(false)}
-        fullWidth
-        maxWidth="xs"
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle>
-          <div>Set current map: {mapToConfirm?.pretty_name}</div>
-          <div>Server: {serverState?.name || "this server"}</div>
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            This will set a 60 seconds timer and override the current active
-            map.
-          </DialogContentText>
-          {mapToConfirm && (
-            <Box
-              sx={{
-                mt: 2,
-                display: "flex",
-                alignItems: "center",
-                gap: 2,
-                p: 2,
-                borderRadius: 1,
-                border: "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              <MapDetailsCardCompact mapLayer={mapToConfirm} />
-            </Box>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmDialogOpen(false)} color="inherit">
-            Cancel
-          </Button>
-          <Button
-            onClick={handleConfirmMapChange}
-            color="primary"
-            variant="contained"
-            startIcon={<CheckCircleIcon />}
-          >
-            Confirm
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <MapChangeDialog />
     </>
   );
 };

--- a/rcongui/src/pages/settings/maps/queries.js
+++ b/rcongui/src/pages/settings/maps/queries.js
@@ -89,8 +89,8 @@ export const mapsManagerMutationOptions = {
 
   // Change current map
   changeMap: {
-    mutationFn: (mapId) =>
-      cmd.SET_MAP({ payload: { map_name: mapId }, throwRouteError: false }),
+    mutationFn: ({ mapId, mapOrdinal = 1 }) =>
+      cmd.SET_MAP({ payload: { map_name: mapId, map_ordinal: mapOrdinal }, throwRouteError: false }),
   },
 
   // Set map rotation shuffle

--- a/rcongui/src/pages/settings/maps/rotation/builder/SortableRotationItem.jsx
+++ b/rcongui/src/pages/settings/maps/rotation/builder/SortableRotationItem.jsx
@@ -1,10 +1,11 @@
 import { Box, IconButton, Tooltip } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import SubdirectoryArrowLeftIcon from '@mui/icons-material/SubdirectoryArrowLeft';
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { MapDetailsCard } from "../../MapDetailsCard";
 
-function SortableRotationItem({ item, onRemove }) {
+function SortableRotationItem({ item, remove, mapChange, mapChangeDisabled }) {
   const {
     attributes,
     listeners,
@@ -65,8 +66,13 @@ function SortableRotationItem({ item, onRemove }) {
         <MapDetailsCard mapLayer={mapLayer} />
       </Box>
       <Box sx={{ display: "flex", gap: 1 }}>
+      <Tooltip title="Set to current map">
+          <IconButton size="small" onClick={mapChange} disabled={mapChangeDisabled} color="primary">
+            <SubdirectoryArrowLeftIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
         <Tooltip title="Remove from rotation">
-          <IconButton size="small" onClick={() => onRemove(mapLayer)} color="error">
+          <IconButton size="small" onClick={remove} color="error">
             <CloseIcon fontSize="small" />
           </IconButton>
         </Tooltip>

--- a/rcongui/src/pages/settings/maps/rotation/builder/SortableRotationList.jsx
+++ b/rcongui/src/pages/settings/maps/rotation/builder/SortableRotationList.jsx
@@ -19,6 +19,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import SortableRotationItem from "./SortableRotationItem";
 import CopyToClipboardButton from "@/components/shared/CopyToClipboardButton";
 import ReplayIcon from "@mui/icons-material/Replay";
+import { useMapChange } from "@/hooks/useMapChange";
 
 export function SortableRotationList({
   maps,
@@ -30,7 +31,10 @@ export function SortableRotationList({
   onSave,
   isDisabled,
   actions,
+  unsavedChanges,
 }) {
+  const { MapChangeDialog, openMapChangeDialog } = useMapChange();
+
   // Set up DnD sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -173,13 +177,18 @@ export function SortableRotationList({
               items={maps.map((item) => item.selectionId)}
               strategy={verticalListSortingStrategy}
             >
-              {maps.map((item, index) => (
-                <SortableRotationItem
-                  key={item.selectionId}
-                  item={item}
-                  onRemove={onRemove}
-                />
-              ))}
+              {maps.map((item, index, arr) => {
+                let mapOrdinal = arr.slice(0, index + 1).filter(m => m.id === item.id).length
+                return (
+                  <SortableRotationItem
+                    key={item.selectionId}
+                    item={item}
+                    remove={() => onRemove(item)}
+                    mapChange={() => openMapChangeDialog(item, mapOrdinal)}
+                    mapChangeDisabled={unsavedChanges}
+                  />
+                )
+              })}
             </SortableContext>
           </DndContext>
         ) : (
@@ -210,6 +219,7 @@ export function SortableRotationList({
           </Box>
         )}
       </Box>
+      <MapChangeDialog />
     </Box>
   );
 }


### PR DESCRIPTION
Implementation of ?forgotten `map_ordinal` parameter in [Map command](https://gist.github.com/DeteCT0R/7d2837729d98eea8f82888e0c48c323c#map-map_name-map_ordinal).

```python
    def set_map(self, map_name: str, map_ordinal: int = 1) -> str:
        return self._str_request(f"map {map_name} {map_ordinal}", log_info=True)
```

Users are now able to go to a specific map in the rotation via the UI.
> e.g. First Driel is selected, the next map will be El Alamein, and Foy when the second Driel is selected.

<img width="1290" height="1066" alt="image" src="https://github.com/user-attachments/assets/7a010918-2fe0-4d54-a02b-c96b5bee8e5e" />
