### PR TITLE
Fix/consecutive offensive maps in selection when disabled

### DIFF
--- a/rcon/vote_map/service.py
+++ b/rcon/vote_map/service.py
@@ -426,9 +426,17 @@ class VoteMap:
     def get_new_selection(self) -> list[Layer]:
         config = self.config
         new_selection = []
+        maps_history = [maps.parse_layer(m["name"]) for m in self._maps_history]
+        current_map = self._maps_history.get_current_map()
         options = {
-            "maps_history": [maps.parse_layer(m["name"]) for m in self._maps_history],
-            "current_map": self._rcon.current_map,
+            "maps_history": maps_history,
+            # Map history is updated before votemap is restarted on match start,
+            # while Rcon.current_map may still contain the previous cached layer.
+            "current_map": (
+                maps.parse_layer(current_map["name"])
+                if current_map
+                else self._rcon.current_map
+            ),
             "allowed_maps": set(self.get_map_whitelist()),
             **config.model_dump(),
         }

--- a/tests/test_vote_map.py
+++ b/tests/test_vote_map.py
@@ -80,6 +80,11 @@ SAMPLE_MAPS = [
 ]
 
 
+class FakeMapsHistory(list):
+    def get_current_map(self):
+        return self[0] if self else None
+
+
 @pytest.fixture
 def redis_client():
     """Fixture for a fake Redis client."""
@@ -214,7 +219,7 @@ def mock_maps_history():
             "end": minus_hour(8),
         },
     ]
-    return history
+    return FakeMapsHistory(history)
 
 
 @pytest.fixture
@@ -502,15 +507,49 @@ def test_ensure_selection_when_no_maps_to_select_from(votemap):
     assert HUR_WARFARE_DAY not in new_selection
 
 
+def test_disallow_consecutive_offensives_uses_current_map_from_history(
+    redis_client, mock_rcon
+):
+    """The RCON current-map cache can still hold the previous layer at match start."""
+    history = FakeMapsHistory(
+        [{"name": CAR_OFF_ALLIES.id, "start": 1, "end": None}]
+    )
+    mock_rcon.current_map = HUR_WARFARE_DAY
+    config_loader = lambda: VoteMapUserConfig(
+        enabled=True,
+        number_last_played_to_exclude=0,
+        consider_offensive_same_map=False,
+        consider_skirmishes_as_same_map=False,
+        allow_consecutive_offensives=False,
+        allow_consecutive_offensives_opposite_sides=True,
+        num_warfare_options=10,
+        num_offensive_options=10,
+        num_skirmish_control_options=10,
+    )
+
+    with patch("rcon.vote_map.state.get_redis_client", return_value=redis_client):
+        votemap = VoteMap(
+            rcon=mock_rcon,
+            config_loader=config_loader,
+            maps_history=history,
+        )
+    votemap.set_map_whitelist(SAMPLE_MAPS)
+
+    selection = votemap.get_new_selection()
+
+    assert selection
+    assert all(map_.game_mode != GameMode.OFFENSIVE for map_ in selection)
+
+
 def test_exclude_last_maps_considers_same_mode_different_environment(
     redis_client, mock_rcon
 ):
     """Excluding last 2 maps also excludes same maps with the same game 
     mode with different environment."""
-    history = [
+    history = FakeMapsHistory([
         {"name": HUR_WARFARE_DAY.id, "start": 1, "end": None},
         {"name": CAR_WARFARE_DAY.id, "start": 0, "end": 1},
-    ]
+    ])
     mock_rcon.current_map = HUR_WARFARE_DAY
     allowed_maps = list(set(SAMPLE_MAPS) | {UTAH_WARFARE_DAY})
 
@@ -556,9 +595,9 @@ def test_dont_allow_same_map_per_mode_with_different_environment(
 ):
     """When new votemap selection is created and allow_multiple_maps_with_same_environment
     is disabled there should never be multiple maps of the same gamemode in the selection"""
-    history = [
+    history = FakeMapsHistory([
         {"name": CAR_SKIRMISH_DAY.id, "start": 1, "end": None},
-    ]
+    ])
     mock_rcon.current_map = HUR_WARFARE_DAY
     allowed_maps = list(set(SAMPLE_MAPS) | {UTAH_WARFARE_DAY})
 
@@ -568,6 +607,7 @@ def test_dont_allow_same_map_per_mode_with_different_environment(
             number_last_played_to_exclude=1,
             consider_environment_as_same_map=False,
             allow_consecutive_offensives_opposite_sides=True,
+            allow_consecutive_skirmishes=True,
             allow_multiple_maps_with_same_environment=allow_multiple_maps_with_same_environment,
             consider_offensive_same_map=False,
             consider_skirmishes_as_same_map=False,


### PR DESCRIPTION
when creating a new selection it is possible old `current_map` was cached - switched from using `current_map` to `MapsHistory.current_map` and use `current_map` as a fallback value