### PR TITLE
Fix player name used by parse_raw_player_info

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -289,7 +289,7 @@ class Rcon(ServerCtl):
                 continue
 
             try:
-                player_data = self._get_detailed_player_info(player_id, player_info, player)
+                player_data = self._get_detailed_player_info(player_info, player)
             except Exception:
                 logger.error("Failed to get info for %s", player_id)
                 fail_count += 1
@@ -483,11 +483,12 @@ class Rcon(ServerCtl):
             raw = super().get_player_info(player_id)
         except HLLCommandError:
             raise HLLCommandFailedError("Player is not online")
-        return self._get_detailed_player_info(player_id, raw, player)
+        return self._get_detailed_player_info(raw, player)
 
-    def _get_detailed_player_info(self, player_id: str, raw: dict[str, Any],
-                                  player: GetPlayersType | None = None) -> GetDetailedPlayer:
-        player_data = parse_raw_player_info(raw, player_id)
+    def _get_detailed_player_info(
+        self, raw: dict[str, Any], player: GetPlayersType | None = None
+    ) -> GetDetailedPlayer:
+        player_data = parse_raw_player_info(raw)
         if player is not None and 'is_vip' in player:
             player_data["is_vip"] = player.get('is_vip')
         else:

--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -419,10 +419,10 @@ def default_player_info_dict(player) -> GetDetailedPlayer:
     }
 
 
-def parse_raw_player_info(raw: dict[str, Any], player) -> GetDetailedPlayer:
+def parse_raw_player_info(raw: dict[str, Any]) -> GetDetailedPlayer:
     """Parse the result of the playerinfo command from the game server"""
 
-    data = default_player_info_dict(player)
+    data = default_player_info_dict(raw["name"])
 
     # Remap keys and parse values
     data[PLAYER_ID] = raw["iD"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,7 +112,7 @@ def mock_get_detailed_player(
 
 
 @pytest.mark.parametrize(
-    "raw, name, expected",
+    "raw, expected",
     [
         (
             {
@@ -121,6 +121,7 @@ def mock_get_detailed_player(
                 "role": 5,
                 "level": "16",
                 "loadout": "Standard Issue",
+                "name": "MasterShake",
                 "platoon": "JIG",
                 "scoreData": {
                     "cOMBAT": 72,
@@ -140,9 +141,8 @@ def mock_get_detailed_player(
                 "eosId": "",
                 "worldPosition": {},
             },
-            "MasterShake",
             mock_get_detailed_player(
-                name="",
+                name="MasterShake",
                 clan_tag="GH",
                 eos_id="",
                 platform="steam",
@@ -172,6 +172,7 @@ def mock_get_detailed_player(
                 "role": 0,
                 "level": "16",
                 "loadout": "Standard Issue",
+                "name": "MasterShake",
                 "platoon": "ABLE",
                 "scoreData": {
                     "cOMBAT": 72,
@@ -191,9 +192,8 @@ def mock_get_detailed_player(
                 "eosId": "",
                 "worldPosition": {},
             },
-            "MasterShake",
             mock_get_detailed_player(
-                name="",
+                name="MasterShake",
                 clan_tag="GH",
                 eos_id="",
                 platform="steam",
@@ -218,5 +218,5 @@ def mock_get_detailed_player(
         ),
     ],
 )
-def test_parse_raw_player_info(raw, name, expected):
-    assert parse_raw_player_info(raw=raw, player="") == expected
+def test_parse_raw_player_info(raw, expected):
+    assert parse_raw_player_info(raw=raw) == expected


### PR DESCRIPTION
Was causing the player's ID to get added as the players most recent name upon being added to a blacklist