### PR TITLE
Fix: Votemap Whitelist page errors when whitelist contains non-existing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,7 @@ then
   python -m rcon.user_config.seed_db
   # TODO: Temporarily handle converting users old scorebot URLs to the new format; remove in a few releases
   SERVER_NUMBER=${SERVER_NUMBER} LOGGING_PATH=/logs/ LOGGING_FILENAME=api_${SERVER_NUMBER}.log python -m rcon.cli port_legacy_scorebot_urls
+  SERVER_NUMBER=${SERVER_NUMBER} LOGGING_PATH=/logs/ LOGGING_FILENAME=api_${SERVER_NUMBER}.log python -m rcon.cli remove_orphaned_map_ids
   ./manage.py register_api
   cd rconweb
   ./manage.py collectstatic --noinput

--- a/rcon/api_commands.py
+++ b/rcon/api_commands.py
@@ -678,7 +678,6 @@ class RconAPI(Rcon):
     def get_votemap_whitelist(self) -> list[str]:
         v = VoteMap()
 
-        # TODO: update this when we return `Layer`s instead of strings
         return [str(map) for map in v.get_map_whitelist()]
 
     def add_map_to_votemap_whitelist(self, map_name: str):
@@ -703,7 +702,7 @@ class RconAPI(Rcon):
 
     def set_votemap_whitelist(self, map_names: Iterable[str]):
         v = VoteMap()
-        v.set_map_whitelist(map_names=map_names)
+        v.set_map_whitelist(map_layers=set([maps.parse_layer(m) for m in map_names]))
 
     def get_votemap_config(self) -> VoteMapUserConfig:
         return VoteMapUserConfig.load_from_db()

--- a/rcongui/src/pages/settings/maps/votemap/builder/index.jsx
+++ b/rcongui/src/pages/settings/maps/votemap/builder/index.jsx
@@ -63,7 +63,11 @@ function VotemapBuilderPage() {
   });
 
   const whitelistMaps = useMemo(
-    () => whitelist.map((mapId) => maps.find((map) => map.id === mapId)),
+    () => whitelist
+      .map((mapId) => maps.find((map) => map.id === mapId))
+      // Map IDs might change over time (maps get removed, added or renamed), in this case
+      // remove the non-existing maps, instead of replacing them with undefined
+      .filter((m) => m),
     [whitelist]
   );
 

--- a/rcongui/src/pages/settings/maps/votemap/builder/index.jsx
+++ b/rcongui/src/pages/settings/maps/votemap/builder/index.jsx
@@ -63,11 +63,7 @@ function VotemapBuilderPage() {
   });
 
   const whitelistMaps = useMemo(
-    () => whitelist
-      .map((mapId) => maps.find((map) => map.id === mapId))
-      // Map IDs might change over time (maps get removed, added or renamed), in this case
-      // remove the non-existing maps, instead of replacing them with undefined
-      .filter((m) => m),
+    () => whitelist.map((mapId) => maps.find((map) => map.id === mapId)),
     [whitelist]
   );
 


### PR DESCRIPTION
map

With the recent update, Stalingrad was renamed to a different map ID, however, Votemap whitelists might still contain the old IDs of the map. When that is the case, the votemap whitelist page simply errors, as these maps will be replaced with "undefined" instead of their map object counterpart.

I decided to simply remove the map IDs from the votemap whitelist selected maps list. An alternative would've been to make a migration server-side to replace the old map ID with the new one.