### PR TITLE
Use `unit_name` vs `unit` in player profile drawer

### DIFF
--- a/rcongui/src/components/PlayerProfileDrawer/index.jsx
+++ b/rcongui/src/components/PlayerProfileDrawer/index.jsx
@@ -394,7 +394,7 @@ const PlayerGameDetails = ({ player }) => {
         <TableBody>
           {[
             "level",
-            "unit",
+            "unit_name",
             "loadout",
             "team",
             "role",


### PR DESCRIPTION
`unit` appears to never had existed in the get_team_view call