### PR TITLE
Fix/update weapon name escaping in localization strings

### DIFF
--- a/rcongui_public/src/components/game/statistics/encounters.tsx
+++ b/rcongui_public/src/components/game/statistics/encounters.tsx
@@ -103,8 +103,9 @@ function EncounterItem({
           <Trans
             t={t}
             i18nKey="timelineDetails.withWeapon"
-            values={{ weapon: encounter.weapon }}
-            components={{ weapon: <span className="font-medium text-foreground" /> }}
+            components={{
+              weapon: <span className="font-medium text-foreground">{encounter.weapon}</span>,
+            }}
           />
         </span>
       )}

--- a/rcongui_public/src/i18n/locales/cs/game.json
+++ b/rcongui_public/src/i18n/locales/cs/game.json
@@ -65,7 +65,7 @@
     "death": "Smrt",
     "killed": "zabil",
     "wasKilledBy": "byl zabit hráčem",
-    "withWeapon": "se zbraní <weapon>{{weapon}}</weapon>",
+    "withWeapon": "se zbraní <weapon />",
     "tankDestroyed": "{{player}} zničil tank",
     "playerState": {
       "joined": "<player>{{player}}</player> se připojil za <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/de/game.json
+++ b/rcongui_public/src/i18n/locales/de/game.json
@@ -65,7 +65,7 @@
     "death": "Tod",
     "killed": "tötete",
     "wasKilledBy": "wurde getötet von",
-    "withWeapon": "mit <weapon>{{weapon}}</weapon>",
+    "withWeapon": "mit <weapon />",
     "tankDestroyed": "{{player}} zerstörte einen Panzer",
     "playerState": {
       "joined": "<player>{{player}}</player> trat als <team>{{team}}</team> bei",

--- a/rcongui_public/src/i18n/locales/en/game.json
+++ b/rcongui_public/src/i18n/locales/en/game.json
@@ -102,7 +102,7 @@
     "death": "Death",
     "killed": "killed",
     "wasKilledBy": "was killed by",
-    "withWeapon": "with <weapon>{{weapon}}</weapon>",
+    "withWeapon": "with <weapon />",
     "tankDestroyed": "{{player}} destroyed a tank",
     "playerState": {
       "joined": "<player>{{player}}</player> joined as <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/es/game.json
+++ b/rcongui_public/src/i18n/locales/es/game.json
@@ -65,7 +65,7 @@
     "death": "Muerte",
     "killed": "eliminó a",
     "wasKilledBy": "fue eliminado por",
-    "withWeapon": "con <weapon>{{weapon}}</weapon>",
+    "withWeapon": "con <weapon />",
     "tankDestroyed": "{{player}} destruyó un tanque",
     "playerState": {
       "joined": "<player>{{player}}</player> se unió como <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/fr/game.json
+++ b/rcongui_public/src/i18n/locales/fr/game.json
@@ -65,7 +65,7 @@
     "death": "Mort",
     "killed": "a éliminé",
     "wasKilledBy": "a été éliminé par",
-    "withWeapon": "avec <weapon>{{weapon}}</weapon>",
+    "withWeapon": "avec <weapon />",
     "tankDestroyed": "{{player}} a détruit un char",
     "playerState": {
       "joined": "<player>{{player}}</player> a rejoint les <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/it/game.json
+++ b/rcongui_public/src/i18n/locales/it/game.json
@@ -65,7 +65,7 @@
     "death": "Morte",
     "killed": "ha ucciso",
     "wasKilledBy": "è stato ucciso da",
-    "withWeapon": "con <weapon>{{weapon}}</weapon>",
+    "withWeapon": "con <weapon />",
     "tankDestroyed": "{{player}} ha distrutto un carro armato",
     "playerState": {
       "joined": "<player>{{player}}</player> si è unito come <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/ja/game.json
+++ b/rcongui_public/src/i18n/locales/ja/game.json
@@ -65,7 +65,7 @@
     "death": "デス",
     "killed": "を倒した",
     "wasKilledBy": "に倒された",
-    "withWeapon": "<weapon>{{weapon}}</weapon>を使用",
+    "withWeapon": "<weapon />を使用",
     "tankDestroyed": "{{player}}が戦車を破壊",
     "playerState": {
       "joined": "<player>{{player}}</player>が<team>{{team}}</team>として参加",

--- a/rcongui_public/src/i18n/locales/ko/game.json
+++ b/rcongui_public/src/i18n/locales/ko/game.json
@@ -65,7 +65,7 @@
     "death": "사망",
     "killed": "처치함",
     "wasKilledBy": "에게 처치됨",
-    "withWeapon": "<weapon>{{weapon}}</weapon> 사용",
+    "withWeapon": "<weapon /> 사용",
     "tankDestroyed": "{{player}}님이 전차를 파괴함",
     "playerState": {
       "joined": "<player>{{player}}</player>님이 <team>{{team}}</team>로 참가",

--- a/rcongui_public/src/i18n/locales/pt/game.json
+++ b/rcongui_public/src/i18n/locales/pt/game.json
@@ -97,7 +97,7 @@
     "death": "Morte",
     "killed": "abateu",
     "wasKilledBy": "foi abatido por",
-    "withWeapon": "com <weapon>{{weapon}}</weapon>",
+    "withWeapon": "com <weapon />",
     "tankDestroyed": "{{player}} destruiu um tanque",
     "playerState": {
       "joined": "<player>{{player}}</player> entrou como <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/ru/game.json
+++ b/rcongui_public/src/i18n/locales/ru/game.json
@@ -65,7 +65,7 @@
     "death": "Смерть",
     "killed": "убил",
     "wasKilledBy": "был убит игроком",
-    "withWeapon": "из <weapon>{{weapon}}</weapon>",
+    "withWeapon": "из <weapon />",
     "tankDestroyed": "{{player}} уничтожил танк",
     "playerState": {
       "joined": "<player>{{player}}</player> присоединился за <team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/zh-Hans/game.json
+++ b/rcongui_public/src/i18n/locales/zh-Hans/game.json
@@ -65,7 +65,7 @@
     "death": "死亡",
     "killed": "击杀了",
     "wasKilledBy": "被击杀者",
-    "withWeapon": "使用 <weapon>{{weapon}}</weapon>",
+    "withWeapon": "使用 <weapon />",
     "tankDestroyed": "{{player}}摧毁了一辆坦克",
     "playerState": {
       "joined": "<player>{{player}}</player>加入<team>{{team}}</team>",

--- a/rcongui_public/src/i18n/locales/zh-Hant/game.json
+++ b/rcongui_public/src/i18n/locales/zh-Hant/game.json
@@ -65,7 +65,7 @@
     "death": "死亡",
     "killed": "擊殺了",
     "wasKilledBy": "被擊殺者",
-    "withWeapon": "使用 <weapon>{{weapon}}</weapon>",
+    "withWeapon": "使用 <weapon />",
     "tankDestroyed": "{{player}}摧毀了一輛戰車",
     "playerState": {
       "joined": "<player>{{player}}</player>加入<team>{{team}}</team>",


### PR DESCRIPTION
The weapon name can be weapon `88 KWK 36 L/56 [Sd.Kfz.181 Tiger 1]` but it renders as `88 KWK 36 L&#x2F;56 [Sd.Kfz.181 Tiger 1]`. The weapon name was being passed to localization component that escaped the weapon name. Only the word `with` is being translated as the weapon name is left as is.