### PR TITLE
Normalise player team to allies/axis on HLL Vietnam

### DIFF
--- a/rcon/utils.py
+++ b/rcon/utils.py
@@ -15,7 +15,7 @@ from rcon.cache_utils import get_redis_pool
 from rcon.game.registry import game_switch
 from rcon.models import GameLayout
 from rcon.types import GameEnum, GetDetailedPlayer, MapInfo, PlayerInfoType, PlayerStat, PlayerStatsType, StructuredLogLineWithMetaData
-from rcon.maps import Layer, parse_map_string, LAYERS, Environment, UNKNOWN_MAP_NAME
+from rcon.maps import Layer, parse_map_string, LAYERS, Environment, UNKNOWN_MAP_NAME, Team
 
 logger = logging.getLogger("rcon")
 
@@ -537,7 +537,7 @@ def parse_raw_player_info(raw: PlayerInfoType, game: GameEnum) -> GetDetailedPla
         role = None
 
     data["faction"] = faction.short_name.lower() if faction else None
-    data["team"] = faction.team.name.lower() if faction else None
+    data["team"] = Team.from_hllrcon(faction.team).value if faction else None
     data["role"] = role.name.lower() if role else None
     data["loadout"] = raw["loadout"].lower()
     data["level"] = int(raw["level"])


### PR DESCRIPTION
## Problem

`hllrcon` names the Vietnam sides *South* and *North*, so

```python
data["team"] = faction.team.name.lower() if faction else None
```

produces `"south"` / `"north"` for every player on a Vietnam server. `rcon.maps.Team` only defines `allies` / `axis` / `unknown`, and `get_team_view()` (`rcon/rcon.py:344`) buckets players on that raw value:

```python
>>> list(get_rcon().get_team_view().keys())
['fail_count', 'south', 'north', 'unassigned']
```

The UI has no `south` / `north` buckets to render, so the team view appears completely empty even though players are online and every other field is correct.

## Fix

`Team.from_hllrcon()` already exists for this, and its comment states the intent:

> hllrcon uses Allies/Axis for HLL and South/North for HLL Vietnam, but both games use the same stable side IDs.

Confirmed mapping:

| faction | `short_name` | `team.name` | `team.id` | `Team.from_hllrcon` |
|---|---|---|---|---|
| id 1 | US | south | 1 | allies |
| id 6 | NVA | north | 2 | axis |

`parse_raw_player_info` was bypassing it and taking the raw name, so this switches to the normaliser. It is a no-op for HLL, which already reports `allies`/`axis`.

`rcon/utils.py` already imports from `rcon.maps`, and `rcon/maps.py` does not import `rcon.utils`, so adding `Team` to that import introduces no cycle.

## Verification

Tested on a live 100 player Vietnam server. `get_team_view()` returns `allies` / `axis` / `unassigned`, with 15 allied squads (47 players) and 14 axis squads (49 players), commanders detected on both sides.

## Ordering

This only becomes observable once the missing `game` argument in `_get_detailed_player_info()` is fixed — before that `team` is `None` for every player and everyone lands in `unassigned`. That is #1356.
