### PR TITLE
Fix: seeder vip overwrite bug

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -744,11 +744,17 @@ class Rcon(ServerCtl):
                 )
                 session.add(vip_record)
             else:
-                previous_expiration = vip_record.expiration.isoformat()
-                vip_record.expiration = expiration_date
-                logger.info(
-                    f"Modified PlayerVIP record {player.player_id=} {vip_record.expiration} {previous_expiration=}"
-                )
+                previous_expiration_dt = vip_record.expiration
+                # Do not shorten existing expirations
+                if expiration_date > previous_expiration_dt:
+                    vip_record.expiration = expiration_date
+                    logger.info(
+                        f"Modified PlayerVIP record {player.player_id=} {vip_record.expiration} previous_expiration={previous_expiration_dt.isoformat()}"
+                    )
+                else:
+                    logger.info(
+                        f"Preserved PlayerVIP record {player.player_id=} previous_expiration={previous_expiration_dt.isoformat()} (ignored shorter expiration_date={expiration_date})"
+                    )
 
         return result
 

--- a/rcon/seed_vip/utils.py
+++ b/rcon/seed_vip/utils.py
@@ -252,7 +252,7 @@ def reward_players(
 
         if has_indefinite_vip(player):
             logger.info(
-                f"{config.dry_run=} Skipping! pre-existing indefinite VIP for {player_id=} {player=} {vip_name=} {expiration_date=}"
+                f"{config.dry_run=} Skipping! pre-existing indefinite VIP for {player_id=} {player=} {expiration_date=}"
             )
             continue
 


### PR DESCRIPTION
### What was wrong
- The seed vip plugin filtered `current_vips` down to only online players before:
  - excluding lifetime VIPs, and
  - carrying over existing expirations.
- If an already‑VIP earner went offline right before seeding:
  - `player = current_vips.get(player_id)` became None
  - The code treated them like a non‑VIP and overwrote their expiration with the short seed reward (even reducing lifetime and longer finite VIPs).

### Temporary workaround
- Set `requirements.online_when_seeded = true`.
  - Only online players at the seed moment are rewarded, so offline pre‑existing VIPs aren’t touched and can’t be overwritten.
  - This avoids the bug but isn’t a real fix if you want to credit offline earners (accumulate mode).

### What the PR fixes
- In `rcon/seed_vip/service.py`:
  - Use the full VIP list (`all_vips = get_vips(...)`) for logic; do not filter to online.
  - Exclude indefinite VIPs from `to_add_vip_steam_ids` using `all_vips`.
  - Build `expiration_timestamps` using `all_vips` so existing expirations are carried forward or extended properly.
  - Call `reward_players(..., current_vips=all_vips, ...)` so offline VIPs are recognized and not overwritten.
- In `rcon/rcon.py:add_vip`:
  - Add a safety guard to never shorten an existing VIP expiration. If the new expiration is earlier, ignore it and keep the previous one.
- In `rcon/seed_vip/utils.py`:
  - Fix the skip‑log to avoid referencing `vip_name` before it’s defined. Note: your latest manual change reintroduced `{vip_name=}` in the skip log; either remove it again or compute `vip_name` before the skip branch.

This combination preserves lifetime and longer finite VIPs even when qualifying players go offline before the server seeds, and hardens the DB layer against any future logic regressions.