### PR TITLE
Pass game to parse_raw_player_info (fixes blank Role/Unit/Level/Team for all players)

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -520,7 +520,7 @@ class Rcon(ServerCtl):
         return self._get_detailed_player_info(player_info, player)
 
     def _get_detailed_player_info(self, player_info: PlayerInfoType, player: GetPlayersType | None = None) -> GetDetailedPlayer:
-        player_data = parse_raw_player_info(player_info)
+        player_data = parse_raw_player_info(player_info, self.game_profile.game)
         if player is not None and 'is_vip' in player:
             player_data["is_vip"] = player.get('is_vip')
         else:


### PR DESCRIPTION
## Problem

`parse_raw_player_info()` takes `(raw, game)`, but its only call site still passes a single argument:

```
rcon/utils.py:516   def parse_raw_player_info(raw: PlayerInfoType, game: GameEnum) -> GetDetailedPlayer:
rcon/rcon.py:523        player_data = parse_raw_player_info(player_info)
```

```
TypeError: parse_raw_player_info() missing 1 required positional argument: 'game'
```

`get_detailed_players()` catches this with a bare `except Exception` and logs only `Failed to get info for <player_id>`, so there is no traceback and no 5xx. It surfaces as **every player having `team`, `unit_id`, `unit_name` and `role` of `None` and a `level` of `0`** — Role / Unit / Level / Team are blank throughout the UI.

The call site is unconditional, so this is not specific to Vietnam servers.

## Reproduction

With players online:

```python
from rcon.rcon import get_rcon
p = list(get_rcon().get_detailed_players()['players'].values())[0]
print(p['team'], p['unit_name'], p['role'], p['level'])
# -> None None None 0
```

The underlying RCON data is present and correct; only the parse fails.

## Fix

`self.game_profile` is already set in `ServerCtl.__init__`, so pass its game through.

## Verification

Tested against a live 100 player server. Before: 0/99 players had `role`, `unit_name` or `team`, and the log filled with `Failed to get info`. After: 99/99 populated, no errors.

On Vietnam this then exposes a separate issue with the `team` value itself (`south`/`north` rather than `allies`/`axis`), which #1358 addresses. That one is only observable once this fix is in, since before it `team` is `None` for everyone.
