### PR TITLE
FIX - U18 - Automod NoLeader punishing unassigned players

### DIFF
--- a/rcon/automods/no_leader.py
+++ b/rcon/automods/no_leader.py
@@ -158,7 +158,7 @@ class NoLeaderAutomod:
             self.logger.debug("Server below min player count : disabling")
             return punitions_to_apply
 
-        if not squad_name:
+        if squad_name == "unassigned":
             self.logger.debug(
                 "Skipping None or empty squad - (%s) %s", team, squad_name
             )


### PR DESCRIPTION
In RCON V1, unassigned players "squad_name" variable was None, so the automod ignored them : https://github.com/MarechJ/hll_rcon_tool/blob/ceb8a25819dd33fe8dc9e3f9b1121949f0506d8f/rcon/automods/no_leader.py#L161

Now they are in a "squad" named "unassigned" : so there IS a squad name, so the automod "sees" them.

Just changed the "is None" check to "== 'unassigned'"