### PR TITLE
Display system usage information

### DIFF
--- a/rcongui/src/components/layout/SideMenu.js
+++ b/rcongui/src/components/layout/SideMenu.js
@@ -57,19 +57,10 @@ export default function SideMenu() {
       <ServerStatus />
       <Divider />
       <MenuContent navigationTree={navMenus} />
-      <List dense>
-        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
-          <ListItemText
-            sx={{ marginLeft: -0.5 }}
-            primary={<ConnectionStatus />}
-          />
-        </ListItem>
-        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
-          <ListItemText
-            sx={{ marginLeft: -0.5 }}
-            primary={<SystemUsage />}
-          />
-        </ListItem>
+      <Divider />
+      <List dense sx={{ color: theme => theme.palette.text.secondary }}>
+        <ConnectionStatus />
+        <SystemUsage />
         <AboutDialog />
       </List>
       <Divider />

--- a/rcongui/src/components/layout/SideMenu.js
+++ b/rcongui/src/components/layout/SideMenu.js
@@ -11,6 +11,7 @@ import AboutDialog from "./sidebar/About";
 import ServerStatus from "../Header/server-status";
 import { useAppStore } from "@/stores/app-state";
 import { UserActions } from "./sidebar/UserActions";
+import SystemUsage from "./sidebar/SystemUsage";
 
 const drawerWidth = 240;
 
@@ -57,10 +58,16 @@ export default function SideMenu() {
       <Divider />
       <MenuContent navigationTree={navMenus} />
       <List dense>
-        <ListItem>
+        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
           <ListItemText
             sx={{ marginLeft: -0.5 }}
             primary={<ConnectionStatus />}
+          />
+        </ListItem>
+        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
+          <ListItemText
+            sx={{ marginLeft: -0.5 }}
+            primary={<SystemUsage />}
           />
         </ListItem>
         <AboutDialog />

--- a/rcongui/src/components/layout/SideMenuMobile.js
+++ b/rcongui/src/components/layout/SideMenuMobile.js
@@ -43,19 +43,9 @@ function AdminSideMenuMobile({ open, toggleDrawer }) {
   return (
     <MobileDrawer open={open} toggleDrawer={toggleDrawer}>
       <MenuContent navigationTree={navMenus} isMobile={true} />
-      <List>
-        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
-          <ListItemText
-            sx={{ marginLeft: -0.5 }}
-            primary={<ConnectionStatus />}
-          />
-        </ListItem>
-        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
-          <ListItemText
-            sx={{ marginLeft: -0.5 }}
-            primary={<SystemUsage />}
-          />
-        </ListItem>
+      <List dense sx={{ color: theme => theme.palette.text.secondary }}>
+        <ConnectionStatus />
+        <SystemUsage />
         <AboutDialog />
       </List>
       <Divider />

--- a/rcongui/src/components/layout/SideMenuMobile.js
+++ b/rcongui/src/components/layout/SideMenuMobile.js
@@ -11,6 +11,7 @@ import ToggleColorMode from "./ColorModeIconDropdown";
 import ColorSchemeSelector from "./ColorSchemeSelector";
 import { UserActions } from "./sidebar/UserActions";
 import CloseIcon from "@mui/icons-material/Close";
+import SystemUsage from "./sidebar/SystemUsage";
 
 const MobileDrawer = ({ open, toggleDrawer, children }) => {
   return (
@@ -42,11 +43,17 @@ function AdminSideMenuMobile({ open, toggleDrawer }) {
   return (
     <MobileDrawer open={open} toggleDrawer={toggleDrawer}>
       <MenuContent navigationTree={navMenus} isMobile={true} />
-      <List dense>
-        <ListItem>
+      <List>
+        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
           <ListItemText
             sx={{ marginLeft: -0.5 }}
             primary={<ConnectionStatus />}
+          />
+        </ListItem>
+        <ListItem sx={{ height: 20, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
+          <ListItemText
+            sx={{ marginLeft: -0.5 }}
+            primary={<SystemUsage />}
           />
         </ListItem>
         <AboutDialog />

--- a/rcongui/src/components/layout/sidebar/About.jsx
+++ b/rcongui/src/components/layout/sidebar/About.jsx
@@ -11,13 +11,12 @@ import ListItemButton from '@mui/material/ListItemButton'
 import { Divider, Stack, Typography, IconButton, Skeleton, useTheme, useMediaQuery } from '@mui/material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons'
-import { faBook } from '@fortawesome/free-solid-svg-icons'
+import { faBook, faCircleQuestion } from '@fortawesome/free-solid-svg-icons'
 import siteConfig from '@/config/siteConfig'
 import { cmd } from '@/utils/fetchUtils'
 import { useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { useGithubReleases } from '@/hooks/useGithubReleases'
-import { Box } from '@mui/material'
 import NewReleasesIcon from "@mui/icons-material/NewReleases";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { Suspense } from 'react';
@@ -65,18 +64,17 @@ export default function AboutDialog() {
 
   return (
     <React.Fragment>
-      <ListItem disablePadding onClick={handleClickOpen}>
-        <ListItemButton>
-          <ListItemText 
+      <ListItem disablePadding onClick={handleClickOpen} sx={{ height: 24, "& .MuiListItemText-root .MuiListItemText-primary": { fontSize: "0.75rem" } }}>
+        <ListItemButton sx={{ marginLeft: 0.5 }}>
+          <ListItemText
             primary={
-              <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-                <Box>About</Box>
+              <Stack direction={"row"} justifyContent={"space-between"} alignItems={"center"}>
+                <Stack alignItems={"center"} direction={"row"} gap={0.5}><FontAwesomeIcon icon={faCircleQuestion} />Version: {apiVersion}</Stack>
                 {unreadCount > 0 && (
                   <NewReleasesIcon sx={{ fill: (theme) => theme.palette.secondary.main }} />
                 )}
-              </Box>
+              </Stack>
             }
-            secondary={apiVersion}
           />
         </ListItemButton>
       </ListItem>

--- a/rcongui/src/components/layout/sidebar/About.jsx
+++ b/rcongui/src/components/layout/sidebar/About.jsx
@@ -21,6 +21,7 @@ import NewReleasesIcon from "@mui/icons-material/NewReleases";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { Suspense } from 'react';
 import { ReleaseNotes } from './ReleaseNotes';
+import { HIGHLIGHT } from './utils'
 
 const isNewerVersion = (a, b) => {
   const [aMajor, aMinor, aPatch] = a.split('.');
@@ -69,10 +70,7 @@ export default function AboutDialog() {
           <ListItemText
             primary={
               <Stack direction={"row"} justifyContent={"space-between"} alignItems={"center"}>
-                <Stack alignItems={"center"} direction={"row"} gap={0.5}><FontAwesomeIcon icon={faCircleQuestion} />Version: {apiVersion}</Stack>
-                {unreadCount > 0 && (
-                  <NewReleasesIcon sx={{ fill: (theme) => theme.palette.secondary.main }} />
-                )}
+                <Stack alignItems={"center"} direction={"row"} gap={0.5}><FontAwesomeIcon icon={faCircleQuestion} color={unreadCount > 0 ? HIGHLIGHT.danger : ""} />Version: {apiVersion}</Stack>
               </Stack>
             }
           />

--- a/rcongui/src/components/layout/sidebar/ConnectionStatus.jsx
+++ b/rcongui/src/components/layout/sidebar/ConnectionStatus.jsx
@@ -1,59 +1,92 @@
 import { useGlobalStore } from "@/stores/global-state";
-import { Typography, Box } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { ListItem, ListItemText, Stack, Tooltip } from "@mui/material";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faServer, faDesktop } from "@fortawesome/free-solid-svg-icons";
+import { HIGHLIGHT } from "./utils";
 
-const connectionStatus = {
-  none: 0,
-  full: 1,
-  backend: 2,
-};
-
-const StatusText = styled("div", {
-  shouldForwardProp: (prop) => prop !== "status",
-})(({ theme, status }) => ({
-  "&:before": {
-    content: "''",
-    display: "inline-block",
-    width: theme.spacing(1.5),
-    height: theme.spacing(1.5),
-    borderRadius: "50%",
-    backgroundColor:
-      status === connectionStatus.full
-        ? theme.palette.success.main
-        : status === connectionStatus.backend
-        ? theme.palette.warning.main
-        : theme.palette.error.main,
-    marginRight: theme.spacing(1),
-  },
-}));
-
-/**
- * Display the connection status of the web app to the backend server and the game server
- * 0 - Green - Connected to both
- * 1 - Yellow - Connected to backend only
- * 2 - Red - Not connected to either
- */
 const ConnectionStatus = () => {
   const backendConnected = useGlobalStore((state) => state.serverState);
   const gameConnected = useGlobalStore((state) => state.status);
 
-  const status =
-    backendConnected && gameConnected
-      ? connectionStatus.full
-      : backendConnected
-      ? connectionStatus.backend
-      : connectionStatus.none;
-
   return (
-    <Box>
-      <StatusText status={status}>
-        {status === connectionStatus.full
-          ? "Connected"
-          : status === connectionStatus.backend
-          ? "Game server not connected"
-          : "Disconnected"}
-      </StatusText>
-    </Box>
+    <>
+      <ListItem
+        sx={{
+          height: 20,
+          "& .MuiListItemText-root .MuiListItemText-primary": {
+            fontSize: "0.75rem",
+          },
+        }}
+      >
+        <ListItemText
+          sx={{ marginLeft: -0.5 }}
+          primary={
+            <Stack
+              direction={"row"}
+              justifyContent={"space-between"}
+              alignItems={"center"}
+            >
+              <Tooltip
+                enterDelay={1000}
+                enterNextDelay={500}
+                title={
+                  gameConnected
+                    ? "Successfully established connection between CRCON and HLL server"
+                    : !backendConnected
+                    ? "Connection between CRCON and HLL server is unknown"
+                    : "CRCON is not connected to the HLL server"
+                }
+              >
+                <Stack
+                  direction={"row"}
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                  gap={0.5}
+                >
+                  <FontAwesomeIcon
+                    icon={faServer}
+                    color={
+                      !gameConnected || !backendConnected
+                        ? HIGHLIGHT.danger
+                        : ""
+                    }
+                  />
+                  <div>
+                    {gameConnected
+                      ? "Online"
+                      : !backendConnected
+                      ? "Unknown"
+                      : "Offline"}
+                  </div>
+                </Stack>
+              </Tooltip>
+              <Tooltip
+                enterDelay={1000}
+                enterNextDelay={500}
+                title={
+                  backendConnected
+                    ? "Successfully connected to CRCON."
+                    : "The connection to CRCON has not been established"
+                }
+              >
+                <Stack
+                  direction={"row"}
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                  gap={0.5}
+                >
+                  <FontAwesomeIcon
+                    icon={faDesktop}
+                    color={!backendConnected ? HIGHLIGHT.danger : ""}
+                  />
+                  <div>{backendConnected ? "Online" : "Offline"}</div>
+                </Stack>
+              </Tooltip>
+            </Stack>
+          }
+        />
+      </ListItem>
+    </>
   );
 };
 

--- a/rcongui/src/components/layout/sidebar/ConnectionStatus.jsx
+++ b/rcongui/src/components/layout/sidebar/ConnectionStatus.jsx
@@ -8,7 +8,7 @@ const connectionStatus = {
   backend: 2,
 };
 
-const StatusText = styled(Typography, {
+const StatusText = styled("div", {
   shouldForwardProp: (prop) => prop !== "status",
 })(({ theme, status }) => ({
   "&:before": {
@@ -46,7 +46,7 @@ const ConnectionStatus = () => {
 
   return (
     <Box>
-      <StatusText variant="subtitle2" status={status}>
+      <StatusText status={status}>
         {status === connectionStatus.full
           ? "Connected"
           : status === connectionStatus.backend

--- a/rcongui/src/components/layout/sidebar/SystemUsage.jsx
+++ b/rcongui/src/components/layout/sidebar/SystemUsage.jsx
@@ -1,0 +1,89 @@
+import { cmd } from "@/utils/fetchUtils";
+import {
+  ListItem,
+  ListItemText,
+  Tooltip,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faMicrochip,
+  faHardDrive,
+  faMemory,
+} from "@fortawesome/free-solid-svg-icons";
+
+const SystemUsage = () => {
+  const { data: system, isLoading } = useQuery({
+    queryKey: [{ queryIdentified: "get_system_usage" }],
+    queryFn: cmd.GET_SYSTEM_USAGE,
+    refetchInterval: 15 * 1000,
+  });
+
+  return (
+    <Stack direction={"row"} justifyContent={"space-between"}>
+      <Tooltip
+        title={
+          !isLoading
+            ? `CPU Usage: ${system.cpu_usage.percent}% on a system with ${system.cpu_usage.cores} cores running ${system.cpu_usage.process_count} processes`
+            : "Loading..."
+        }
+      >
+        <Stack
+          direction={"row"}
+          justifyContent={"start"}
+          alignItems={"center"}
+          gap={0.5}
+        >
+          <FontAwesomeIcon icon={faMicrochip} />
+          <div>{`${!isLoading ? system.cpu_usage.percent : "?"}%`}</div>
+        </Stack>
+      </Tooltip>
+      <Tooltip
+        title={
+          !isLoading
+            ? `RAM Usage: ${system.ram_usage.percent}%. Used ${Number(
+                system.ram_usage.used
+              ).toFixed(1)} GB out of ${Number(system.ram_usage.total).toFixed(
+                1
+              )} GB of total memory`
+            : "Loading..."
+        }
+      >
+        <Stack
+          direction={"row"}
+          justifyContent={"start"}
+          alignItems={"center"}
+          gap={0.5}
+        >
+          <FontAwesomeIcon icon={faMemory} />
+          <div>{`${!isLoading ? system.ram_usage.percent : "?"}%`}</div>
+        </Stack>
+      </Tooltip>
+      <Tooltip
+        title={
+          !isLoading
+            ? `Storage Usage: ${system.disk_usage.percent}%. Used ${Number(
+                system.disk_usage.used
+              ).toFixed(1)} GB out of ${Number(system.disk_usage.total).toFixed(
+                1
+              )} GB of total disk space`
+            : "Loading..."
+        }
+      >
+        <Stack
+          direction={"row"}
+          justifyContent={"start"}
+          alignItems={"center"}
+          gap={0.5}
+        >
+          <FontAwesomeIcon icon={faHardDrive} />
+          <div>{`${!isLoading ? system.disk_usage.percent : "?"}%`}</div>
+        </Stack>
+      </Tooltip>
+    </Stack>
+  );
+};
+
+export default SystemUsage;

--- a/rcongui/src/components/layout/sidebar/SystemUsage.jsx
+++ b/rcongui/src/components/layout/sidebar/SystemUsage.jsx
@@ -13,6 +13,7 @@ import {
   faHardDrive,
   faMemory,
 } from "@fortawesome/free-solid-svg-icons";
+import { byUsage } from "./utils";
 
 const SystemUsage = () => {
   const { data: system, isLoading } = useQuery({
@@ -21,68 +22,108 @@ const SystemUsage = () => {
     refetchInterval: 15 * 1000,
   });
 
+  if (isLoading)
+    return (
+      <ListItem
+        sx={{
+          height: 20,
+          "& .MuiListItemText-root .MuiListItemText-primary": {
+            fontSize: "0.75rem",
+          },
+        }}
+      >
+        <ListItemText
+          sx={{ marginLeft: -0.5 }}
+          primary={
+            <Stack direction={"row"} justifyContent={"space-between"}>
+              <FontAwesomeIcon icon={faMicrochip} />
+              <FontAwesomeIcon icon={faMemory} />
+              <FontAwesomeIcon icon={faHardDrive} />
+            </Stack>
+          }
+        />
+      </ListItem>
+    );
+
   return (
-    <Stack direction={"row"} justifyContent={"space-between"}>
-      <Tooltip
-        title={
-          !isLoading
-            ? `CPU Usage: ${system.cpu_usage.percent}% on a system with ${system.cpu_usage.cores} cores running ${system.cpu_usage.process_count} processes`
-            : "Loading..."
-        }
-      >
-        <Stack
-          direction={"row"}
-          justifyContent={"start"}
-          alignItems={"center"}
-          gap={0.5}
-        >
-          <FontAwesomeIcon icon={faMicrochip} />
-          <div>{`${!isLoading ? system.cpu_usage.percent : "?"}%`}</div>
-        </Stack>
-      </Tooltip>
-      <Tooltip
-        title={
-          !isLoading
-            ? `RAM Usage: ${system.ram_usage.percent}%. Used ${Number(
+    <ListItem
+      sx={{
+        height: 20,
+        "& .MuiListItemText-root .MuiListItemText-primary": {
+          fontSize: "0.75rem",
+        },
+      }}
+    >
+      <ListItemText
+        sx={{ marginLeft: -0.5 }}
+        primary={
+          <Stack direction={"row"} justifyContent={"space-between"}>
+            <Tooltip
+              enterDelay={500}
+              enterNextDelay={500}
+              title={`CPU Usage: ${system.cpu_usage.percent}% on a system with ${system.cpu_usage.cores} cores running ${system.cpu_usage.process_count} processes [CRCON environment]`}
+            >
+              <Stack
+                direction={"row"}
+                justifyContent={"start"}
+                alignItems={"center"}
+                gap={0.5}
+              >
+                <FontAwesomeIcon
+                  icon={faMicrochip}
+                  color={byUsage(system.cpu_usage.percent)}
+                />
+                <div>{`${system.cpu_usage.percent}%`}</div>
+              </Stack>
+            </Tooltip>
+            <Tooltip
+              enterDelay={500}
+              enterNextDelay={500}
+              title={`RAM Usage: ${system.ram_usage.percent}% (${Number(
                 system.ram_usage.used
-              ).toFixed(1)} GB out of ${Number(system.ram_usage.total).toFixed(
-                1
-              )} GB of total memory`
-            : "Loading..."
-        }
-      >
-        <Stack
-          direction={"row"}
-          justifyContent={"start"}
-          alignItems={"center"}
-          gap={0.5}
-        >
-          <FontAwesomeIcon icon={faMemory} />
-          <div>{`${!isLoading ? system.ram_usage.percent : "?"}%`}</div>
-        </Stack>
-      </Tooltip>
-      <Tooltip
-        title={
-          !isLoading
-            ? `Storage Usage: ${system.disk_usage.percent}%. Used ${Number(
+              ).toFixed(1)} used GB out of ${Number(
+                system.ram_usage.total
+              ).toFixed(1)} GB of total CRCON environment)`}
+            >
+              <Stack
+                direction={"row"}
+                justifyContent={"start"}
+                alignItems={"center"}
+                gap={0.5}
+              >
+                <FontAwesomeIcon
+                  icon={faMemory}
+                  color={byUsage(system.ram_usage.percent)}
+                />
+                <div>{`${system.ram_usage.percent}%`}</div>
+              </Stack>
+            </Tooltip>
+            <Tooltip
+              enterDelay={500}
+              enterNextDelay={500}
+              title={`Storage Usage: ${system.disk_usage.percent}% (${Number(
                 system.disk_usage.used
-              ).toFixed(1)} GB out of ${Number(system.disk_usage.total).toFixed(
-                1
-              )} GB of total disk space`
-            : "Loading..."
+              ).toFixed(1)} GB used out of ${Number(
+                system.disk_usage.total
+              ).toFixed(1)} GB of total CRCON environment)`}
+            >
+              <Stack
+                direction={"row"}
+                justifyContent={"start"}
+                alignItems={"center"}
+                gap={0.5}
+              >
+                <FontAwesomeIcon
+                  icon={faHardDrive}
+                  color={byUsage(system.disk_usage.percent)}
+                />
+                <div>{`${system.disk_usage.percent}%`}</div>
+              </Stack>
+            </Tooltip>
+          </Stack>
         }
-      >
-        <Stack
-          direction={"row"}
-          justifyContent={"start"}
-          alignItems={"center"}
-          gap={0.5}
-        >
-          <FontAwesomeIcon icon={faHardDrive} />
-          <div>{`${!isLoading ? system.disk_usage.percent : "?"}%`}</div>
-        </Stack>
-      </Tooltip>
-    </Stack>
+      />
+    </ListItem>
   );
 };
 

--- a/rcongui/src/components/layout/sidebar/utils.js
+++ b/rcongui/src/components/layout/sidebar/utils.js
@@ -1,0 +1,14 @@
+export const HIGHLIGHT = {
+  danger: "#f44336",
+  warning: "#ffc107",
+  success: "#76ff03",
+};
+
+export const byUsage = (percentage) =>
+  typeof percentage !== "number"
+    ? ""
+    : percentage >= 80
+    ? HIGHLIGHT.danger
+    : percentage >= 67
+    ? HIGHLIGHT.warning
+    : "";

--- a/rcongui/src/features/title-manager/TitleManager.jsx
+++ b/rcongui/src/features/title-manager/TitleManager.jsx
@@ -33,9 +33,19 @@ const TitleManager = () => {
     isLoading: isServerLoading,
   } = useQuery({
     queryKey: [{ queryIdentifier: "get_status" }],
-    queryFn: cmd.GET_GAME_SERVER_STATUS,
+    queryFn: async () => {
+      let result;
+      try {
+        result = await cmd.GET_GAME_SERVER_STATUS()
+        useGlobalStore.setState((state) => ({ status: result }));
+      } catch (error) {
+        useGlobalStore.setState((state) => ({ status: null }));
+      }
+      return result
+    },
     refetchIntervalInBackground: true,
     refetchInterval: 30_000,
+    retry: 1,
   });
 
   const [pendingTitleIcon, setPendingTitleIcon] = useState("");

--- a/rcongui/src/stores/global-state.js
+++ b/rcongui/src/stores/global-state.js
@@ -31,11 +31,17 @@ const refetchInterval = 30 * 1000;
 const globalQueries = [
   queryOptions({
     queryKey: [{ queryIdentifier: "get_status" }],
-    queryFn: cmd.GET_GAME_SERVER_STATUS,
-    select: (data) => {
-      useGlobalStore.setState((state) => ({ status: data }));
-      return data;
+    queryFn: async () => {
+      let result;
+      try {
+        result = await cmd.GET_GAME_SERVER_STATUS()
+        useGlobalStore.setState((state) => ({ status: result }));
+      } catch (error) {
+        useGlobalStore.setState((state) => ({ status: null }));
+      }
+      return result
     },
+    retry: 1,
   }),
   queryOptions({
     queryKey: [{ queryIdentifier: "get_gamestate" }],

--- a/rcongui/src/utils/fetchUtils.js
+++ b/rcongui/src/utils/fetchUtils.js
@@ -174,6 +174,7 @@ export const cmd = {
   GET_SERVER_NAME: (params) => requestFactory({ method: "GET", cmd: "get_name", ...params }),
   GET_SERVER_SETTINGS: (params) => requestFactory({ method: "GET", cmd: "get_server_settings", ...params }),
   GET_SERVICES: (params) => requestFactory({ method: "GET", cmd: "get_services", ...params }),
+  GET_SYSTEM_USAGE: (params) => requestFactory({ method: "GET", cmd: "get_system_usage", ...params }),
   GET_VERSION: (params) => requestFactory({ method: "GET", cmd: "get_version", ...params }),
   GET_VIPS: (params) => requestFactory({ method: "GET", cmd: "get_vip_ids", ...params }),
   GET_VOTEKICK_AUTOTOGGLE_CONFIG: (params) => requestFactory({ method: "GET", cmd: "get_votekick_autotoggle_config", ...params }),

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -6,6 +6,7 @@ import traceback
 from functools import wraps
 from subprocess import PIPE, run
 from typing import Any, Callable
+import psutil
 
 import pydantic
 from django.http import (
@@ -145,6 +146,45 @@ def get_public_info(request):
         result=res,
         failed=False,
         command="get_public_info",
+    )
+
+@login_required()
+@csrf_exempt
+@require_http_methods(["GET"])
+def get_system_usage(request):
+    # CPU usage (percentage)
+    cpu_percent = psutil.cpu_percent(interval=None)
+    process_count = len(list(psutil.process_iter()))
+    cpu_usage = {
+        "cores": psutil.cpu_count(),
+        "percent": cpu_percent,
+        "process_count": process_count,
+    }
+
+    # RAM usage
+    memory = psutil.virtual_memory()
+    ram_usage = {
+        "total": memory.total / (1024**3),  # Convert to GB
+        "used": memory.used / (1024**3),
+        "percent": memory.percent,
+    }
+
+    # Disk usage
+    disk = psutil.disk_usage("/")
+    disk_usage = {
+        "total": disk.total / (1024**3),  # Convert to GB
+        "used": disk.used / (1024**3),
+        "percent": disk.percent,
+    }
+
+    return api_response(
+        result={
+            "cpu_usage": cpu_usage,
+            "ram_usage": ram_usage,
+            "disk_usage": disk_usage,
+        },
+        failed=False,
+        command="get_system_usage",
     )
 
 
@@ -891,6 +931,7 @@ commands = [
     ("get_connection_info", get_connection_info),
     ("get_public_info", get_public_info),
     ("run_raw_command", run_raw_command),
+    ("get_system_usage", get_system_usage)
 ]
 
 if not os.getenv("HLL_MAINTENANCE_CONTAINER") and not os.getenv(

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ git+https://github.com/cemathey/django-directory@f51ee1e8dc50edf453fee4a0d9631c0
 pre-commit
 humanize==4.12.3
 httpx==0.28.1
+psutil==7.0.0


### PR DESCRIPTION
Added cpu, ram and disk usage information.
A minor change in styling the bottom section about connection and version details.

I believe this is useful information to have and save some logging into the environment directly.

🆕 API endpoint `/api/get_system_usage`
> example
```
{
    "cpu_usage": {
        "cores": 4,
        "percent": 10.4,
        "process_count": 4
    },
    "ram_usage": {
        "total": 15.244922637939453,
        "used": 7.427345275878906,
        "percent": 51.5
    },
    "disk_usage": {
        "total": 149.91522216796875,
        "used": 26.94037628173828,
        "percent": 18.7
    }
}
```

<img width="681" height="1800" alt="image" src="https://github.com/user-attachments/assets/0a523f5e-305f-4f97-8d32-50a7f49b8da1" />
