### PR TITLE
Fix/offensive match tracking

### DIFF
--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -27,7 +27,12 @@ from rcon.logs.loop import (
     on_match_end,
     on_match_start,
 )
-from rcon.maps import UNKNOWN_MAP_NAME, GameMode, parse_layer
+from rcon.maps import (
+    UNKNOWN_MAP_NAME,
+    GameMode,
+    get_theoretical_match_time,
+    parse_layer,
+)
 from rcon.message_variables import format_message_string, populate_message_variables
 from rcon.models import PlayerID, PlayerSoldier, enter_session, GameLayout
 from rcon.player_history import (
@@ -280,10 +285,26 @@ def handle_new_match_start(rcon: Rcon, struct_log):
                 # Don't use the current_map property and clear the cache to pull the new map name
                 gamestate = rcon.get_gamestate()
                 current_map = parse_layer(gamestate["current_map"]["id"])
-                match_time = gamestate["match_time"]
-                if current_map.game_mode == GameMode.OFFENSIVE:
-                    # HLL Server displays match time for only one objetive not the theoretical length for all 5 objectives
-                    match_time *= 5
+                if current_map.game_mode != gamestate["game_mode"]:
+                    # During a map transition the session fields are not updated
+                    # atomically. Do not combine a new layer with the old mode's
+                    # timer; the polling loop will fill this in once they agree.
+                    match_time = 0
+                    logger.warning(
+                        "Current map mode %s does not match session mode %s; "
+                        "deferring match-time recording",
+                        current_map.game_mode,
+                        gamestate["game_mode"],
+                    )
+                elif gamestate["game_mode"] == GameMode.OFFENSIVE:
+                    # matchTime has been observed retaining Warfare's 90-minute
+                    # value at this boundary. The polling loop derives the
+                    # objective window from remainingMatchTime once play starts.
+                    match_time = 0
+                else:
+                    match_time = get_theoretical_match_time(
+                        gamestate["game_mode"], gamestate["match_time"]
+                    )
             except HLLCommandFailedError:
                 current_map = parse_layer(UNKNOWN_MAP_NAME)
                 match_time = 0

--- a/rcon/hooks.py
+++ b/rcon/hooks.py
@@ -29,7 +29,6 @@ from rcon.logs.loop import (
 )
 from rcon.maps import (
     UNKNOWN_MAP_NAME,
-    GameMode,
     get_theoretical_match_time,
     parse_layer,
 )
@@ -296,11 +295,6 @@ def handle_new_match_start(rcon: Rcon, struct_log):
                         current_map.game_mode,
                         gamestate["game_mode"],
                     )
-                elif gamestate["game_mode"] == GameMode.OFFENSIVE:
-                    # matchTime has been observed retaining Warfare's 90-minute
-                    # value at this boundary. The polling loop derives the
-                    # objective window from remainingMatchTime once play starts.
-                    match_time = 0
                 else:
                     match_time = get_theoretical_match_time(
                         gamestate["game_mode"], gamestate["match_time"]

--- a/rcon/logs/loop.py
+++ b/rcon/logs/loop.py
@@ -14,7 +14,7 @@ from hllrcon.data import Role, Team
 from rcon.cache_utils import get_redis_client, ttl_cache
 from rcon.connection import HLLServerError
 from rcon.discord import make_hook
-from rcon.maps import get_theoretical_match_time, parse_layer
+from rcon.maps import GameMode, Team as MapTeam, get_theoretical_match_time, parse_layer
 from rcon.rcon import get_rcon
 from rcon.types import AllLogTypes, GameStateType, GetDetailedPlayers, MapInfo, MapScore, UnitHistoryEntry, StructuredLogLineWithMetaData, PlayerStat, WorldPositionType
 from rcon.user_config.log_line_webhooks import LogLineWebhookUserConfig
@@ -236,6 +236,7 @@ class LogLoop:
         self.RECORD_PLAYER_STATS_DELAY = 120 # 2 minutes
         self.GET_LOGS_SINCE_MIN = 180 # 3 hours
         self.CLEANUP_MIN = 180 # 3 hours
+        self.CURR_MAP_END = 0
         self.now = 0
         logger.info("Registered hooks: %s", HOOKS)
 
@@ -290,9 +291,13 @@ class LogLoop:
 
         curr_map_time_elapsed = self.now - map_start
 
-        if current_map["end"] is not None:
+        map_has_ended = current_map["end"] is not None
+        if map_has_ended:
             logger.info("[MATCH ENDED]")
-            return current_map["end"] - map_start
+            # Let it record stats one more time
+            if current_map["end"] == self.CURR_MAP_END:
+                return current_map["end"] - map_start
+            self.CURR_MAP_END = current_map["end"]
 
         if gs["current_map"]["id"] != current_map["name"]:
             logger.info(
@@ -323,12 +328,15 @@ class LogLoop:
                 cached_game_mode, gs["match_time"]
             )
 
+        if not map_has_ended:
+            self.record_cap_flips(current_map, curr_map_time_elapsed, gs)
+            maps_history.update(self.ACTIVE_MAP_INDEX, current_map)
+
         dp = self.get_detailed_players()
         logger.info(
             "RCON map/player polling completed in %.3fs",
             time.perf_counter() - started,
         )
-        self.record_cap_flips(current_map, curr_map_time_elapsed, gs)
 
         # logger.debug("\n[MATCH RUNNING] - Recording stats")
         # logger.debug("\n[MATCH RUNNING]\nMatch Start: %d\nMatch Time: %d\nRemaining Match Time: %d\nTime elapsed: %d\nTime elapsed(now-start): %d\n", current_map["start"], gs["match_time"], gs["time_remaining"].seconds, prev_map_time_elapsed, now - current_map["start"])
@@ -366,10 +374,30 @@ class LogLoop:
 
     def record_cap_flips(self, current_map: MapInfo, sec_from_start: int, gs: GameStateType):
         cap_flips = current_map.setdefault("cap_flips", [])
+        layer = parse_layer(current_map["name"])
 
-        if gs["allied_score"] == 2 and gs["axis_score"] == 2 and len(cap_flips) > 0:
-            # Most likely leak from the current map
+        if (
+            layer.game_mode == GameMode.WARFARE
+            and gs["allied_score"] == 2
+            and gs["axis_score"] == 2
+            and cap_flips
+        ):
+            # Most likely the initial score leaking from a new match.
             return
+
+        if layer.game_mode == GameMode.OFFENSIVE and cap_flips:
+            initial_score = {
+                MapTeam.ALLIES: (0, 5),
+                MapTeam.AXIS: (5, 0),
+            }.get(layer.attackers)
+            live_score = (gs["allied_score"], gs["axis_score"])
+            if live_score == initial_score:
+                logger.warning(
+                    "Ignoring Offensive score reset to %d:%d after %d cap flips",
+                    *live_score,
+                    len(cap_flips),
+                )
+                return
 
         if len(cap_flips) == 0 or cap_flips[-1]["allied_score"] != gs["allied_score"] or cap_flips[-1]["axis_score"] != gs["axis_score"]:
             logger.debug("[MATCH SCORE] - New cap flip recorded as the score has changed")

--- a/rcon/logs/loop.py
+++ b/rcon/logs/loop.py
@@ -14,6 +14,7 @@ from hllrcon.data import Role, Team
 from rcon.cache_utils import get_redis_client, ttl_cache
 from rcon.connection import HLLServerError
 from rcon.discord import make_hook
+from rcon.maps import GameMode, get_theoretical_match_time, parse_layer
 from rcon.rcon import get_rcon
 from rcon.types import AllLogTypes, GameStateType, GetDetailedPlayers, MapInfo, MapScore, UnitHistoryEntry, StructuredLogLineWithMetaData, PlayerStat, WorldPositionType
 from rcon.user_config.log_line_webhooks import LogLineWebhookUserConfig
@@ -274,9 +275,7 @@ class LogLoop:
 
     def update_maps_history(self, prev_map_time_elapsed: int) -> int:
         started = time.perf_counter()
-        dp = self.get_detailed_players()
         gs = self.rcon.get_gamestate()
-        logger.info("RCON map/player polling completed in %.3fs", time.perf_counter() - started)
         maps_history = MapsHistory()
         current_map = maps_history.get_current_map()
 
@@ -290,27 +289,63 @@ class LogLoop:
             return prev_map_time_elapsed
 
         curr_map_time_elapsed = self.now - map_start
-        self.record_cap_flips(current_map, curr_map_time_elapsed, gs)
-        maps_history.update(self.ACTIVE_MAP_INDEX, current_map)
 
-        # it should be 100 not 90 but let's leave 10s to log latest stats on match end
-        if map_start is not None and current_map["end"] is not None and gs["time_remaining"].seconds <= 90 and gs["time_remaining"].seconds > 0:
+        if current_map["end"] is not None:
             logger.info("[MATCH ENDED]")
             return current_map["end"] - map_start
 
-        if gs["current_map"]["id"] != current_map["name"] and gs["time_remaining"].seconds == 0:
-            logger.info("[MATCH IDLE] - Map has changed but has not started yet(based on map id diff), skipping saving stats - current_map: %s - cached_map:%s", gs["current_map"]["id"], current_map["name"])
+        if gs["current_map"]["id"] != current_map["name"]:
+            logger.info(
+                "[MATCH IDLE] - Live and cached map IDs differ, skipping stats "
+                "- current_map: %s - cached_map: %s",
+                gs["current_map"]["id"],
+                current_map["name"],
+            )
             return 0
-        
+
+        cached_game_mode = parse_layer(current_map["name"]).game_mode
+        if cached_game_mode != gs["game_mode"]:
+            logger.info(
+                "[MATCH IDLE] - Live and cached game modes differ, skipping stats "
+                "- current_mode: %s - cached_mode: %s",
+                gs["game_mode"],
+                cached_game_mode,
+            )
+            return 0
+
         # time remaining is 0 during match overtime so that value alone is not sufficient enough
         if gs["time_remaining"].seconds == 0 and prev_map_time_elapsed == 0:
             logger.info("[MATCH IDLE] - Map has changed but has not started yet(based on time remaining diff), skipping saving stats - time_remaining: %d - currently_recorded_time_elapsed: %d - previously_recorded_time_elapsed: %d", gs["time_remaining"].seconds, curr_map_time_elapsed, prev_map_time_elapsed)
             return 0
 
-        if gs["allied_score"] == 2 and gs["axis_score"] == 2 and len(current_map["cap_flips"]) > 1:
-            logger.info("New score is 2:2 but there are some cap flips records already")
-            current_map["cap_flips"].clear()
-            return gs["time_remaining"].seconds
+        if current_map["match_time"] == 0:
+            if cached_game_mode == GameMode.OFFENSIVE:
+                remaining = int(gs["time_remaining"].total_seconds())
+                if curr_map_time_elapsed <= 60 and remaining > 100:
+                    # The session's matchTime can still contain Warfare's
+                    # 90-minute value at the match boundary. remainingMatchTime
+                    # is the live Offensive objective timer; round it back up to
+                    # its configured whole-minute value after polling delay.
+                    objective_time = ((remaining + 59) // 60) * 60
+                    current_map["match_time"] = get_theoretical_match_time(
+                        cached_game_mode, objective_time
+                    )
+                    logger.info(
+                        "Recorded Offensive match time %ds from %ds objective timer",
+                        current_map["match_time"],
+                        objective_time,
+                    )
+            else:
+                current_map["match_time"] = get_theoretical_match_time(
+                    cached_game_mode, gs["match_time"]
+                )
+
+        dp = self.get_detailed_players()
+        logger.info(
+            "RCON map/player polling completed in %.3fs",
+            time.perf_counter() - started,
+        )
+        self.record_cap_flips(current_map, curr_map_time_elapsed, gs)
 
         # logger.debug("\n[MATCH RUNNING] - Recording stats")
         # logger.debug("\n[MATCH RUNNING]\nMatch Start: %d\nMatch Time: %d\nRemaining Match Time: %d\nTime elapsed: %d\nTime elapsed(now-start): %d\n", current_map["start"], gs["match_time"], gs["time_remaining"].seconds, prev_map_time_elapsed, now - current_map["start"])

--- a/rcon/logs/loop.py
+++ b/rcon/logs/loop.py
@@ -14,7 +14,7 @@ from hllrcon.data import Role, Team
 from rcon.cache_utils import get_redis_client, ttl_cache
 from rcon.connection import HLLServerError
 from rcon.discord import make_hook
-from rcon.maps import GameMode, get_theoretical_match_time, parse_layer
+from rcon.maps import get_theoretical_match_time, parse_layer
 from rcon.rcon import get_rcon
 from rcon.types import AllLogTypes, GameStateType, GetDetailedPlayers, MapInfo, MapScore, UnitHistoryEntry, StructuredLogLineWithMetaData, PlayerStat, WorldPositionType
 from rcon.user_config.log_line_webhooks import LogLineWebhookUserConfig
@@ -319,26 +319,9 @@ class LogLoop:
             return 0
 
         if current_map["match_time"] == 0:
-            if cached_game_mode == GameMode.OFFENSIVE:
-                remaining = int(gs["time_remaining"].total_seconds())
-                if curr_map_time_elapsed <= 60 and remaining > 100:
-                    # The session's matchTime can still contain Warfare's
-                    # 90-minute value at the match boundary. remainingMatchTime
-                    # is the live Offensive objective timer; round it back up to
-                    # its configured whole-minute value after polling delay.
-                    objective_time = ((remaining + 59) // 60) * 60
-                    current_map["match_time"] = get_theoretical_match_time(
-                        cached_game_mode, objective_time
-                    )
-                    logger.info(
-                        "Recorded Offensive match time %ds from %ds objective timer",
-                        current_map["match_time"],
-                        objective_time,
-                    )
-            else:
-                current_map["match_time"] = get_theoretical_match_time(
-                    cached_game_mode, gs["match_time"]
-                )
+            current_map["match_time"] = get_theoretical_match_time(
+                cached_game_mode, gs["match_time"]
+            )
 
         dp = self.get_detailed_players()
         logger.info(

--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -97,6 +97,10 @@ class GameMode(str, Enum):
 def get_theoretical_match_time(game_mode: GameMode, match_time: int) -> int:
     """Return the full match window represented by the server timer."""
     if game_mode == GameMode.OFFENSIVE:
+        if match_time == 90 * 60:
+            # Server bug: the uncustomized Offensive timer is reported as the
+            # 90-minute Warfare timer instead of the 30-minute objective timer.
+            match_time = 30 * 60
         # The server reports the timer for one objective. An Offensive match can
         # use that timer up to five times.
         return match_time * 5

--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -94,6 +94,15 @@ class GameMode(str, Enum):
         return self in GameMode.small()
 
 
+def get_theoretical_match_time(game_mode: GameMode, match_time: int) -> int:
+    """Return the full match window represented by the server timer."""
+    if game_mode == GameMode.OFFENSIVE:
+        # The server reports the timer for one objective. An Offensive match can
+        # use that timer up to five times.
+        return match_time * 5
+    return match_time
+
+
 class Team(str, Enum):
     ALLIES = "allies"
     AXIS = "axis"

--- a/tests/test_log_loop_maps_history.py
+++ b/tests/test_log_loop_maps_history.py
@@ -82,7 +82,7 @@ def test_live_map_mismatch_does_not_record_cap_flip(maps_history_cls):
 
 
 @patch("rcon.logs.loop.MapsHistory")
-def test_offensive_match_time_uses_live_objective_timer(maps_history_cls):
+def test_offensive_match_time_normalizes_broken_server_default(maps_history_cls):
     current_map = make_map_info()
     history = maps_history_cls.return_value
     history.get_current_map.return_value = current_map

--- a/tests/test_log_loop_maps_history.py
+++ b/tests/test_log_loop_maps_history.py
@@ -1,0 +1,100 @@
+import os
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("HLL_MAINTENANCE_CONTAINER", "1")
+os.environ.setdefault("SERVER_NUMBER", "1")
+
+from rcon.logs.loop import LogLoop
+from rcon.maps import GameMode
+
+
+OFFENSIVE_MAP = "carentan_offensive_us"
+
+
+def make_map_info(*, end=None, match_time=0):
+    return {
+        "name": OFFENSIVE_MAP,
+        "start": 1_000,
+        "end": end,
+        "guessed": False,
+        "player_stats": {},
+        "game_layout": {"requested": [], "set": []},
+        "cap_flips": [{"allied_score": 0, "axis_score": 5, "ts": 0}],
+        "match_time": match_time,
+    }
+
+
+def make_gamestate(
+    *, map_id=OFFENSIVE_MAP, remaining=1_798, allied_score=1, axis_score=4
+):
+    return {
+        "current_map": {"id": map_id},
+        "game_mode": GameMode.OFFENSIVE,
+        "time_remaining": timedelta(seconds=remaining),
+        "match_time": 5_400,
+        "allied_score": allied_score,
+        "axis_score": axis_score,
+    }
+
+
+def make_loop(gamestate):
+    loop = object.__new__(LogLoop)
+    loop.ACTIVE_MAP_INDEX = 0
+    loop.now = 1_002
+    loop.rcon = Mock()
+    loop.rcon.get_gamestate.return_value = gamestate
+    loop.get_detailed_players = Mock(return_value={"players": {}, "fail_count": 0})
+    loop.record_player_stats = Mock()
+    return loop
+
+
+@patch("rcon.logs.loop.MapsHistory")
+def test_ended_match_is_not_mutated_by_next_match_score(maps_history_cls):
+    current_map = make_map_info(end=1_100, match_time=9_000)
+    history = maps_history_cls.return_value
+    history.get_current_map.return_value = current_map
+    loop = make_loop(make_gamestate(allied_score=5, axis_score=0))
+
+    elapsed = loop.update_maps_history(prev_map_time_elapsed=98)
+
+    assert elapsed == 100
+    assert current_map["cap_flips"] == [
+        {"allied_score": 0, "axis_score": 5, "ts": 0}
+    ]
+    loop.get_detailed_players.assert_not_called()
+    history.update.assert_not_called()
+
+
+@patch("rcon.logs.loop.MapsHistory")
+def test_live_map_mismatch_does_not_record_cap_flip(maps_history_cls):
+    current_map = make_map_info(match_time=9_000)
+    history = maps_history_cls.return_value
+    history.get_current_map.return_value = current_map
+    loop = make_loop(make_gamestate(map_id="foy_offensive_ger"))
+
+    elapsed = loop.update_maps_history(prev_map_time_elapsed=98)
+
+    assert elapsed == 0
+    assert len(current_map["cap_flips"]) == 1
+    loop.get_detailed_players.assert_not_called()
+    history.update.assert_not_called()
+
+
+@patch("rcon.logs.loop.MapsHistory")
+def test_offensive_match_time_uses_live_objective_timer(maps_history_cls):
+    current_map = make_map_info()
+    history = maps_history_cls.return_value
+    history.get_current_map.return_value = current_map
+    loop = make_loop(make_gamestate())
+
+    elapsed = loop.update_maps_history(prev_map_time_elapsed=1)
+
+    assert elapsed == 2
+    assert current_map["match_time"] == 9_000
+    assert current_map["cap_flips"][-1] == {
+        "allied_score": 1,
+        "axis_score": 4,
+        "ts": 2,
+    }
+    history.update.assert_called_once_with(0, current_map)

--- a/tests/test_log_loop_maps_history.py
+++ b/tests/test_log_loop_maps_history.py
@@ -2,6 +2,8 @@ import os
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
+import pytest
+
 os.environ.setdefault("HLL_MAINTENANCE_CONTAINER", "1")
 os.environ.setdefault("SERVER_NUMBER", "1")
 
@@ -41,6 +43,7 @@ def make_gamestate(
 def make_loop(gamestate):
     loop = object.__new__(LogLoop)
     loop.ACTIVE_MAP_INDEX = 0
+    loop.CURR_MAP_END = 0
     loop.now = 1_002
     loop.rcon = Mock()
     loop.rcon.get_gamestate.return_value = gamestate
@@ -58,12 +61,12 @@ def test_ended_match_is_not_mutated_by_next_match_score(maps_history_cls):
 
     elapsed = loop.update_maps_history(prev_map_time_elapsed=98)
 
-    assert elapsed == 100
+    assert elapsed == 2
     assert current_map["cap_flips"] == [
         {"allied_score": 0, "axis_score": 5, "ts": 0}
     ]
-    loop.get_detailed_players.assert_not_called()
-    history.update.assert_not_called()
+    loop.get_detailed_players.assert_called_once()
+    history.update.assert_called_once_with(0, current_map)
 
 
 @patch("rcon.logs.loop.MapsHistory")
@@ -97,4 +100,47 @@ def test_offensive_match_time_normalizes_broken_server_default(maps_history_cls)
         "axis_score": 4,
         "ts": 2,
     }
-    history.update.assert_called_once_with(0, current_map)
+    assert history.update.call_count == 2
+    history.update.assert_called_with(0, current_map)
+
+
+@pytest.mark.parametrize(
+    ("map_name", "initial_score", "later_score"),
+    (
+        ("carentan_offensive_us", (0, 5), (1, 4)),
+        ("carentan_offensive_ger", (5, 0), (4, 1)),
+    ),
+)
+def test_offensive_initial_score_cannot_be_recorded_again(
+    map_name, initial_score, later_score
+):
+    current_map = make_map_info()
+    current_map["name"] = map_name
+    current_map["cap_flips"] = []
+    loop = object.__new__(LogLoop)
+
+    gs = make_gamestate(
+        map_id=map_name,
+        allied_score=initial_score[0],
+        axis_score=initial_score[1],
+    )
+    loop.record_cap_flips(current_map, 0, gs)
+
+    gs["allied_score"], gs["axis_score"] = later_score
+    loop.record_cap_flips(current_map, 300, gs)
+
+    gs["allied_score"], gs["axis_score"] = initial_score
+    loop.record_cap_flips(current_map, 600, gs)
+
+    assert current_map["cap_flips"] == [
+        {
+            "allied_score": initial_score[0],
+            "axis_score": initial_score[1],
+            "ts": 0,
+        },
+        {
+            "allied_score": later_score[0],
+            "axis_score": later_score[1],
+            "ts": 300,
+        },
+    ]

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -13,6 +13,7 @@ from rcon.maps import (
     Layer,
     Team,
     get_opposite_side,
+    get_theoretical_match_time,
     is_server_loading_map,
     numbered_maps,
     parse_layer,
@@ -20,6 +21,23 @@ from rcon.maps import (
 )
 
 logger = getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    ("game_mode", "server_match_time", "expected"),
+    (
+        (GameMode.OFFENSIVE, 10 * 60, 50 * 60),
+        (GameMode.OFFENSIVE, 30 * 60, 5 * 30 * 60),
+        (GameMode.OFFENSIVE, 60 * 60, 5 * 60 * 60),
+        # The server incorrectly reports Warfare's default when the Offensive
+        # timer has not been customized.
+        (GameMode.OFFENSIVE, 90 * 60, 5 * 30 * 60),
+        (GameMode.WARFARE, 90 * 60, 90 * 60),
+        (GameMode.SKIRMISH, 30 * 60, 30 * 60),
+    ),
+)
+def test_get_theoretical_match_time(game_mode, server_match_time, expected):
+    assert get_theoretical_match_time(game_mode, server_match_time) == expected
 
 MOR_WARFARE_DAY = Layer(
     id="mortain_warfare_day", map=MAPS["mortain"], game_mode=GameMode.WARFARE


### PR DESCRIPTION
There was an investigation into the issue where all Offensive match times are set to 27000 seconds => 90 minutes per objective, and it was found that there is a HLL server bug that when the game mode is Offensive and the Match Timer was not customized the HLL server returns exactly 90 minutes match_time but Offensive allows values to be only between 10-60 minutes per objective.

When the Match Timer is not set it should return 30 minutes.

In this PR the match time is adjusted to 30 minutes if the server returns 90 minutes when Offensive.
There is also a minor update on how cap flips are being recorded during Offensive as some matches recorded the first default score from the next match as well.