### PR TITLE
Fix HLL Vietnam squad leader detection

### DIFF
--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -473,8 +473,16 @@ class Rcon(ServerCtl):
         return "infantry"
 
     def _has_leader(self, squad) -> bool:
-        for players in squad.get("players", []):
-            if players.get("role") in ["tankcommander", "officer", "spotter", "artilleryobserver"]:
+        for player in squad.get("players", []):
+            if player.get("role") in [
+                "tankcommander",
+                "officer",
+                "squadleader",
+                "spotter",
+                "artilleryobserver",
+                "mortarobserver",
+                "helicopterlogisticsofficer",
+            ]:
                 return True
         return False
 


### PR DESCRIPTION
## Summary

Adds support for HLL Vietnam squad leader roles when determining whether a squad has a leader.

HLL Vietnam uses additional role names that are currently not recognized by `_has_leader()`. This causes valid squads to be shown as having no squad leader.

## Changes

Adds the following HLL Vietnam leader roles:

- `squadleader`
- `helicopterlogisticsofficer`
- `mortarobserver`

Existing HLL roles remain unchanged.

## Testing

Tested against a live Hell Let Loose: Vietnam server running CRCON v12.0.1.

Confirmed live examples:

### Infantry squad

`role=squadleader`

Result:

`has_leader=True`

### Helicopter logistics squad

`role=helicopterlogisticsofficer`

Result:

`has_leader=True`

Without these additional role mappings, these squads were incorrectly reported as having no squad leader.

## Note

`mortarobserver` was added based on the HLL Vietnam role naming, but has not yet been confirmed in a live squad during testing.