### PR TITLE
Reduce Redis scan load

### DIFF
--- a/rcon/cache_utils.py
+++ b/rcon/cache_utils.py
@@ -314,3 +314,13 @@ def invalidates(*cached_funcs):
     yield None
     for f in cached_funcs:
         f.cache_clear()
+
+
+@contextmanager
+def invalidates_for(*cached_funcs):
+    """Invalidate the exact no-argument key for each cached function."""
+    for f in cached_funcs:
+        f.clear_for()
+    yield None
+    for f in cached_funcs:
+        f.clear_for()

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -518,7 +518,7 @@ def handle_on_connect(
     rcon: Rcon, struct_log: StructuredLogLineWithMetaData, name: str, player_id: str
 ):
     try:
-        rcon.get_players.cache_clear()
+        rcon.get_players.clear_for()
         rcon.get_player_info.clear_for(player_id=struct_log["player_id_1"])
         rcon.get_detailed_player_info.clear_for(player_id=struct_log["player_id_1"])
     except Exception:

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -13,7 +13,7 @@ from dateutil import parser
 
 from rcon.connection import HLLCommandError
 import rcon.steam_utils
-from rcon.cache_utils import get_redis_client, invalidates, ttl_cache
+from rcon.cache_utils import get_redis_client, invalidates, invalidates_for, ttl_cache
 from rcon.commands import HLLCommandFailedError, ServerCtl, VipId
 from rcon.maps import UNKNOWN_MAP_NAME, Layer, is_server_loading_map, parse_layer
 from rcon.models import PlayerID, PlayerVIP, enter_session, GameLayout
@@ -765,10 +765,10 @@ class Rcon(ServerCtl):
         Remaining Time: 0:11:51
         Map: foy_warfare
         Next Map: stmariedumont_warfare"""
-        with invalidates(
-                Rcon.team_sizes,
-                Rcon.get_team_objective_scores,
-                Rcon.get_round_time_remaining,
+        with invalidates_for(
+            Rcon.team_sizes,
+            Rcon.get_team_objective_scores,
+            Rcon.get_round_time_remaining,
         ):
             return super().get_gamestate()
 
@@ -848,7 +848,7 @@ class Rcon(ServerCtl):
         return int(super().get_autobalance_threshold())
 
     def set_autobalance_threshold(self, max_diff: int) -> bool:
-        with invalidates(Rcon.get_autobalance_threshold):
+        with invalidates_for(Rcon.get_autobalance_threshold):
             return super().set_autobalance_threshold(max_diff)
 
     @ttl_cache(ttl=60 * 10)
@@ -856,7 +856,7 @@ class Rcon(ServerCtl):
         return int(super().get_idle_autokick_time())
 
     def set_idle_autokick_time(self, minutes) -> bool:
-        with invalidates(Rcon.get_idle_autokick_time):
+        with invalidates_for(Rcon.get_idle_autokick_time):
             return super().set_idle_autokick_time(minutes)
 
     @ttl_cache(ttl=60 * 10)

--- a/rcon/webhook_service.py
+++ b/rcon/webhook_service.py
@@ -2,6 +2,7 @@ import asyncio
 import math
 import os
 import random
+import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -91,6 +92,11 @@ try:
     HLL_WH_LOOP_SLEEP_TIME = float(os.getenv("HLL_WH_LOOP_SLEEP_TIME"))
 except (ValueError, TypeError):
     HLL_WH_LOOP_SLEEP_TIME = 0.006
+
+# Queue contents still get checked every service loop. Redis key discovery is
+# intentionally slower because newly created webhook queues can tolerate this
+# small delay and SCAN is otherwise executed hundreds of times per second.
+QUEUE_KEY_REFRESH_INTERVAL_SECS = 1.0
 
 # Global datastructures to support associating hooks with locks
 _RATE_LIMIT_BUCKETS: defaultdict[str, asyncio.Lock | None] = defaultdict(lambda: None)
@@ -830,6 +836,37 @@ def get_all_queue_keys_not_empty(
     return populated_queues + populated_transient_messages
 
 
+@dataclass
+class WebhookQueueKeyCache:
+    """Reuse webhook queue keys while continuing to poll their contents."""
+
+    red: redis.StrictRedis
+    prefix: str = PREFIX
+    refresh_interval_secs: float = QUEUE_KEY_REFRESH_INTERVAL_SECS
+    queue_ids: tuple[str, ...] = ()
+    transient_message_keys: tuple[str, ...] = ()
+    next_refresh_at: float = 0.0
+
+    def get_not_empty(self, now: float | None = None) -> list[str]:
+        now = time.monotonic() if now is None else now
+        if now >= self.next_refresh_at:
+            self.queue_ids = tuple(get_all_queue_keys(red=self.red, prefix=self.prefix))
+            self.transient_message_keys = tuple(
+                get_all_transient_message_keys(red=self.red, prefix=self.prefix)
+            )
+            self.next_refresh_at = now + self.refresh_interval_secs
+
+        populated_queues = [
+            queue_id for queue_id in self.queue_ids if self.red.llen(queue_id) > 0
+        ]
+        populated_transient_messages = [
+            queue_id
+            for queue_id in self.transient_message_keys
+            if self.red.exists(queue_id)
+        ]
+        return populated_queues + populated_transient_messages
+
+
 def get_transient_message_overview(
     queue_id: str,
     red: redis.StrictRedis | None,
@@ -1088,6 +1125,7 @@ async def main():
     client = httpx.AsyncClient()
     lock: asyncio.Lock | None = None
     continue_logged = False
+    queue_key_cache = WebhookQueueKeyCache(red=red)
 
     # Create a file to use for the docker health check
     from pathlib import Path
@@ -1096,8 +1134,7 @@ async def main():
     path.touch()
 
     while True:
-        # Check each loop to pick up new queues that have been added since last iteration
-        queue_ids = get_all_queue_keys_not_empty(red=red)
+        queue_ids = queue_key_cache.get_not_empty()
 
         # Keep each message queue under its max, dropping the oldest messages first
         for queue_id in queue_ids:

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -5,7 +5,7 @@ from unittest import mock
 import redis
 import redis.exceptions
 
-from rcon.cache_utils import RedisCached, ttl_cache
+from rcon.cache_utils import RedisCached, invalidates_for, ttl_cache
 
 logger = getLogger(__name__)
 
@@ -72,3 +72,14 @@ def test_mem_cache_used(monkeypatch):
     # so we can't isinstance check it
     c = ttl_cache(ttl=1)
     assert not isinstance(c, RedisCached)
+
+
+def test_invalidates_for_clears_exact_key_before_and_after():
+    cached_func = mock.Mock()
+
+    with invalidates_for(cached_func):
+        cached_func.clear_for.assert_called_once_with()
+        cached_func.cache_clear.assert_not_called()
+
+    assert cached_func.clear_for.call_count == 2
+    cached_func.cache_clear.assert_not_called()

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock, call
+
+from rcon.webhook_service import WebhookQueueKeyCache
+
+
+def test_webhook_queue_key_cache_reuses_discovery_within_refresh_interval():
+    red = Mock()
+    red.scan_iter.side_effect = [
+        iter([b"whs:list:1"]),
+        iter([b"whs:transient_identifier:1"]),
+        iter([b"whs:list:2"]),
+        iter([]),
+    ]
+    red.llen.return_value = 1
+    red.exists.return_value = 1
+    cache = WebhookQueueKeyCache(red=red, refresh_interval_secs=1.0)
+
+    expected = ["whs:list:1", "whs:transient_identifier:1"]
+    assert cache.get_not_empty(now=10.0) == expected
+    assert cache.get_not_empty(now=10.5) == expected
+    assert red.scan_iter.call_args_list == [
+        call(match="whs*", _type="list"),
+        call(match="whs*", _type="string"),
+    ]
+
+    assert cache.get_not_empty(now=11.0) == ["whs:list:2"]
+    assert red.scan_iter.call_count == 4
+
+
+def test_webhook_queue_key_cache_filters_queues_deleted_between_scans():
+    red = Mock()
+    red.scan_iter.side_effect = [
+        iter([b"whs:list:1"]),
+        iter([b"whs:transient_identifier:1"]),
+    ]
+    red.llen.side_effect = [1, 0]
+    red.exists.side_effect = [1, 0]
+    cache = WebhookQueueKeyCache(red=red, refresh_interval_secs=1.0)
+
+    assert cache.get_not_empty(now=10.0) == [
+        "whs:list:1",
+        "whs:transient_identifier:1",
+    ]
+    assert cache.get_not_empty(now=10.5) == []
+    assert red.scan_iter.call_count == 2


### PR DESCRIPTION
## Summary

Reduce Redis `SCAN` traffic generated by the webhook service and cache invalidation paths.

## Root cause

The webhook service discovers all queue keys on every loop iteration. With the default `HLL_WH_LOOP_SLEEP_TIME=0.006`, both queue key scans run roughly 167 times per second even when the set of queues has not changed.

In addition, several parameterless cached methods use `cache_clear()`. That method scans the complete Redis database for the function prefix, although these methods have exactly one cache key and can be invalidated directly.

## Changes

- Cache discovered webhook queue keys for one second while continuing to check the contents and existence of known queues on every service loop.
- Add `invalidates_for()` for exact invalidation of parameterless cached functions.
- Use exact invalidation for gamestate-derived caches, autobalance settings, idle autokick settings, and the player list on connect.
- Add unit coverage for queue discovery refreshes, deleted queues, and exact invalidation before and after a mutation.

New webhook queues may take up to one second to be discovered. Existing queues continue to be processed at the configured loop interval.

## Validation

- Python compile check passed.
- Black check passed for the changed formatted files.
- 12 directly relevant unit tests passed.
- Tested in a live two-server deployment: Redis `SCAN` traffic fell from approximately 1,798 calls/s to 8 calls/s (99.6% reduction) while both backends, webhook processing, and RCON supervisor processes remained operational.
