### PR TITLE
Guard against an empty game mode in parse_game_mode (follow-up to #1357)

### DIFF
--- a/rcon/game/base.py
+++ b/rcon/game/base.py
@@ -35,11 +35,15 @@ class GameProfile:
         # HLL Vietnam prefixes offensive modes with the attacking faction,
         # e.g. "US Offensive" / "NVA Offensive". Every GameMode value is a
         # single word, so match on the final token.
-        mode = (
-            game_mode
-            if isinstance(game_mode, GameMode)
-            else GameMode(game_mode.strip().lower().rsplit(None, 1)[-1])
-        )
+        if isinstance(game_mode, GameMode):
+            mode = game_mode
+        else:
+            # rsplit returns [] for a blank string, so guard the index and fall
+            # back to the raw value. The game server sends an empty gameMode
+            # between matches, and an unguarded [-1] raises IndexError there.
+            normalised = game_mode.strip().lower()
+            tokens = normalised.rsplit(None, 1)
+            mode = GameMode(tokens[-1] if tokens else normalised)
         if mode not in self.supported_game_modes:
             raise ValueError(
                 f"Game mode {mode.value!r} is not supported by the '{self.game.value}' game profile"


### PR DESCRIPTION
## Problem

Follow-up to #1357, which is already merged.

That change matched on the final whitespace-separated token so the faction-prefixed Vietnam modes (`"US Offensive"` / `"NVA Offensive"`) would parse. `rsplit` returns an **empty list** for a blank string, so the `[-1]` raises:

```
  File "/code/rcon/game/base.py", line 42, in parse_game_mode
    else GameMode(game_mode.strip().lower().rsplit(None, 1)[-1])
IndexError: list index out of range
```

The game server sends an empty `gameMode` between matches. `update_maps_history()` calls `get_gamestate()` on every poll, and neither catches `IndexError`, so the log event loop dies at every map change:

```
rcon.cli cli.py:run_log_loop:76 | Chat recorder stopped
Traceback (most recent call last):
  File "/code/rcon/cli.py", line 74, in run_log_loop
  File "/code/rcon/logs/loop.py", line 257, in run
  File "/code/rcon/logs/loop.py", line 279, in update_maps_history
  ...
  File "/code/rcon/game/base.py", line 42, in parse_game_mode
IndexError: list index out of range
```

Supervisor restarts it, but a restart landing during the map change records the new match with a name of `unknown`:

```json
{"name": "unknown", "start": 1786649343, "end": null, "guessed": true}
```

After that, `gs["current_map"]["id"] != current_map["name"]` is permanently true and stats are skipped for the whole match:

```
[MATCH IDLE] - Live and cached map IDs differ, skipping stats
  - current_map: wdevc_offensiveus_day - cached_map: unknown
```

Observed 273 consecutive polls in that state on a live server before the next map change cleared it.

Prior to #1357 this path raised `ValueError` for an empty mode, which is the behaviour this restores.

## Fix

Guard the index and fall back to the raw value.

| input | before #1357 | after #1357 | this PR |
|---|---|---|---|
| `"US Offensive"` | ValueError | offensive | offensive |
| `"NVA Offensive"` | ValueError | offensive | offensive |
| `"Warfare"` | warfare | warfare | warfare |
| `""` | ValueError | **IndexError** | ValueError |
| `"   "` | ValueError | **IndexError** | ValueError |
| `"Nonsense"` | ValueError | ValueError | ValueError |

## Verification

Applied to a live Vietnam server. All six cases above behave as tabulated, and the log event loop has run through map changes without dying since.

Apologies for the round trip — I should have covered the empty case in #1357.
