### PR TITLE
Show every map layer, and name recorded ones by their own game

### DIFF
--- a/rcon/types.py
+++ b/rcon/types.py
@@ -176,7 +176,9 @@ class GameEnum(enum.StrEnum):
 
     @classmethod
     def from_int(cls, value: int) -> "GameEnum":
-        return cls(GameIntEnum(value).name)
+        # Look the member up by NAME, mirroring to_int(). Calling cls() would
+        # look it up by VALUE ("hll" / "hllv") and so always raise on a name.
+        return cls[GameIntEnum(value).name]
 
 class GameIntEnum(enum.IntEnum):
     HLL_WW2 = 1

--- a/rcongui/src/pages/settings/maps/MapFilter.jsx
+++ b/rcongui/src/pages/settings/maps/MapFilter.jsx
@@ -39,7 +39,10 @@ const MenuProps = {
  */
 export const MapFilter = ({ maps, onFilterChange }) => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedModes, setSelectedModes] = useState(["warfare"]);
+  // An empty selection means "no mode filter". Defaulting to a single mode
+  // hides most of the pool behind checkboxes the admin has to find first,
+  // which is especially misleading on HLL:V, where Warfare is 6 of 30 layers.
+  const [selectedModes, setSelectedModes] = useState([]);
   const [selectedWeathers, setSelectedWeathers] = useState([]);
 
   // Compute unique modes and weathers for dropdowns

--- a/rconweb/api/scoreboards.py
+++ b/rconweb/api/scoreboards.py
@@ -5,10 +5,12 @@ from datetime import UTC, datetime
 from django.views.decorators.csrf import csrf_exempt
 from django_ratelimit.decorators import ratelimit
 
-from rcon.maps import parse_layer
 from rcon.api_commands import get_rcon_api
+from rcon.game import get_game_profile
+from rcon.maps import Layer
 from rcon.models import Maps, enter_session
 from rcon.player_stats import LiveStats, get_cached_live_game_stats
+from rcon.types import GameEnum
 from rcon.user_config.rcon_server_settings import RconServerSettingsUserConfig
 from rcon.utils import MapsHistory
 
@@ -17,6 +19,19 @@ from .decorators import require_http_methods
 from .views import _get_data
 
 logger = logging.getLogger("rconweb")
+
+
+def parse_recorded_layer(record: Maps) -> Layer:
+    """Resolve a stored map name against the game the match was played on.
+
+    Every row carries the game it belongs to, so historical records stay
+    correct even after a server switches games. Resolving against the WWII
+    catalog unconditionally leaves Vietnam matches with a placeholder layer:
+    the ID title-cased into a name ("Wdevc") and default WWII factions.
+    """
+    return get_game_profile(GameEnum.from_int(record.game)).parse_layer(
+        record.map_name
+    )
 
 
 @csrf_exempt
@@ -68,11 +83,12 @@ def get_scoreboard_maps(request):
         res = query.limit(page_size).offset((page - 1) * page_size).all()
 
         maps = []
-        for r in res:
-            r = r.to_dict()
+        for record in res:
+            layer = parse_recorded_layer(record)
+            r = record.to_dict()
             maps.append(
                 dict(
-                    map=parse_layer(r["map_name"]),
+                    map=layer,
                     id=r["id"],
                     creation_time=r["creation_time"],
                     start=r["start"],
@@ -112,8 +128,9 @@ def get_map_scoreboard(request):
                 error = "No map for this ID"
                 failed = True
             else:
+                layer = parse_recorded_layer(game)
                 game = game.to_dict(with_stats=True)
-                game["map"] = parse_layer(game["map_name"])
+                game["map"] = layer
 
                 logs = get_rcon_api().get_historical_logs(
                     action="KILL",

--- a/tests/test_game_profiles.py
+++ b/tests/test_game_profiles.py
@@ -18,7 +18,7 @@ from rcon.game.hll.profile import HLL_PROFILE
 from rcon.game.hllv.profile import HLLV_PROFILE
 from rcon.maps import GameMode, Team, UNKNOWN_MAP_NAME, parse_map_string
 from rcon.rcon import HLLRcon, HLLVRcon, Rcon, create_rcon
-from rcon.types import GameEnum, ServerInfo
+from rcon.types import GameEnum, GameIntEnum, ServerInfo
 from rcon.utils import guess_map_from_log
 
 
@@ -323,3 +323,38 @@ def test_timer_commands_validate_mode_against_profile():
 
     with pytest.raises(ValueError, match="not supported by the 'hllv' game profile"):
         ctl.set_match_timer(GameMode.SKIRMISH, 30)
+
+
+@pytest.mark.parametrize("game", list(GameEnum))
+def test_game_enum_survives_a_round_trip_through_its_stored_int(game):
+    """Maps.game persists a GameIntEnum, so reading a row back needs both ways."""
+    assert GameEnum.from_int(game.to_int()) is game
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (GameIntEnum.HLL_WW2, GameEnum.HLL_WW2),
+        (GameIntEnum.HLL_VIETNAM, GameEnum.HLL_VIETNAM),
+    ],
+)
+def test_game_enum_from_int_accepts_the_values_stored_in_the_database(stored, expected):
+    assert GameEnum.from_int(int(stored)) is expected
+
+
+def test_layer_id_from_another_game_degrades_to_a_placeholder():
+    """Why a stored map name has to be resolved against the game it was played on.
+
+    The WWII catalog has no Vietnam IDs, so it synthesises a layer from the ID
+    itself -- a title-cased name and WWII factions -- rather than failing. Any
+    reader that ignores the recorded game silently shows that placeholder.
+    """
+    stored = "wdevc_warfare_day"
+
+    placeholder = HLL_PROFILE.parse_layer(stored)
+    assert placeholder.map.name == "Wdevc"
+    assert placeholder.map.axis.name == "ger"
+
+    actual = HLLV_PROFILE.parse_layer(stored)
+    assert actual.pretty_name == "Hu\u1ebf Outskirts Warfare"
+    assert actual.map.axis.name == "nva"


### PR DESCRIPTION
Two separate things hide Vietnam content in the UI. Both are also live on `master`.

### The map picker opens filtered to Warfare

`MapFilter` initialises `selectedModes` to `["warfare"]`, and it gates the option list for the change-map page **and** the rotation / votemap builders (`MapListBuilder` → `MapFilter` → `MapList`). So only Warfare layers are offered until an admin finds and ticks the other Game Mode boxes.

On WWII that hid Offensive and Skirmish. On Vietnam it hides Domination, Conquest and one offensive direction per map — 24 of the 30 layers `AddMapToRotation` actually offers.

An empty selection already means "no mode filter" in the component's own predicate:

```js
!selectedModes.length || selectedModes.includes(unifiedGamemodeName(mapLayer.game_mode))
```

so defaulting to `[]` shows everything and leaves the checkboxes behaving exactly as before.

### Recorded matches are named by the WWII catalog

`get_scoreboard_maps()` and `get_map_scoreboard()` resolved stored map names with the global WWII `parse_layer()`. Vietnam IDs are not in that catalog, so the fallback synthesises a placeholder layer out of the ID itself:

```
wdevc_warfare_day  ->  "Wdevc Warfare", axis "ger", allies "us"
```

visible on the admin games list, the public `/games` page and the per-match detail page. Live pages were unaffected — only data read back out of `map_history`.

`Maps.game` already records which game the match was played on, so resolve against that game's profile. Keying off the row rather than the current `HLL_GAME` also keeps history correct if a server ever switches games; an unrecognised value logs a warning and falls back to the column default rather than failing the whole page.

### `GameEnum.from_int()` never worked

Reaching for it exposed:

```python
return cls(GameIntEnum(value).name)   # value lookup ("hll"), given a name ("HLL_WW2")
```

It raised `ValueError` for every possible input. It had no callers in the tree, which is why nobody had hit it. Now `cls[...]`, mirroring the working `to_int()`.

### Verification

WWII behaviour is unchanged, checked rather than assumed: all **170** WWII layers resolve identically through `HLL_PROFILE.parse_layer()` and the old global `parse_layer()`, including the `unknown` fallback and an unrecognised ID.

Test suite against `master`, run on the v12.0.1 runtime image:

```
master : 4 failed, 372 passed, 3 errors
branch : 4 failed, 377 passed, 3 errors
```

Same four failures and three errors before and after (`ban_tk_connect`, `watchlist`, `log_recorder` — all pre-existing and untouched here); the five extra passes are the tests added in `tests/test_game_profiles.py` covering the `from_int` round trip and the cross-game placeholder behaviour.

Both fixes are running on two live Vietnam servers.