### PR TITLE
API: expose message_all_players

### DIFF
--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -395,6 +395,7 @@ def run_raw_command(request):
 
 
 ENDPOINT_PERMISSIONS: dict[Callable, list[str] | set[str] | str] = {
+    rcon_api.message_all_players: "api.can_message_players",
     rcon_api.disband_squad: "api.can_disband_squad",
     rcon_api.disband_squad_by_name: "api.can_disband_squad",
     rcon_api.remove_player_from_squad: "api.can_remove_player_from_squad",
@@ -681,6 +682,7 @@ DEPRECATED_ENDPOINTS = (
 )
 
 RCON_ENDPOINT_HTTP_METHODS: dict[Callable, list[str]] = {
+    rcon_api.message_all_players: ["POST"],
     rcon_api.disband_squad: ["POST"],
     rcon_api.disband_squad_by_name: ["POST"],
     rcon_api.remove_player_from_squad: ["POST"],


### PR DESCRIPTION
Expose message_all_players to web API

POST `/api/message_all_players `
```
{
  message: str
}
```