### PR TITLE
Don't let an unreachable game server block CRCON's web UI from booting

### DIFF
--- a/rcon/cli.py
+++ b/rcon/cli.py
@@ -597,7 +597,13 @@ def convert_win_player_ids():
 @cli.command(name="remove_orphaned_map_ids")
 def remove_orphaned_map_ids():
     vm = VoteMap()
-    known_map_ids = [m.id for m in ctl.get_maps()]
+    try:
+        known_map_ids = [m.id for m in ctl.get_maps()]
+    except OSError as e:
+        logger.error(
+            f"Could not reach the game server to remove orphaned map IDs, skipping: {e}"
+        )
+        return
 
     res = set()
     prev = vm.get_map_whitelist()


### PR DESCRIPTION
Tested this and it works on a container without a valid RCON connection to a game server.

Worth fixing because otherwise people can't get to their admin portal if they only have a single game server and they can't use the web UI or API to make valid offline changes (auto settings, etc.)

`remove_orphaned_map_ids` runs in the startup script.