### PR TITLE
Add CLIENT_IP_HEADER .env var and middleware

### DIFF
--- a/default.env
+++ b/default.env
@@ -110,6 +110,26 @@ NB_API_THREADS=8
 SESSION_COOKIE_DOMAIN=
 CSRF_COOKIE_DOMAIN=
 
+# Use this *only* if hosting your RCON behind a reverse proxy (nginx, Caddy, Cloudflare, etc).
+# Otherwise leave it empty.
+#
+# When CRCON sits behind a reverse proxy, Django (and therefore django-ratelimit and any IP
+# based bans/throttling) sees the proxy's IP as the client IP (REMOTE_ADDR), not the real
+# visitor's IP, because that's who actually opened the TCP connection to the backend.
+#
+# Set this to the name of the HTTP header your reverse proxy uses to forward the original
+# client IP, and CRCON will use it to overwrite REMOTE_ADDR for every request. Common values:
+#   CLIENT_IP_HEADER=X-Forwarded-For
+#   CLIENT_IP_HEADER=X-Real-IP
+#   CLIENT_IP_HEADER=CF-Connecting-IP
+#
+# WARNING: only set this if you are actually behind a reverse proxy that YOU control, and
+# that proxy is configured to always set/overwrite this header itself. If you set this
+# without a trusted proxy in front of CRCON (or if your proxy doesn't strip client-supplied
+# values for this header), anyone can spoof this header to fake their IP and bypass rate
+# limiting / IP bans.
+CLIENT_IP_HEADER=
+
 # -----------------------------
 # Webhook Service
 # -----------------------------

--- a/docker-templates/one-server.yaml
+++ b/docker-templates/one-server.yaml
@@ -34,6 +34,7 @@ x-backend: &backend
     DONT_SEED_ADMIN_USER: ${DONT_SEED_ADMIN_USER}
     SESSION_COOKIE_DOMAIN: ${SESSION_COOKIE_DOMAIN}
     CSRF_COOKIE_DOMAIN: ${CSRF_COOKIE_DOMAIN}
+    CLIENT_IP_HEADER: ${CLIENT_IP_HEADER}
   command: web
   restart: on-failure
   healthcheck:

--- a/docker-templates/ten-servers.yaml
+++ b/docker-templates/ten-servers.yaml
@@ -43,6 +43,7 @@ x-backend: &backend
     DONT_SEED_ADMIN_USER: ${DONT_SEED_ADMIN_USER}
     SESSION_COOKIE_DOMAIN: ${SESSION_COOKIE_DOMAIN}
     CSRF_COOKIE_DOMAIN: ${CSRF_COOKIE_DOMAIN}
+    CLIENT_IP_HEADER: ${CLIENT_IP_HEADER}
   command: web
   restart: on-failure
   healthcheck:

--- a/rconweb/api/middleware.py
+++ b/rconweb/api/middleware.py
@@ -1,0 +1,61 @@
+import logging
+import os
+
+logger = logging.getLogger("rconweb")
+
+
+class ClientIpHeaderMiddleware:
+    """
+    Rewrites ``request.META["REMOTE_ADDR"]`` using the value of a
+    configurable HTTP header, so that ``django-ratelimit`` (and anything
+    else in Django that relies on ``REMOTE_ADDR``, e.g. IP bans) sees the
+    real client IP when CRCON is running behind a reverse proxy / load
+    balancer, rather than the IP of the proxy itself.
+
+    Configure the header to trust via the ``CLIENT_IP_HEADER`` environment
+    variable, using the normal HTTP header name, e.g.::
+
+        CLIENT_IP_HEADER=X-Forwarded-For
+        CLIENT_IP_HEADER=X-Real-IP
+        CLIENT_IP_HEADER=CF-Connecting-IP
+
+    Leave ``CLIENT_IP_HEADER`` unset/empty (the default) to disable this
+    middleware entirely; ``REMOTE_ADDR`` is then left untouched, which is
+    whatever your WSGI/ASGI server set it to (typically the IP of whatever
+    connected directly to it).
+
+    SECURITY WARNING: only enable this if CRCON is actually behind a
+    reverse proxy that you control, and that proxy always sets/overwrites
+    this header itself (i.e. it strips/ignores any value a client tries to
+    send for it). Otherwise a client could simply set this header on their
+    request and spoof any IP they like, bypassing rate limiting and IP
+    based bans.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+        header = (os.getenv("CLIENT_IP_HEADER") or "").strip()
+        # Django exposes HTTP headers on request.META using the
+        # "HTTP_HEADER_NAME" convention (uppercased, dashes -> underscores)
+        self.meta_key = "HTTP_" + header.upper().replace("-", "_") if header else None
+
+        if self.meta_key:
+            logger.info(
+                "ClientIpHeaderMiddleware enabled: REMOTE_ADDR will be set from the '%s' header (%s)",
+                header,
+                self.meta_key,
+            )
+
+    def __call__(self, request):
+        if self.meta_key:
+            value = request.META.get(self.meta_key)
+            if value:
+                # Headers such as X-Forwarded-For can contain a comma
+                # separated chain of IPs (client, proxy1, proxy2, ...).
+                # The left-most entry is the original client IP.
+                ip = value.split(",")[0].strip()
+                if ip:
+                    request.META["REMOTE_ADDR"] = ip
+
+        return self.get_response(request)

--- a/rconweb/rconweb/settings.py
+++ b/rconweb/rconweb/settings.py
@@ -197,6 +197,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "api.middleware.ClientIpHeaderMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -250,7 +251,7 @@ DATABASES = {
         "NAME": db_info["NAME"],
         "OPTIONS": {
             "application_name": (os.getenv("SERVER_NUMBER") or "") + "Django",
-        }
+        },
     }
 }
 


### PR DESCRIPTION
This along with #1352 should fix ratelimit for those with reverse proxies in front of their CRCON installs.  Without this ratelimit only see's the proxies IP and thus everyone shares the limit.