### PR TITLE
fix failing merge_duplicate_player_ids script on start-up

### DIFF
--- a/rcon/cli.py
+++ b/rcon/cli.py
@@ -550,6 +550,14 @@ def _merge_duplicate_player_ids(existing_ids: set[str] | None = None):
                 {"ids": ids},
             )
             session.execute(
+                text("DELETE FROM player_soldier WHERE player_id_id = ANY(:ids)"),
+                {"ids": ids},
+            )
+            session.execute(
+                text("DELETE FROM player_account WHERE player_id_id = ANY(:ids)"),
+                {"ids": ids},
+            )
+            session.execute(
                 text("DELETE FROM steam_id_64 WHERE id = ANY(:ids)"), {"ids": ids}
             )
     logger.info(f"Duplicate player ID merge complete")


### PR DESCRIPTION
Since `PlayerAccount` and `PlayerSoldier` tables were added the `_merge_duplicate_player_ids` keeps failing.

```
Updating to 11.9 is failing due to a crash in the deduplication migration;

maintenance-1  | [2026-03-02 15:12:35,354][INFO][TheCircle2][v11.9.0] main cli.py:_merge_duplicate_player_ids:440 | Merging duplicate player ID records
maintenance-1  | [2026-03-02 15:12:51,954][INFO][TheCircle2][v11.9.0] main cli.py:_merge_duplicate_player_ids:463 | Merging c16de7b3d672043ed7681148f1aa9bc1
maintenance-1  | Traceback (most recent call last):
maintenance-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
maintenance-1  |     self.dialect.do_execute(
maintenance-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 951, in do_execute
maintenance-1  |     cursor.execute(statement, parameters)
maintenance-1  | psycopg2.errors.ForeignKeyViolation: update or delete on table "steam_id_64" violates foreign key constraint "player_account_playersteamid_id_fkey" on table "player_account"
maintenance-1  | DETAIL:  Key (id)=(628839) is still referenced from table "player_account".
```