### PR TITLE
Add hook-specific admin ping trigger words

### DIFF
--- a/rcon/discord_chat.py
+++ b/rcon/discord_chat.py
@@ -18,6 +18,7 @@ from rcon.user_config.webhooks import (
     DiscordMentionWebhook,
     DiscordWebhook,
     KillsWebhooksUserConfig,
+    TriggerWordMentionWebhook,
 )
 from rcon.webhook_service import (
     enqueue_message,
@@ -78,9 +79,16 @@ class DiscordWebhookHandler:
             server_settings or RconServerSettingsUserConfig.load_from_db()
         )
 
-        ping_trigger_webhooks = []
+        ping_trigger_webhooks: list[
+            tuple[DiscordWebhook, TriggerWordMentionWebhook]
+        ] = []
         try:
-            ping_trigger_webhooks = self._make_hook(self.admin_wh_config.hooks)
+            made_hooks = self._make_hook(self.admin_wh_config.hooks)
+            ping_trigger_webhooks = [
+                (made, config)
+                for made, config in zip(made_hooks, self.admin_wh_config.hooks)
+                if made
+            ]
         except Exception as e:
             logger.exception("Error initializing ping trigger webhooks: %s", e)
 
@@ -97,7 +105,7 @@ class DiscordWebhookHandler:
             logger.exception("Error initializing ping trigger webhooks: %s", e)
 
         # TODO: If we don't get a valid response for a webhook we should log it
-        self.ping_trigger_webhooks = [wh for wh in ping_trigger_webhooks if wh]
+        self.ping_trigger_webhooks = ping_trigger_webhooks
         self.chat_webhooks = [wh for wh in chat_webhooks if wh]
         self.kills_webhooks = [wh for wh in kills_webhooks if wh]
 
@@ -128,27 +136,35 @@ class DiscordWebhookHandler:
 
         return embed
 
-    def create_admin_ping_message(self, log) -> tuple[str, DiscordEmbed, bool]:
+    def hook_trigger_words(
+        self, hook: TriggerWordMentionWebhook
+    ) -> list[str]:
+        """The trigger words that fire this hook: the config level trigger words
+        (which apply to every hook) combined with any defined on the hook itself."""
+        return list(
+            dict.fromkeys(self.admin_wh_config.trigger_words + hook.trigger_words)
+        )
+
+    def create_admin_ping_message(
+        self, log, hook: TriggerWordMentionWebhook
+    ) -> tuple[str, DiscordEmbed, bool]:
         message = log["sub_content"]
         embed = self.create_chat_embed(log)
 
         content = ""
         triggered = False
-        if self.admin_wh_config.trigger_words:
+        trigger_words = self.hook_trigger_words(hook)
+        if trigger_words:
             msg_words = re.split(r"([^a-zA-Z!@\d])", message)
-            for trigger_word in self.admin_wh_config.trigger_words:
+            for trigger_word in trigger_words:
                 for i, msg_word in enumerate(msg_words):
                     if trigger_word == msg_word.lower():
                         triggered = True
                         msg_words[i] = f"__**{msg_words[i]}**__"
             if triggered:
                 mentions: list[str] = []
-                mentions.extend(
-                    [id_ for h in self.admin_wh_config.hooks for id_ in h.user_mentions]
-                )
-                mentions.extend(
-                    [id_ for h in self.admin_wh_config.hooks for id_ in h.role_mentions]
-                )
+                mentions.extend(hook.user_mentions)
+                mentions.extend(hook.role_mentions)
                 content = " ".join(mentions)
                 embed.description = discord.utils.escape_mentions("".join(msg_words))
 
@@ -197,7 +213,6 @@ class DiscordWebhookHandler:
 
     def send_chat_message(self, log):
         try:
-            content, admin_embed, triggered = self.create_admin_ping_message(log)
             chat_embed = self.create_chat_message(log)
 
             for wh in self.chat_webhooks:
@@ -212,19 +227,21 @@ class DiscordWebhookHandler:
                     )
                 )
 
-            if triggered:
-                for wh in self.ping_trigger_webhooks:
-                    wh.remove_embeds()
-                    wh.add_embed(admin_embed)
-                    wh.content = content
-                    enqueue_message(
-                        message=WebhookMessage(
-                            payload=wh.json,
-                            webhook_type=WebhookType.DISCORD,
-                            message_type=WebhookMessageType.ADMIN_PING,
-                            server_number=int(get_server_number()),
-                        )
+            for wh, hook in self.ping_trigger_webhooks:
+                content, admin_embed, triggered = self.create_admin_ping_message(log, hook)
+                if not triggered:
+                    continue
+                wh.remove_embeds()
+                wh.add_embed(admin_embed)
+                wh.content = content
+                enqueue_message(
+                    message=WebhookMessage(
+                        payload=wh.json,
+                        webhook_type=WebhookType.DISCORD,
+                        message_type=WebhookMessageType.ADMIN_PING,
+                        server_number=int(get_server_number()),
                     )
+                )
         except Exception as e:
             logger.exception("error enqueing chat message webhook: %s", e)
             raise

--- a/rcon/message_variables.py
+++ b/rcon/message_variables.py
@@ -338,7 +338,10 @@ def _discord_invite_url(config: RconServerSettingsUserConfig | None = None) -> s
 def _admin_ping_trigger_words(config: AdminPingWebhooksUserConfig | None = None) -> str:
     if config is None:
         config = AdminPingWebhooksUserConfig.load_from_db()
-    return ", ".join(config.trigger_words[:])
+    words = list(config.trigger_words)
+    for hook in config.hooks:
+        words.extend(hook.trigger_words)
+    return ", ".join(dict.fromkeys(words))
 
 
 def _next_map(rcon: Rcon | None = None) -> str:

--- a/rcon/user_config/webhooks.py
+++ b/rcon/user_config/webhooks.py
@@ -91,6 +91,30 @@ class DiscordMentionWebhook(DiscordWebhook):
         return list(role_ids)
 
 
+def _normalize_trigger_words(vs: list[str]) -> list[str]:
+    """Lower-case, strip and de-duplicate trigger words."""
+    processed_words = set()
+    for v in vs:
+        processed_words.add(v.lower().strip())
+    return sorted(processed_words)
+
+
+class TriggerWordMentionWebhook(DiscordMentionWebhook):
+    """A mention webhook that may define its own trigger words.
+
+    These are added on top of the config level
+    ``AdminPingWebhooksUserConfig.trigger_words`` (which apply to every hook), so
+    a hook fires on the shared words plus any extra words defined here.
+    """
+
+    trigger_words: list[str] = pydantic.Field(default_factory=list)
+
+    @pydantic.field_validator("trigger_words")
+    @classmethod
+    def ensure_case_unique(cls, vs):
+        return _normalize_trigger_words(vs)
+
+
 class BaseMentionWebhookUserConfig(BaseUserConfig):
     hooks: list[DiscordMentionWebhook] = pydantic.Field(default_factory=list)
 
@@ -148,16 +172,12 @@ class CameraWebhooksUserConfig(BaseMentionWebhookUserConfig):
 
 class AdminPingWebhooksUserConfig(BaseMentionWebhookUserConfig):
     trigger_words: list[str] = pydantic.Field(default_factory=list)
+    hooks: list[TriggerWordMentionWebhook] = pydantic.Field(default_factory=list)
 
     @pydantic.field_validator("trigger_words")
     @classmethod
     def ensure_case_unique(cls, vs):
-        processed_words = set()
-        v: str
-        for v in vs:
-            processed_words.add(v.lower().strip())
-
-        return sorted(list(processed_words))
+        return _normalize_trigger_words(vs)
 
     @staticmethod
     def save_to_db(values: AdminPingWebhookType, dry_run=False) -> None:
@@ -167,11 +187,11 @@ class AdminPingWebhooksUserConfig(BaseMentionWebhookUserConfig):
         for obj in raw_hooks:
             key_check(
                 WebhookMentionType.__required_keys__,
-                WebhookMentionType.__optional_keys__,
+                WebhookMentionType.__optional_keys__ | {"trigger_words"},
                 obj.keys(),
             )
 
-        validated_hooks = parse_raw_mention_hooks(raw_hooks)
+        validated_hooks = parse_raw_admin_ping_hooks(raw_hooks)
         validated_conf = AdminPingWebhooksUserConfig(
             trigger_words=values.get("trigger_words"),
             hooks=validated_hooks,
@@ -247,6 +267,25 @@ def parse_raw_mention_hooks(
             url=raw_hook.get("url"),
             user_mentions=list(user_ids),
             role_mentions=list(role_ids),
+        )
+        validated_hooks.append(h)
+
+    return validated_hooks
+
+
+def parse_raw_admin_ping_hooks(
+    raw_hooks: list[WebhookMentionType],
+) -> list["TriggerWordMentionWebhook"]:
+    validated_hooks: list[TriggerWordMentionWebhook] = []
+    for raw_hook in raw_hooks:
+        user_ids = set(raw_hook.get("user_mentions", []))
+        role_ids = set(raw_hook.get("role_mentions", []))
+
+        h = TriggerWordMentionWebhook(
+            url=raw_hook.get("url"),
+            user_mentions=list(user_ids),
+            role_mentions=list(role_ids),
+            trigger_words=raw_hook.get("trigger_words", []),
         )
         validated_hooks.append(h)
 

--- a/rcongui/src/pages/settings/_data/webhooks/admin-ping.js
+++ b/rcongui/src/pages/settings/_data/webhooks/admin-ping.js
@@ -1,6 +1,6 @@
 const adminPingWebhooksNotes = `
 {
-    /* 
+    /*
         A list of Discord webhook URLs and user/role IDs to mention when one of \`trigger_words\` is used in game chat
 
         You can set as many URLs as you want, but these are updated sequentially not concurrently,
@@ -17,11 +17,21 @@ const adminPingWebhooksNotes = `
             /* A list of role ID(s), must be in the <@&...> format */
             "role_mentions": [
                 "<@&1234>"
+            ],
+            /*
+                Optional trigger words for THIS hook only, in addition to the
+                top-level "trigger_words" below. Use these for words that should
+                ping only this hook (with its own mentions). Leave empty to only
+                use the shared top-level words.
+            */
+            "trigger_words": [
+                "!report"
             ]
         }
     ],
     /*
-        Comma-separated list of trigger words. Case-insensitive. Trigger words match whole words.
+        Shared trigger words that ping every hook. Comma-separated list. Case-insensitive.
+        Trigger words match whole words.
         "this is a TeSt message" would match trigger word "test"
         "this is a testmessage" would NOT match trigger word "test"
     */

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -7,6 +7,7 @@ from rcon.user_config.webhooks import (
     DiscordMentionWebhook,
     DiscordWebhook,
     KillsWebhooksUserConfig,
+    TriggerWordMentionWebhook,
 )
 
 
@@ -103,7 +104,7 @@ def test_admin_pings_mention_start():
     config = AdminPingWebhooksUserConfig(
         trigger_words=["!admin"],
         hooks=[
-            DiscordMentionWebhook(
+            TriggerWordMentionWebhook(
                 url=HttpUrl("http://example.com"),
                 user_mentions=["<@1212>"],
                 role_mentions=[],
@@ -118,7 +119,8 @@ def test_admin_pings_mention_start():
             "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
-        }
+        },
+        hook=config.hooks[0],
     )
 
     assert embed.description == "__**!admin**__ test @\u200bhere"
@@ -130,7 +132,7 @@ def test_admin_pings_mention_middle():
     config = AdminPingWebhooksUserConfig(
         trigger_words=["!admin"],
         hooks=[
-            DiscordMentionWebhook(
+            TriggerWordMentionWebhook(
                 url=HttpUrl("http://example.com"),
                 user_mentions=["<@1212>"],
                 role_mentions=[],
@@ -145,7 +147,8 @@ def test_admin_pings_mention_middle():
             "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
-        }
+        },
+        hook=config.hooks[0],
     )
 
     assert embed.description == "test __**!admin**__ @\u200bhere"
@@ -157,7 +160,7 @@ def test_admin_pings_contains_numbers():
     config = AdminPingWebhooksUserConfig(
         trigger_words=["testword123"],
         hooks=[
-            DiscordMentionWebhook(
+            TriggerWordMentionWebhook(
                 url=HttpUrl("http://example.com"),
                 user_mentions=["<@1212>"],
                 role_mentions=[],
@@ -172,12 +175,90 @@ def test_admin_pings_contains_numbers():
             "player_name_1": "some dude",
             "player_id_1": "1234",
             "action": "CHAT[Allies][Team]",
-        }
+        },
+        hook=config.hooks[0],
     )
 
     assert embed.description == "__**testword123**__ test @\u200bhere"
     assert triggered
     assert content == "<@1212>"
+
+
+def test_admin_ping_per_hook_trigger_words():
+    config = AdminPingWebhooksUserConfig(
+        hooks=[
+            TriggerWordMentionWebhook(
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1111>"],
+                role_mentions=[],
+                trigger_words=["!report"],
+            ),
+            TriggerWordMentionWebhook(
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@2222>"],
+                role_mentions=[],
+                trigger_words=["!teamkill"],
+            ),
+        ],
+    )
+
+    handler = DiscordWebhookHandler(admin_wh_config=config)
+    report_hook, teamkill_hook = config.hooks
+
+    log = {
+        "sub_content": "!report help",
+        "player_name_1": "some dude",
+        "player_id_1": "1234",
+        "action": "CHAT[Allies][Team]",
+    }
+
+    content, embed, triggered = handler.create_admin_ping_message(log, hook=report_hook)
+    assert triggered
+    assert content == "<@1111>"
+    assert embed.description == "__**!report**__ help"
+
+    content, embed, triggered = handler.create_admin_ping_message(
+        log, hook=teamkill_hook
+    )
+    assert not triggered
+    assert content == ""
+
+
+def test_admin_ping_config_words_apply_to_every_hook():
+    config = AdminPingWebhooksUserConfig(
+        trigger_words=["!admin"],
+        hooks=[
+            TriggerWordMentionWebhook(
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@1111>"],
+                role_mentions=[],
+            ),
+            TriggerWordMentionWebhook(
+                url=HttpUrl("http://example.com"),
+                user_mentions=["<@2222>"],
+                role_mentions=[],
+                trigger_words=["!report"],
+            ),
+        ],
+    )
+
+    handler = DiscordWebhookHandler(admin_wh_config=config)
+    plain_hook, report_hook = config.hooks
+
+    log = {
+        "sub_content": "!admin help",
+        "player_name_1": "some dude",
+        "player_id_1": "1234",
+        "action": "CHAT[Allies][Team]",
+    }
+
+    content, _, triggered = handler.create_admin_ping_message(log, hook=plain_hook)
+    assert triggered
+    assert content == "<@1111>"
+
+    content, _, triggered = handler.create_admin_ping_message(log, hook=report_hook)
+    assert triggered
+    assert content == "<@2222>"
 
 
 def test_kill_message():

--- a/tests/test_message_variables.py
+++ b/tests/test_message_variables.py
@@ -41,8 +41,9 @@ class MockRconServerSettingsUserConfig:
 
 
 class MockAdminPingWebhooksUserConfig:
-    def __init__(self, trigger_words: list[str]) -> None:
+    def __init__(self, trigger_words: list[str], hooks: list | None = None) -> None:
         self.trigger_words = trigger_words
+        self.hooks = hooks or []
 
 
 def make_mock_stat(player: str, player_id: str, *args, **kwargs):


### PR DESCRIPTION
# Summary

Admin Ping webhooks (settings/webhooks/admin-ping) support multiple Discord hooks, but trigger words were applied globally. 
This PR adds an optional, hook specific "trigger_words" field. This way pings can be routed to dedicated hooks.
The hooks fire on both their specific and the global trigger words, in order to maintain backwards compatibility. 

# Changes

### rcon/user_config/webhooks.py

- New `TriggerWordMentionWebhook` model (subclass of `DiscordMentionWebhook`) adding a validated `trigger_words` field; integrated by `AdminPingWebhooksUserConfig.hooks`
Note: I'm not sure if im happy with the name `TriggerWordMentionWebhook`.

- Extracted the existing case-fold/strip/dedupe/sort logic into a shared `_normalize_trigger_words` helper, reused by both the global (`AdminPingWebhooksUserConfig`) and per-hook fields.
- `save_to_db` key check now allows the optional per-hook `trigger_words` key.


### rcon/discord_chat.py

- Each constructed webhook is kept paired with its config (`(webhook, hook_config)`) so per-hook trigger words/mentions are available at send time.
- New `hook_trigger_words(hook)` returns the shared + per-hook union; `create_admin_ping_message(log, hook)` is now evaluated per hook; `send_chat_message` loops hooks and enqueues only those that matched.


### rcon/message_variables.py

- `{admin_ping_trigger_words}` now aggregates the top-level list plus every hook's words (de-duplicated).

### rcongui/src/pages/settings/_data/webhooks/admin-ping.js
- settings notes document shared vs. per-hook trigger words


# Testing 

###  tests/test_discord_handler.py
Updated/added unit tests to pass hook config in `create_admin_ping_message`
- per-hook words fire only their own hook
- shared top-level words fire every hook

### tests/test_message_variables.py 
- Updated the mock for the aggregated variable