### PR TITLE
Feat: Persist player level information

### DIFF
--- a/alembic/versions/78098bd1bbb0_add_level_column_to_playerstats.py
+++ b/alembic/versions/78098bd1bbb0_add_level_column_to_playerstats.py
@@ -1,0 +1,24 @@
+"""Add level column to PlayerStats
+
+Revision ID: 78098bd1bbb0
+Revises: f80b6dc2833a
+Create Date: 2025-08-12 12:37:30.321976
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '78098bd1bbb0'
+down_revision = 'f80b6dc2833a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('player_stats', sa.Column('level', sa.Integer, nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('player_stats', 'level')

--- a/rcon/logs/loop.py
+++ b/rcon/logs/loop.py
@@ -287,13 +287,16 @@ class LogLoop:
                     p_defense=0,
                     support=player["support"],
                     p_support=0,
+                    level=player["level"],
                 ),
             )
+
             for stat in ["combat", "offense", "defense", "support"]:
                 if player[stat] < p[stat]:
                     p["p_" + stat] = p["p_" + stat] + p[stat]
-
                 p[stat] = player[stat]
+            
+            p["level"] = player["level"]
             map_players[player_id] = p
         maps.update(0, m)
 

--- a/rcon/models.py
+++ b/rcon/models.py
@@ -592,6 +592,7 @@ class PlayerStats(Base):
         foreign_keys=[player_id_id], back_populates="stats"
     )
     map: Mapped[Maps] = relationship(back_populates="player_stats")
+    level: Mapped[int] = mapped_column()
 
     def detect_team(self) -> PlayerTeamAssociation:
         def get_value(item):
@@ -680,6 +681,7 @@ class PlayerStats(Base):
             "weapons": self.weapons,
             "death_by_weapons": self.death_by_weapons,
             "team": self.detect_team(),
+            "level": self.level,
         }
 
 

--- a/rcon/player_stats.py
+++ b/rcon/player_stats.py
@@ -205,6 +205,7 @@ class BaseStats:
                 "offense": 0,
                 "defense": 0,
                 "support": 0,
+                "level": 0,
             }
 
             streaks = Streaks()
@@ -607,6 +608,7 @@ def current_game_stats():
         stat["offense"] = map_stat["offense"] + map_stat["p_offense"]
         stat["defense"] = map_stat["defense"] + map_stat["p_defense"]
         stat["support"] = map_stat["support"] + map_stat["p_support"]
+        stat["level"] = map_stat["level"]
     return stats
 
 

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -460,6 +460,7 @@ class PlayerStat(TypedDict):
     p_defense: int
     support: int
     p_support: int
+    level: int
 
 
 class CachedLiveGameStats(TypedDict):

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -449,6 +449,7 @@ class PlayerStatsType(TypedDict):
     weapons: Optional[dict]
     death_by_weapons: Optional[dict]
     team: Optional[PlayerTeamAssociation]
+    level: int
 
 
 class PlayerStat(TypedDict):
@@ -602,6 +603,7 @@ class PlayerProfileType(BasicPlayerProfileType):
     flags: list[PlayerFlagType]
     watchlist: Optional[WatchListType]
     vips: Optional[list[PlayerVIPType]]
+    level: int
 
 
 class PlayerProfileTypeEnriched(PlayerProfileType):

--- a/rcon/workers.py
+++ b/rcon/workers.py
@@ -216,6 +216,7 @@ def record_stats_from_map(
                 p_offense=0,
                 p_defense=0,
                 p_support=0,
+                level=0,
             )
             if existing is not None:
                 default_stat = PlayerStat(
@@ -227,6 +228,7 @@ def record_stats_from_map(
                     p_defense=0,
                     support=existing.support,
                     p_support=0,
+                    level=existing.level
                 )
             map_stats: PlayerStat = ps.get(player_id, default_stat)
             player_stat = dict(
@@ -258,6 +260,7 @@ def record_stats_from_map(
                 offense=map_stats.get("offense", 0) + map_stats.get("p_offense", 0),
                 defense=map_stats.get("defense", 0) + map_stats.get("p_defense", 0),
                 support=map_stats.get("support", 0) + map_stats.get("p_support", 0),
+                level=map_stats.get("level", 0),
             )
             if existing is not None and force != True:
                 continue
@@ -291,6 +294,7 @@ def record_stats_from_map(
                 existing.offense = player_stat.get("offense")
                 existing.defense = player_stat.get("defense")
                 existing.support = player_stat.get("support")
+                existing.level = player_stat.get("level")
             else:
                 logger.debug(f"Saving stats %s", player_stat)
                 player_stat_record = PlayerStats(**player_stat)

--- a/rcongui/src/components/PlayerProfileDrawer/index.jsx
+++ b/rcongui/src/components/PlayerProfileDrawer/index.jsx
@@ -24,6 +24,7 @@ import { TabContext, TabPanel } from "@mui/lab";
 import dayjs from "dayjs";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CloseIcon from "@mui/icons-material/Close";
 import { useActionDialog } from "@/hooks/useActionDialog";
 import { usePlayerSidebar } from "@/hooks/usePlayerSidebar";
 import { generatePlayerActions } from "@/features/player-action/actions";
@@ -38,6 +39,7 @@ import {
 import PlayerProfileHeader from "../player/profile/Header";
 import PlayerProfileSummary from "../player/profile/Summary";
 import PlayerProfileStatusTags from "../player/profile/StatusTags";
+import { ActionMenu } from "@/features/player-action/ActionMenu";
 
 const Penalties = ({ punish, kick, tempBan, parmaBan }) => (
   <dl>
@@ -203,18 +205,43 @@ const PlayerDetails = ({ player, onClose }) => {
   });
   const name = player?.name ?? profile.names[0]?.name ?? "?";
   const avatar = profile?.steaminfo?.profile?.avatar;
+  const country = profile?.country ?? profile?.steaminfo?.country;
+  const level = player?.level ?? player?.profile?.level ?? 0;
 
   return (
     <ProfileWrapper component={"article"}>
-      <PlayerProfileHeader
-        player={player}
-        isOnline={isOnline}
-        onClose={onClose}
-        handleActionClick={handleActionClick([player])}
+      <Box sx={{ paddingTop: 2, paddingLeft: 8 }}>
+        <PlayerProfileHeader
+          player={player}
+          isOnline={isOnline}
+          avatar={avatar}
+          name={name}
+          country={country}
+          level={level}
+        />
+      </Box>
+      <ActionMenu
+        handleActionClick={handleActionClick}
         actionList={actionList}
-        avatar={avatar}
-        name={name}
+        sx={{
+          position: "absolute",
+          top: (theme) => theme.spacing(1),
+          left: (theme) => theme.spacing(0.5),
+        }}
       />
+      {onClose && (
+        <IconButton
+          sx={{
+            position: "absolute",
+            top: (theme) => theme.spacing(1),
+            right: (theme) => theme.spacing(0.5),
+          }}
+          size="small"
+          onClick={onClose}
+        >
+          <CloseIcon />
+        </IconButton>
+      )}
       <Divider />
       <PlayerProfileStatusTags
         isVip={isVip}

--- a/rcongui/src/components/player/profile/Header.jsx
+++ b/rcongui/src/components/player/profile/Header.jsx
@@ -1,78 +1,120 @@
 import { OnlineStatusBadge, ProfileHeader } from "./styled";
-import { Avatar, Box, IconButton, Typography, Button } from "@mui/material";
+import { Avatar, Box, Typography, Stack, Chip } from "@mui/material";
 import { Link } from "react-router-dom";
-import { faSteam } from "@fortawesome/free-brands-svg-icons";
+import { faSteam, faXbox } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CopyableText from "@/components/shared/CopyableText";
-import { isSteamPlayer, getSteamProfileUrl } from "@/utils/lib";
-import CloseIcon from "@mui/icons-material/Close";
-import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
-import { ActionMenu } from "@/features/player-action/ActionMenu";
+import {
+  isSteamPlayer,
+  getSteamProfileUrl,
+  levelToRank,
+  toSnakeCase,
+} from "@/utils/lib";
+import { ActionMenu, ActionMenuButton } from "@/features/player-action/ActionMenu";
+import { generatePlayerActions } from "@/features/player-action/actions";
 
-const PlayerProfileHeader = ({ player, isOnline, onClose, handleActionClick, actionList, avatar, name }) => {
+const PlayerProfileHeader = ({
+  player,
+  isOnline,
+  handleActionClick,
+  actionList,
+  avatar,
+  name,
+  level,
+  country,
+}) => {
   return (
     <ProfileHeader rowGap={1}>
-      <OnlineStatusBadge
-        overlap="circular"
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        variant="dot"
-        isOnline={isOnline}
-      >
-        <Avatar src={avatar}>{name[0]}</Avatar>
-      </OnlineStatusBadge>
-      <Box sx={{ flexGrow: 1 }}>
-        <Typography
-          component={"h1"}
-          variant="h6"
-          sx={{ textOverflow: "ellipsis" }}
-        >
-          <Link
-            style={{ color: "inherit" }}
-            to={`/records/players/${player?.player_id ?? profile.player_id}`}
+      <Stack direction={"row"} gap={2}>
+        <Box sx={{ position: "relative" }}>
+          <OnlineStatusBadge
+            overlap="circular"
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            variant="dot"
+            isOnline={isOnline}
           >
-            {name}
-          </Link>
-        </Typography>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-          <CopyableText text={player?.player_id ?? profile.player_id} />
+            <Avatar src={avatar}>{name[0]}</Avatar>
+          </OnlineStatusBadge>
         </Box>
-        <Box>
-          {isSteamPlayer(player) && (
-            <Button
-              variant={"outline"}
-              LinkComponent={"a"}
-              href={getSteamProfileUrl(player.player_id)}
-              target="_blank"
-              rel="noreferrer"
+        <Stack direction={"row"} justifyContent={"space-between"} flexGrow={1}>
+          <Stack>
+            <Typography
+              textOverflow={"ellipsis"}
+              fontSize={"1.125rem"}
+              fontWeight={600}
+              lineHeight={"1.25rem"}
+              marginBottom={0.2}
             >
-              <FontAwesomeIcon icon={faSteam} />
-            </Button>
+              <Link
+                style={{ color: "inherit" }}
+                to={`/records/players/${
+                  player?.player_id ?? profile.player_id
+                }`}
+              >
+                {name}
+              </Link>
+            </Typography>
+            <Box
+              sx={{ display: "flex", alignItems: "center", marginBottom: 0.75 }}
+            >
+              <CopyableText
+                text={player?.player_id ?? profile.player_id}
+                size="0.75rem"
+                sx={{ color: (theme) => theme.palette.text.secondary }}
+              />
+            </Box>
+          </Stack>
+          {actionList && handleActionClick && (
+            <ActionMenuButton
+              withProfile
+              recipients={{ player_id: player.player_id, name }}
+              actions={actionList}
+            />
           )}
-          {!isSteamPlayer(player) && <SportsEsportsIcon />}
-        </Box>
-      </Box>
-      {onClose && (
-        <IconButton
-          sx={{
-            position: "absolute",
-            top: (theme) => theme.spacing(0.5),
-            right: (theme) => theme.spacing(0.5),
-          }}
-        size="small"
-          onClick={onClose}
-        >
-          <CloseIcon />
-        </IconButton>
-      )}
-      <ActionMenu
-        handleActionClick={handleActionClick}
-        actionList={actionList}
-        sx={{
-          position: "absolute",
-          top: (theme) => theme.spacing(0.5),
-          left: (theme) => theme.spacing(0.5),
-        }}
-      />
+        </Stack>
+      </Stack>
+      <Stack direction={"row"} gap={1} alignItems={"center"}>
+        {!!level && (
+          <Chip
+            avatar={
+              <Avatar
+                alt="Natacha"
+                src={`/icons/ranks/${toSnakeCase(levelToRank(level))}.webp`}
+              />
+            }
+            label={level}
+          />
+        )}
+        {isSteamPlayer(player) ? (
+          <Chip
+            component={"a"}
+            href={getSteamProfileUrl(player.player_id)}
+            target="_blank"
+            rel="noreferrer"
+            icon={<FontAwesomeIcon icon={faSteam} />}
+            label="Steam"
+            sx={{ "&:hover": { cursor: "pointer" } }}
+          />
+        ) : (
+          <Chip
+            icon={<FontAwesomeIcon icon={faXbox} />}
+            label="Other"
+          />
+        )}
+        {country && (
+          <Chip
+            avatar={
+              <Avatar
+                alt="Natacha"
+                src={`https://flagcdn.com/w20/${country.toLowerCase()}.png`}
+              />
+            }
+            label={country}
+            variant="outlined"
+            size="small"
+          />
+        )}
+      </Stack>
     </ProfileHeader>
   );
 };

--- a/rcongui/src/components/player/profile/styled.jsx
+++ b/rcongui/src/components/player/profile/styled.jsx
@@ -53,13 +53,9 @@ export const ProfileWrapper = styled(Box)(({ theme }) => ({
 }));
 
 export const ProfileHeader = styled(Stack)(({ theme }) => ({
-  paddingRight: theme.spacing(1),
-  paddingLeft: theme.spacing(2),
-  paddingTop: theme.spacing(2),
-  marginBottom: theme.spacing(1),
-  alignItems: "center",
-  textAlign: "center",
-  position: "relative",
+  marginBottom: theme.spacing(0.5),
+  justifyContent: "center",
+  width: 330,
 }));
 
 export const Message = styled(Box)(({ theme }) => ({

--- a/rcongui/src/components/shared/CountryFlag.jsx
+++ b/rcongui/src/components/shared/CountryFlag.jsx
@@ -1,15 +1,18 @@
+import { Box } from "@mui/material";
 import { getName } from "country-list";
 
-export const CountryFlag = ({ country }) => {
+export const CountryFlag = ({ country, ...props }) => {
   const countryName = getName(country);
   return (
-    <img
+    <Box
+      component={"img"}
       src={`https://flagcdn.com/w20/${country.toLowerCase()}.png`}
       width={20}
       height={10}
       aria-label={`Flag of ${countryName}`}
       alt={countryName}
       title={countryName}
+      {...props}
     />
   );
 };

--- a/rcongui/src/components/shared/RankIcon.jsx
+++ b/rcongui/src/components/shared/RankIcon.jsx
@@ -1,7 +1,9 @@
 import { toSnakeCase } from "@/utils/lib";
+import { Box } from "@mui/material";
 
 export const RankIcon = ({ rank, ...props }) => (
-    <img
+    <Box
+      component={"img"}
       src={`/icons/ranks/${toSnakeCase(rank)}.webp`}
       width={16}
       height={16}

--- a/rcongui/src/components/shared/card/PlayerCard.jsx
+++ b/rcongui/src/components/shared/card/PlayerCard.jsx
@@ -1,15 +1,10 @@
-import { ActionMenuButton } from "@/features/player-action/ActionMenu";
 import { generatePlayerActions } from "@/features/player-action/actions";
 import {
   Card,
-  CardHeader,
   CardContent,
-  Avatar,
   Stack,
   Divider,
   Typography,
-  Box,
-  Badge,
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -17,11 +12,21 @@ import NoAccountsIcon from "@mui/icons-material/NoAccounts";
 import GavelIcon from "@mui/icons-material/Gavel";
 import dayjs from "dayjs";
 import Emoji from "@/components/shared/Emoji";
-import CopyableText from "../CopyableText";
-import { Link } from "react-router-dom";
-import { CountryFlag } from "../CountryFlag";
+import PlayerProfileHeader from "@/components/player/profile/Header";
+import { useActionDialog } from "@/hooks/useActionDialog";
 
 export default function PlayerCard({ player }) {
+  const { openDialog } = useActionDialog();
+
+  const handleActionClick = (recipients) => (action) => {
+    openDialog(action, recipients);
+  };
+
+  const actionList = generatePlayerActions({
+    multiAction: false,
+    onlineAction: player.is_online,
+  });
+
   const name = player.names.length > 0 ? player.names[0].name : "???";
   const avatar = player?.steaminfo?.profile?.avatar ?? name;
   const flags = player?.flags;
@@ -39,57 +44,32 @@ export default function PlayerCard({ player }) {
     .duration(player.total_playtime_seconds * 1000)
     .asHours()
     .toFixed(1);
+  const level = player?.level ?? player?.profile?.level ?? 0;
 
   return (
-    <Card sx={{ height: "100%", width: "100%" }}>
-      <CardHeader
-        avatar={
-          <Badge
-            overlap="circular"
-            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-            badgeContent={country ? <CountryFlag country={country} /> : null}
-          >
-            <Avatar src={avatar}>{name.charAt(0)}</Avatar>
-          </Badge>
-        }
-        title={
-          <Box
-            component={Link}
-            to={`/records/players/${player.player_id}`}
-            sx={{
-              fontSize: "1rem",
-              color: "text.primary",
-              fontWeight: 500,
-            }}
-          >
-            {name}
-          </Box>
-        }
-        subheader={<CopyableText text={player.player_id} />}
-        subheaderTypographyProps={{
-          fontSize: "0.7rem",
-        }}
-        titleTypographyProps={{
-          fontSize: 18,
-        }}
-        action={
-          <ActionMenuButton
-            withProfile
-            recipients={{
+    <Card>
+      <CardContent>
+        <PlayerProfileHeader
+          player={player}
+          isOnline={player.is_online}
+          handleActionClick={handleActionClick([
+            {
               player_id: player.player_id,
               name,
-            }}
-            actions={generatePlayerActions()}
-          />
-        }
-      />
-      <CardContent>
+            },
+          ])}
+          actionList={actionList}
+          avatar={avatar}
+          name={name}
+          country={country}
+          level={level}
+        />
         <Stack
           direction="row"
           alignItems={"center"}
           justifyContent={"center"}
           spacing={1}
-          sx={{ pt: 1, height: 30 }}
+          sx={{ height: 30 }}
         >
           {flags?.map(({ flag }) => (
             <Typography key={flag} variant="body" color="text.secondary">

--- a/rcongui/src/pages/records/players/[playerId]/index.jsx
+++ b/rcongui/src/pages/records/players/[playerId]/index.jsx
@@ -63,6 +63,8 @@ export default function PlayerProfilePage() {
   });
   const name = profile?.name ?? profile.names[0]?.name ?? "?";
   const avatar = profile?.steaminfo?.profile?.avatar;
+  const country = profile?.country ?? profile?.steaminfo?.country
+  const level = thisOnlinePlayer?.level ?? profile?.level ?? 0
 
   const { openDialog } = useActionDialog();
 
@@ -100,6 +102,8 @@ export default function PlayerProfilePage() {
               actionList={actionList}
               avatar={avatar}
               name={name}
+              country={country}
+              level={level}
             />
             <Divider />
             <PlayerProfileStatusTags

--- a/rcongui_public/src/components/game/statistics/game-columns.tsx
+++ b/rcongui_public/src/components/game/statistics/game-columns.tsx
@@ -14,6 +14,7 @@ import {HeartCrackIcon, HeartOffIcon, ScaleIcon, SkullIcon, ZapIcon} from "lucid
 import {ColumnCategory} from "@/lib/tables";
 import {Awards} from "@/components/game/statistics/award";
 import {PlayerBaseWithAwards} from "@/pages/games/[id]";
+import { Level } from './level'
 
 const threeDigitsWidth = 40
 const fourDigitsWidth = 50
@@ -417,12 +418,32 @@ const statusColumn: ColumnDef<Player | PlayerWithStatus> = {
   enableHiding: false,
 }
 
+const levelColumn = (): ColumnDef<Player | PlayerWithStatus> => {
+  const { t } = useTranslation('game')
+
+  return {
+    id: 'level',
+    accessorKey: 'level',
+    meta: { label: t('playersTable.level'), category: ColumnCategory.GENERAL },
+    size: threeDigitsWidth,
+    header: function LevelHeader() {
+      const { t } = useTranslation('game')
+      return <div>{t('playersTable.level')}</div>
+    },
+    cell: ({ row }) => {
+      const player = row.original
+      return <div className='text-center font-bold'><Level level={player.level} /></div>
+    },
+  }
+}
+
 export const getLiveGameColumns = (handlePlayerClick: (id: string) => void): ColumnDef<Player | PlayerWithStatus>[] => [
   statusColumn,
+  levelColumn(),
   playerColumn(handlePlayerClick),
   ...pointColumns(false),
 ]
 
 export const getCompletedGameColumns = (
   handlePlayerClick: (id: string) => void,
-): ColumnDef<Player | PlayerWithStatus | PlayerBaseWithAwards>[] => [teamColumn(), playerColumn(handlePlayerClick), awardColumn(), ...pointColumns(true)]
+): ColumnDef<Player | PlayerWithStatus | PlayerBaseWithAwards>[] => [teamColumn(), levelColumn(), playerColumn(handlePlayerClick), awardColumn(), ...pointColumns(true)]

--- a/rcongui_public/src/components/game/statistics/level.tsx
+++ b/rcongui_public/src/components/game/statistics/level.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import {cn} from '@/lib/utils'
+import { getPlayerTier } from './utils'
+import { useTheme } from '@/hooks/use-theme-provider'
+
+type LevelProps = {
+  level: number
+} & React.HTMLAttributes<HTMLSpanElement>
+
+export function Level({ level, ...props }: LevelProps) {
+  const theme = useTheme()
+
+  if (level < 1) {
+    return null
+  }
+
+  const tier = getPlayerTier(level)
+
+  if (tier === "Novice") {
+    return <span className={cn(theme.theme === 'light' ? 'text-red-700' : 'text-red-500', props.className)}>{level}</span>
+  } else if (tier === "Apprentice") {
+    return <span className={cn(theme.theme === 'light' ? 'text-yellow-800' : 'text-yellow-500', props.className)}>{level}</span>
+  } else if (tier === "Expert") {
+    return <span className={cn(theme.theme === 'light' ? 'text-green-700' : 'text-green-500', props.className)}>{level}</span>
+  } else if (tier === "Master") {
+    return <span className={cn(theme.theme === 'light' ? 'text-blue-700' : 'text-blue-500', props.className)}>{level}</span>
+  } else {
+    return <span className={cn(theme.theme === 'light' ? 'text-purple-700' : 'text-purple-500', props.className)}>{level}</span>
+  }
+}

--- a/rcongui_public/src/components/game/statistics/utils.ts
+++ b/rcongui_public/src/components/game/statistics/utils.ts
@@ -54,3 +54,48 @@ export const generateTicks = (max: number, interval: number, negative?: boolean)
 
   return ticks;
 }
+
+// https://hellletloose.fandom.com/wiki/Career_level
+export const levelToRank = (level: number) => {
+  if (level < 20) return "Private";
+  if (level < 30) return "Private First Class";
+  if (level < 40) return "Corporal";
+  if (level < 50) return "Sergeant";
+  if (level < 60) return "Staff Sergeant";
+  if (level < 70) return "First Sergeant";
+  if (level < 80) return "Master Sergeant";
+  if (level < 90) return "2nd Lieutenant";
+  if (level < 100) return "1st Lieutenant";
+  if (level < 150) return "Captain";
+  if (level < 200) return "Major";
+  if (level < 250) return "Lieutenant Colonel";
+  if (level < 300) return "Colonel";
+  if (level < 350) return "Brigadier General";
+  if (level < 400) return "Major General";
+  if (level < 450) return "Lieutenant General";
+  if (level < 500) return "General";
+  return "General of the Army";
+};
+
+export function getPlayerTier(level: number) {
+  if (level < 20) {
+    return "Novice";
+  } else if (level >= 20 && level < 75) {
+    return "Apprentice";
+  } else if (level >= 75 && level < 200) {
+    return "Expert";
+  } else if (level >= 200 && level < 350) {
+    return "Master";
+  } else {
+    return "Legend";
+  }
+}
+
+// Returns tier colors based on theme mode ("light" or "dark")
+export const getTierColors = (mode = "light") => ({
+  Novice: mode === "dark" ? colors.red[500] : colors.red[700],
+  Apprentice: mode === "dark" ? colors.yellow[500] : colors.yellow[800],
+  Expert: mode === "dark" ? colors.green[500] : colors.green[700],
+  Master: mode === "dark" ? colors.blue[500] : colors.blue[700],
+  Legend: mode === "dark" ? colors.purple[500] : colors.purple[700],
+});

--- a/rcongui_public/src/i18n/locales/en/game.json
+++ b/rcongui_public/src/i18n/locales/en/game.json
@@ -48,7 +48,8 @@
         "deathsPerMinute": "DPM",
         "general":  "General",
         "advanced": "Advanced",
-        "ingame": "Ingame"
+        "ingame": "Ingame",
+        "level": "Level"
     },
     "weaponType": {
       "sniper": "Sniper",

--- a/rcongui_public/src/types/player.ts
+++ b/rcongui_public/src/types/player.ts
@@ -115,6 +115,7 @@ export interface PlayerBase {
   weapons: Record<Weapon, number>
   death_by_weapons: Record<Weapon, number> | null
   team: PlayerTeamAssociation
+  level: number
 }
 
 export interface PlayerTeamAssociation {


### PR DESCRIPTION
The level is stored on the same principle as combat, ..., support scores and runs as a part of the log loop -> record player stats routine and so the level is persisted on the match end. This way each match stats will persist the player's level at the time of the game not the last known. The known "bug" is that the admin UI won't display the player's level after disconnect and before the match ends. 

There is a slight UI change in the player profile card due to this change.

<img width="3119" height="1789" alt="image" src="https://github.com/user-attachments/assets/9a00f98e-62d5-4657-96ca-0ab1e303da54" />

<img width="3119" height="1792" alt="image" src="https://github.com/user-attachments/assets/cba757f5-0057-4f7a-abd1-2a34a5654073" />
