### PR TITLE
Fix/increase rate limit for public info endpoint

### DIFF
--- a/rconweb/api/views.py
+++ b/rconweb/api/views.py
@@ -88,7 +88,7 @@ def get_version(request):
 
 @csrf_exempt
 @require_http_methods(["GET"])
-@ratelimit(key='ip', rate='10/m')
+@ratelimit(key='ip', rate='60/m')
 def get_public_info(request):
     cached_cur_map = MapsHistory().get_current_map()
     if not cached_cur_map:


### PR DESCRIPTION
Increase from 10 to 60 request per minute per IP as it was uncommon to run into 403 on the public stats pages