### PR TITLE
Expose serverconfig via get_public_info

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -9,7 +9,7 @@ from typing import Generator, Literal, Sequence, Any, List
 from rcon.connection import HLLCommandError, HLLConnection, Handle, Response
 from rcon.maps import LAYERS, MAPS, UNKNOWN_MAP_NAME, Environment, GameMode, LayerType
 from rcon.perf_statistics import PerformanceStatistics
-from rcon.types import MapRotationResponse, MapSequenceResponse, PlayerInfoType, ServerInfoType, SlotsType, VipId, GameStateType, AdminType
+from rcon.types import MapRotationResponse, MapSequenceResponse, PlayerInfoType, ServerConfigType, ServerInfoType, SlotsType, VipId, GameStateType, AdminType
 from rcon.utils import exception_in_chain
 
 logger = logging.getLogger(__name__)
@@ -697,6 +697,16 @@ class ServerCtl:
 
     def set_dynamic_weather_enabled(self, map_name: str, enabled: bool):
         self.exchange("SetDynamicWeatherEnabled", 2, {"MapId": map_name, "Enable": enabled})
+
+    def get_server_config(self) -> ServerConfigType:
+        cfg = self.exchange("GetServerInformation", 2, {"Name": "serverconfig", "Value": ""}).content_dict
+        return {
+            "build_number": cfg["buildNumber"],
+            "build_revision": cfg["buildRevision"],
+            "password_protected": cfg["passwordProtected"],
+            "server_name": cfg["serverName"],
+            "supported_platforms": cfg["supportedPlatforms"]
+        }
 
 
 

--- a/rcon/types.py
+++ b/rcon/types.py
@@ -843,6 +843,12 @@ class PublicInfoNameType(TypedDict):
     public_stats_port: int | None
     public_stats_port_https: int | None
 
+class ServerConfigType(TypedDict):
+    build_number: str
+    build_revision: str
+    password_protected: bool
+    server_name: str
+    supported_platforms: list[str]
 
 class PublicInfoType(TypedDict):
     """TypedDict for rcon.views.get_public_info"""
@@ -856,6 +862,7 @@ class PublicInfoType(TypedDict):
     time_remaining: float
     vote_status: list[VoteMapStatusType]
     name: PublicInfoNameType
+    config: ServerConfigType
 
 
 class SlotsType(TypedDict):

--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -96,6 +96,7 @@ def get_public_info(request):
     config = RconServerSettingsUserConfig.load_from_db()
     gamestate = rcon_api.get_gamestate()
     slots = rcon_api.get_slots()
+    server_config = rcon_api.get_server_config()
     current_players = slots["current_players"]
     max_players = slots["max_players"]
 
@@ -140,6 +141,7 @@ def get_public_info(request):
         "time_remaining": gamestate["time_remaining"].total_seconds(),
         "vote_status": vote_status,
         "name": name,
+        "config": server_config,
     }
 
     return api_response(


### PR DESCRIPTION
GET `get_public_info` extended with
```
{
  ...,
  config:  {
    build_number: str
    build_revision: str
    password_protected: bool
    server_name: str
    supported_platforms: list[str]
   }
}
```