### PR TITLE
Don't fail get_gamestate() when the server reports no game mode

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -612,8 +612,15 @@ class ServerCtl:
         seconds_remaining = int(time_remaining.total_seconds())
         raw_time_remaining = f"{seconds_remaining // 3600}:{(seconds_remaining // 60) % 60:02}:{seconds_remaining % 60:02}"
 
-        game_mode = self.game_profile.parse_game_mode(s["gameMode"])
         current_map = self.game_profile.parse_layer_or_unknown(s["mapId"])
+        # The server reports an empty gameMode between matches. The layer ID is
+        # still populated there and encodes the mode, so prefer it over failing
+        # the whole gamestate call -- an unhandled ValueError here kills every
+        # caller, including the log event loop and the scoreboard service.
+        game_mode = (
+            self.game_profile.parse_game_mode_or_none(s["gameMode"])
+            or current_map.game_mode
+        )
 
         try:
             next_map = self.game_profile.parse_layer_or_unknown(

--- a/rcon/game/base.py
+++ b/rcon/game/base.py
@@ -68,6 +68,18 @@ class GameProfile:
             candidates[0],
         )
 
+    def parse_game_mode_or_none(self, game_mode: str | GameMode) -> GameMode | None:
+        """Best-effort game mode parse, mirroring :meth:`parse_layer_or_unknown`.
+
+        The server reports an empty ``gameMode`` while no match is in progress,
+        which is a normal transient state rather than an error, so callers that
+        poll the game state need a total function here.
+        """
+        try:
+            return self.parse_game_mode(game_mode)
+        except (KeyError, TypeError, ValueError):
+            return None
+
     def parse_game_mode(self, game_mode: str | GameMode) -> GameMode:
         # HLL Vietnam prefixes offensive modes with the attacking faction,
         # e.g. "US Offensive" / "NVA Offensive". Every GameMode value is a

--- a/tests/test_game_profiles.py
+++ b/tests/test_game_profiles.py
@@ -163,6 +163,51 @@ def test_profiles_only_accept_their_supported_game_modes():
         HLLV_PROFILE.parse_game_mode("Skirmish")
 
 
+@pytest.mark.parametrize("profile", [HLL_PROFILE, HLLV_PROFILE])
+@pytest.mark.parametrize("game_mode", ["", "   ", "not a game mode"])
+def test_parse_game_mode_or_none_returns_none_instead_of_raising(profile, game_mode):
+    assert profile.parse_game_mode_or_none(game_mode) is None
+
+
+@pytest.mark.parametrize(
+    ("profile", "game_mode", "expected"),
+    [
+        (HLL_PROFILE, "Skirmish", GameMode.SKIRMISH),
+        (HLLV_PROFILE, "US Offensive", GameMode.OFFENSIVE),
+    ],
+)
+def test_parse_game_mode_or_none_still_parses_valid_modes(profile, game_mode, expected):
+    assert profile.parse_game_mode_or_none(game_mode) is expected
+
+
+@pytest.mark.parametrize(
+    ("game", "map_id"),
+    [
+        (GameEnum.HLL_WW2, "carentan_warfare"),
+        (GameEnum.HLL_VIETNAM, "wdeve_warfare_day"),
+    ],
+)
+def test_game_state_falls_back_to_layer_when_game_mode_is_blank(game, map_id):
+    """The server reports an empty gameMode between matches.
+
+    That used to raise ValueError out of get_gamestate(), taking down every
+    caller. The layer ID is still populated, so the mode is read back from it.
+    """
+    ctl_type = HLLServerCtl if game is GameEnum.HLL_WW2 else HLLVServerCtl
+    ctl = ctl_type(ServerInfo(game=game), Mock())
+    ctl.exchange = Mock(
+        side_effect=[
+            _response(_session(map_id, "")),
+            _response({"mAPS": [{"iD": map_id}], "currentIndex": 0}),
+        ]
+    )
+
+    game_state = ctl.get_gamestate()
+
+    assert game_state["game_mode"] is GameMode.WARFARE
+    assert game_state["current_map"]["id"] == map_id
+
+
 @pytest.mark.parametrize(
     ("game", "game_mode", "expected_map_id"),
     [


### PR DESCRIPTION
## Problem

The game server sends an empty `gameMode` in `GetServerInformation` while no match is in progress. `GameProfile.parse_game_mode()` passes it straight to the enum:

```
ValueError: '' is not a valid GameMode
```

Nothing catches it, so every `get_gamestate()` caller dies:

```
File "/code/rcon/logs/loop.py", line 279, in update_maps_history
    gs = self.rcon.get_gamestate()
File "/code/rcon/commands.py", line 615, in get_gamestate
    game_mode = self.game_profile.parse_game_mode(s["gameMode"])
File "/code/rcon/game/base.py", line 47, in parse_game_mode
ValueError: '' is not a valid GameMode
-> Program requested exit SystemExit(1)
```

The supervisor-managed services then exit(1) and restart at each map transition. On a Vietnam server this was `log_event_loop` and `scoreboard` restarting several times a night — at one transition `scoreboard` flapped six times before staying up — with each restart dropping a few seconds of log tailing, and with it kill/chat events. It also shows up as intermittent 500s on `/api/get_public_info` and `/api/get_status`.

## Fix

`get_gamestate()` already tolerates an unparseable map via `parse_layer_or_unknown()`; only the game mode was fatal. This removes that asymmetry:

- add `GameProfile.parse_game_mode_or_none()`, mirroring the existing `parse_layer_or_unknown()` idiom. `parse_game_mode()` is **unchanged** and still raises, so callers wanting strictness keep it.
- in `get_gamestate()`, resolve the layer first and fall back to `current_map.game_mode` when the field is blank.

The layer ID is still populated during that window and encodes the mode, so the fallback returns the *correct* mode rather than merely avoiding the crash. Observed on a live server, a blank `gameMode` alongside `wdevb_warfare_day` now resolves to `GameMode.WARFARE`.

If both the mode and the map are unavailable, the result is the unknown layer's mode. That is arbitrary, but it is a state that previously crashed outright, and downstream comparisons such as `update_maps_history`'s simply skip stats as they already do for an idle match.

## Tests

Ten new cases across both profiles, all of which fail without the change:

- `parse_game_mode_or_none()` returns `None` for blank / whitespace / unparseable input, and still parses valid modes (including HLLV's faction-prefixed `US Offensive`)
- `get_gamestate()` falls back to the layer's mode when `gameMode` is blank, for `hll` (`carentan_warfare`) and `hllv` (`wdeve_warfare_day`)

Full suite before and after is identical apart from the additions — `5 failed, 361 passed, 3 errors` to `5 failed, 371 passed, 3 errors`; the pre-existing failures need a live redis/postgres.