### PR TITLE
"none" like rconv1 instead of None for team

### DIFF
--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -427,7 +427,7 @@ def parse_raw_player_info(raw: dict[str, Any], player) -> GetDetailedPlayer:
     faction = hllrcon.data.Faction.by_id(raw["team"])
     role = hllrcon.data.Role.by_id(raw["role"])
 
-    data["team"] = faction.team.name.lower() if faction else None
+    data["team"] = faction.team.name.lower() if faction else "none"
     data["role"] = role.name.lower() if role else None
     data["loadout"] = raw["loadout"].lower()
     data["level"] = int(raw["level"])


### PR DESCRIPTION
Old rconv1 used to have the string "none" as the player team when they were waiting in the lobby and had not picked a team yet.  Using the keyword None here instead results in the player being left out of the results from get_team_view which means the player does not show in the player table in live view and is shown as offline on their player profile.