### PR TITLE
UI: Navigation drawer search & more

### DIFF
--- a/rcongui/src/components/Header/nav-data.js
+++ b/rcongui/src/components/Header/nav-data.js
@@ -111,6 +111,11 @@ export const navMenus = [
         icon: <PeopleIcon />,
       },
       {
+        name: "Vips",
+        to: "/records/vips",
+        icon: <GradeIcon />,
+      },
+      {
         name: "Blacklist",
         to: "/records/blacklists",
         icon: <AccountBalanceIcon />,
@@ -155,11 +160,6 @@ export const navMenus = [
         name: "Console Admins",
         to: "/settings/console-admins",
         icon: <AdminPanelSettingsIcon />,
-      },
-      {
-        name: "Vips",
-        to: "/settings/vip",
-        icon: <GradeIcon />,
       },
       {
         name: "Templates",

--- a/rcongui/src/components/layout/MenuContent.js
+++ b/rcongui/src/components/layout/MenuContent.js
@@ -7,10 +7,11 @@ import Stack from "@mui/material/Stack";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { Link } from "react-router-dom";
-import { Collapse, TextField, InputAdornment } from "@mui/material";
+import { Collapse, TextField, InputAdornment, IconButton } from "@mui/material";
 import {useState} from "react";
 import { useAppStore } from "@/stores/app-state";
 import SearchIcon from "@mui/icons-material/Search";
+import CloseIcon from "@mui/icons-material/Close";
 
 const NavigationLink = ({ to, icon, text, onClick }) => {
 
@@ -116,23 +117,31 @@ export default function MenuContent({ navigationTree, isMobile }) {
         overflow: "hidden",
       }}
     >
-      <TextField
-        size="small"
-        placeholder="Search..."
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
-        sx={{ mb: 1 }}
-        slotProps={{
-          input: {
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-          }
-        }}
-      />
-      <List dense sx={{ overflowY: "auto" }}>
+      <Stack direction={"row"} alignItems={"start"} spacing={0.5}>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Search..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          sx={{ mb: 1 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            }
+          }}
+        />
+        {isMobile && (
+          <IconButton size="small" onClick={toggleDrawer}>
+            <CloseIcon sx={{ fontSize: 24 }} />
+          </IconButton>
+        )}
+      </Stack>
+      <List dense sx={{ overflowY: "auto", scrollbarWidth: "none" }}>
         {filteredTree
           .filter((group) => !("name" in group))
           .map((group) =>

--- a/rcongui/src/components/layout/SideMenuMobile.js
+++ b/rcongui/src/components/layout/SideMenuMobile.js
@@ -3,14 +3,13 @@ import Drawer, { drawerClasses } from "@mui/material/Drawer";
 import Stack from "@mui/material/Stack";
 import MenuContent from "./MenuContent";
 import SelectContent from "./SelectContent";
-import { Box, List, ListItem, ListItemText, IconButton } from "@mui/material";
+import { Box, List } from "@mui/material";
 import { navMenus } from "../Header/nav-data";
 import ConnectionStatus from "./sidebar/ConnectionStatus";
 import AboutDialog from "./sidebar/About";
 import ToggleColorMode from "./ColorModeIconDropdown";
 import ColorSchemeSelector from "./ColorSchemeSelector";
 import { UserActions } from "./sidebar/UserActions";
-import CloseIcon from "@mui/icons-material/Close";
 import SystemUsage from "./sidebar/SystemUsage";
 
 const MobileDrawer = ({ open, toggleDrawer, children }) => {
@@ -29,12 +28,7 @@ const MobileDrawer = ({ open, toggleDrawer, children }) => {
         },
       }}
     >
-      <Box sx={{ display: "flex", justifyContent: "flex-end", px: 1, pt: 0.5 }}>
-        <IconButton size="small" onClick={toggleDrawer}>
-          <CloseIcon sx={{ fontSize: 24 }} />
-        </IconButton>
-      </Box>
-      <Stack sx={{ height: "100%", mt: -2 }}>{children}</Stack>
+      <Stack sx={{ height: "100%" }}>{children}</Stack>
     </Drawer>
   );
 };

--- a/rcongui/src/router.jsx
+++ b/rcongui/src/router.jsx
@@ -189,6 +189,13 @@ const router = createBrowserRouter([
                         ]
                     },
                     {
+                        path: 'vips',
+                        handle: { crumb: () => <Link to={'/records/vips'}>Vips</Link> },
+                        loader: vipLoader,
+                        element: <VipSettings />,
+                        errorElement: <RouteError />,
+                    },
+                    {
                         path: 'blacklists',
                         handle: { crumb: () => <Link to={'/records/blacklists'}>Blacklists</Link> },
                         element: <BlacklistRecords />,
@@ -264,13 +271,6 @@ const router = createBrowserRouter([
                 element: <ServicesSettings />,
                 loader: servicesLoader,
                 action: servicesAction,
-                errorElement: <RouteError />,
-            },
-            {
-                path: 'settings/vip',
-                handle: { crumb: () => <Link to={'/settings/vip'}>Vip</Link> },
-                loader: vipLoader,
-                element: <VipSettings />,
                 errorElement: <RouteError />,
             },
             {


### PR DESCRIPTION
A minor update to the navigation drawer.
+ search input & filtering
+ link groups expanded by default
+ vips moved under records/vips
+ hidden scrollbars for cleaner ui


> Large screen
<img width="302" height="949" alt="image" src="https://github.com/user-attachments/assets/c7785aa2-7be3-4d1d-a1ed-6ba836a03ffe" />


> Small screen
<img width="403" height="906" alt="image" src="https://github.com/user-attachments/assets/8fb20c0f-ff01-40ba-965f-e7b3163062c6" />

