### PR TITLE
fix: ensure that player_id is always treated as a string when add or remove vip

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -88,7 +88,6 @@ LOG_ACTIONS = [
 ]
 logger = logging.getLogger(__name__)
 
-
 CTL: Optional["Rcon"] = None
 
 
@@ -263,7 +262,7 @@ class Rcon(ServerCtl):
         players = self.get_players()
         fail_count = 0
         players_by_id: dict[str, GetDetailedPlayer] = {}
-        
+
         all_player_info = {
             p["iD"]: p
             for p in super().get_all_player_info()
@@ -362,10 +361,10 @@ class Rcon(ServerCtl):
 
     @ttl_cache(ttl=1)
     def get_structured_logs(
-        self,
-        since_min_ago: int,
-        filter_action: str | None = None,
-        filter_player: str | None = None,
+            self,
+            since_min_ago: int,
+            filter_action: str | None = None,
+            filter_player: str | None = None,
     ) -> ParsedLogsType:
         raw = super().get_logs(since_min_ago)
         return self.parse_logs(raw, filter_action, filter_player)
@@ -375,7 +374,7 @@ class Rcon(ServerCtl):
         return super().get_admin_groups()
 
     def get_logs(
-        self, since_min_ago: str | int, filter_: str = "", by: str = ""
+            self, since_min_ago: str | int, filter_: str = "", by: str = ""
     ) -> list[str]:
         """Returns raw text logs from the game server with no parsing performed
 
@@ -388,10 +387,13 @@ class Rcon(ServerCtl):
 
     @overload
     def get_player_ids(
-        self, as_dict: Literal[False] = False
-    ) -> list[tuple[str, str]]: ...
+            self, as_dict: Literal[False] = False
+    ) -> list[tuple[str, str]]:
+        ...
+
     @overload
-    def get_player_ids(self, as_dict: Literal[True] = False) -> dict[str, str]: ...
+    def get_player_ids(self, as_dict: Literal[True] = False) -> dict[str, str]:
+        ...
 
     def get_player_ids(self, as_dict=False) -> dict[str, str] | list[tuple[str, str]]:
         raw_list = super().get_player_ids()
@@ -409,7 +411,7 @@ class Rcon(ServerCtl):
         return vip_count
 
     def _guess_squad_type(
-        self, squad
+            self, squad
     ) -> Literal["armor", "recon", "commander", "infantry"]:
         for player in squad.get("players", []):
             if player.get("role") in ["tankcommander", "crewman"]:
@@ -441,7 +443,7 @@ class Rcon(ServerCtl):
             logger.exception("Can't get player info for %s", player_id)
             # logger.exception("Can't get player info for %s", player)
             return {}
-        
+
         if player["iD"] != player_id:
             logger.error(
                 "get_player_info('%s') returned for a different id: %s %s",
@@ -464,7 +466,8 @@ class Rcon(ServerCtl):
             raise HLLCommandFailedError("Got bad data")
         return self._get_detailed_player_info(player_id, raw, player)
 
-    def _get_detailed_player_info(self, player_id: str, raw: dict[str, Any], player: GetPlayersType | None = None) -> GetDetailedPlayer:
+    def _get_detailed_player_info(self, player_id: str, raw: dict[str, Any],
+                                  player: GetPlayersType | None = None) -> GetDetailedPlayer:
         player_data = parse_raw_player_info(raw, player_id)
         if player is not None and 'is_vip' in player:
             player_data["is_vip"] = player.get('is_vip')
@@ -567,7 +570,6 @@ class Rcon(ServerCtl):
 
     def remove_vip(self, player_id) -> bool:
         """Removes VIP status on the game server and removes their PlayerVIP record."""
-        player_id = str(player_id)
 
         # Remove VIP before anything else in case we have errors
         with invalidates(Rcon.get_vip_ids):
@@ -605,11 +607,9 @@ class Rcon(ServerCtl):
         return result
 
     def add_vip(
-        self, player_id: str, description: str, expiration: str | None = None
+            self, player_id: str, description: str, expiration: str | None = None
     ) -> bool:
         """Adds VIP status on the game server and adds or updates their PlayerVIP record."""
-        player_id = str(player_id)
-
         with invalidates(Rcon.get_vip_ids):
             # Add VIP before anything else in case we have errors
             result = super().add_vip(player_id, description)
@@ -692,12 +692,12 @@ class Rcon(ServerCtl):
         return True
 
     def message_player(
-        self,
-        player_id: str,
-        message: str = "",
-        by: str = "",
-        save_message: bool = False,
-        player_name: str | None = None,
+            self,
+            player_id: str,
+            message: str = "",
+            by: str = "",
+            save_message: bool = False,
+            player_name: str | None = None,
     ) -> bool:
         config = RconServerSettingsUserConfig.load_from_db()
         if config.message_enhancements.enabled:
@@ -731,9 +731,9 @@ class Rcon(ServerCtl):
         Map: foy_warfare
         Next Map: stmariedumont_warfare"""
         with invalidates(
-            Rcon.team_sizes,
-            Rcon.get_team_objective_scores,
-            Rcon.get_round_time_remaining,
+                Rcon.team_sizes,
+                Rcon.get_team_objective_scores,
+                Rcon.get_round_time_remaining,
         ):
             return super().get_gamestate()
 
@@ -787,9 +787,9 @@ class Rcon(ServerCtl):
 
     def set_map_shuffle_enabled(self, enabled: bool) -> None:
         with invalidates(
-            Rcon.get_map_sequence,
-            Rcon.get_map_shuffle_enabled,
-            Rcon.get_next_map,
+                Rcon.get_map_sequence,
+                Rcon.get_map_shuffle_enabled,
+                Rcon.get_next_map,
         ):
             return super().set_map_shuffle_enabled(enabled)
 
@@ -983,7 +983,7 @@ class Rcon(ServerCtl):
             return super().set_votekick_enabled(value)
 
     def set_votekick_thresholds(
-        self, threshold_pairs: list[tuple[int, int]]
+            self, threshold_pairs: list[tuple[int, int]]
     ):
         with invalidates(self.get_votekick_thresholds):
             flattened = [str(val) for val in chain.from_iterable(threshold_pairs)]
@@ -1048,12 +1048,12 @@ class Rcon(ServerCtl):
         return res
 
     def temp_ban(
-        self,
-        player_id: str,
-        duration_hours: int = 2,
-        reason: str = "",
-        by: str = "",
-        player_name: str | None = None,
+            self,
+            player_id: str,
+            duration_hours: int = 2,
+            reason: str = "",
+            by: str = "",
+            player_name: str | None = None,
     ) -> bool:
         with invalidates(Rcon.get_players, Rcon.get_temp_bans):
             res = super().temp_ban(
@@ -1119,32 +1119,32 @@ class Rcon(ServerCtl):
         return maps
 
     def add_map_to_rotation(
-        self,
-        map_name: str,
-        after_map_name: str | None = None,
+            self,
+            map_name: str,
+            after_map_name: str | None = None,
     ) -> None:
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_map_sequence,
-            Rcon.get_next_map,
+                Rcon.get_map_rotation,
+                Rcon.get_map_sequence,
+                Rcon.get_next_map,
         ):
             return super().add_map_to_rotation(
                 map_name, after_map_name
             )
 
     def add_map_to_rotation_at_index(
-        self,
-        map_name: str,
-        map_index: int,
+            self,
+            map_name: str,
+            map_index: int,
     ) -> None:
         if map_index < 0:
             rotation = self.get_map_rotation()
             map_index = len(rotation) + map_index + 1
 
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_map_sequence,
-            Rcon.get_next_map,
+                Rcon.get_map_rotation,
+                Rcon.get_map_sequence,
+                Rcon.get_next_map,
         ):
             return super().add_map_to_rotation_at_index(
                 map_name, map_index
@@ -1152,9 +1152,9 @@ class Rcon(ServerCtl):
 
     def remove_map_from_rotation(self, map_name: str):
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_map_sequence,
-            Rcon.get_next_map
+                Rcon.get_map_rotation,
+                Rcon.get_map_sequence,
+                Rcon.get_next_map
         ):
             return super().remove_map_from_rotation(map_name)
 
@@ -1164,17 +1164,17 @@ class Rcon(ServerCtl):
             map_index = len(rotation) + map_index + 1
 
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_map_sequence,
-            Rcon.get_next_map
+                Rcon.get_map_rotation,
+                Rcon.get_map_sequence,
+                Rcon.get_next_map
         ):
             return super().remove_map_from_rotation_at_index(map_index)
 
     def remove_maps_from_rotation(self, map_names: list[str]):
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_map_sequence,
-            Rcon.get_next_map
+                Rcon.get_map_rotation,
+                Rcon.get_map_sequence,
+                Rcon.get_next_map
         ):
             for map_name in map_names:
                 super().remove_map_from_rotation(map_name)
@@ -1184,9 +1184,9 @@ class Rcon(ServerCtl):
         rotation = self.get_map_rotation()
         results = []
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_map_sequence,
-            Rcon.get_next_map
+                Rcon.get_map_rotation,
+                Rcon.get_map_sequence,
+                Rcon.get_next_map
         ):
             for map_index, map_name in enumerate(map_names, start=len(rotation)):
                 super().add_map_to_rotation_at_index(
@@ -1206,9 +1206,9 @@ class Rcon(ServerCtl):
         rotation_size = len(rotation)
 
         with invalidates(
-            Rcon.get_map_rotation,
-            Rcon.get_next_map,
-            Rcon.get_map_sequence
+                Rcon.get_map_rotation,
+                Rcon.get_next_map,
+                Rcon.get_map_sequence
         ):
             # Do nothing if rotations are the same
             current_map_names = [map_.id for map_ in rotation]
@@ -1232,9 +1232,9 @@ class Rcon(ServerCtl):
         return super().get_objective_rows()
 
     def set_game_layout(
-        self,
-        objectives: Sequence[str | int | None],
-        random_constraints: GameLayoutRandomConstraints = GameLayoutRandomConstraints(0),
+            self,
+            objectives: Sequence[str | int | None],
+            random_constraints: GameLayoutRandomConstraints = GameLayoutRandomConstraints(0),
     ):
         if len(objectives) != 5:
             raise ValueError("5 objectives must be provided")
@@ -1407,8 +1407,8 @@ class Rcon(ServerCtl):
                 player = match.groups()[0]
             # VOTESYS: Player [NoodleArms] Started a vote of type (PVR_Kick_Abuse) against [buscÃ´O-sensei]. VoteID: [2]
             elif match := re.match(
-                Rcon.vote_started_pattern,
-                raw_line,
+                    Rcon.vote_started_pattern,
+                    raw_line,
             ):
                 action = "VOTE STARTED"
                 player, player2 = match.groups()
@@ -1483,9 +1483,9 @@ class Rcon(ServerCtl):
 
     @staticmethod
     def parse_logs(
-        raw_logs: list[str],
-        filter_action: str | None = None,
-        filter_player: str | None = None,
+            raw_logs: list[str],
+            filter_action: str | None = None,
+            filter_player: str | None = None,
     ) -> ParsedLogsType:
         """Parse a chunk of raw gameserver RCON logs"""
         synthetic_actions = LOG_ACTIONS
@@ -1495,7 +1495,7 @@ class Rcon(ServerCtl):
         players: set[str] = set()
 
         for raw_relative_time, raw_timestamp, raw_log_line in Rcon.split_raw_log_lines(
-            raw_logs
+                raw_logs
         ):
             time = Rcon._extract_time(raw_timestamp)
             try:


### PR DESCRIPTION
When a VIP was added through the /api/add_vip endpoint, the response returned success (HTTP 200). However, when checking for the inserted VIP, it did not exist. After reviewing the logs, an error was identified — it occurred due to a comparison being made between an integer and a string.

the player_id parameter is typed as str in the function signature, but somewhere in the call chain, it's being passed as an integer.

Solution:
Ensure that player_id is converted to a string at the beginning of both the add_vip and remove_vip methods.