### PR TITLE
Fix - Updates default postgres max connections from 100 to 300

### DIFF
--- a/docker-compose-common-components.yaml
+++ b/docker-compose-common-components.yaml
@@ -17,6 +17,8 @@ services:
       - common
   postgres:
     image: ${POSTGRES_IMAGE}
+    # Increases the default 100 to 300
+    command: postgres -c max_connections=300
     environment:
       # If a password is not defined this container will fail to create
       POSTGRES_PASSWORD: ${HLL_DB_PASSWORD}


### PR DESCRIPTION
The default 100 max postgres connections isn't enough when managing more than 4 (?) game servers, triggering http 502 errors in UI (see : https://discord.com/channels/685692524442026020/685695097349734469/1470638305606373452).

This fix increases the default to 300. This arbitrary number should suffice for a number of managed game servers up to 8, but still has to be evaluated in real conditions and edge cases (8+ servers).

This should be considered as a temporary fix : as an alternative, we could use PgBouncer (https://www.pgbouncer.org/) to pool the database connections.