### PR TITLE
copy nginx.conf on frontend start with fallback

### DIFF
--- a/config/default-nginx.conf
+++ b/config/default-nginx.conf
@@ -1,3 +1,5 @@
+### To edit this file make a copy named nginx.conf, it will be used instead
+
 # --- Real client IP resolution ----------------------------------------------
 # nginx currently sees the immediate connecting peer as $remote_addr. If that
 # peer is another reverse proxy (Traefik, Caddy, HAProxy, WHM/Apache, another

--- a/docker-templates/one-server.yaml
+++ b/docker-templates/one-server.yaml
@@ -78,7 +78,7 @@ x-frontend: &frontend
   volumes:
     - ./static:/static/
     - ./certs:/certs/
-    - ./config/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    - ./config:/config/:ro
 
 services:
   ########### SERVER 1  #############

--- a/docker-templates/ten-servers.yaml
+++ b/docker-templates/ten-servers.yaml
@@ -87,7 +87,7 @@ x-frontend: &frontend
   volumes:
     - ./static:/static/
     - ./certs:/certs/
-    - ./config/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    - ./config:/config/:ro
 
 services:
   ########### SERVER 1  #############

--- a/rcongui/entrypoint.sh
+++ b/rcongui/entrypoint.sh
@@ -30,4 +30,12 @@ if [ ! -f "/certs/cert.crt" ] || [ ! -f "/certs/key.key" ]; then
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /certs/key.key -out /certs/cert.crt -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=$RCONWEB_EXTERNAL_ADDRESS" 
 fi
 
+if [ -f "/config/nginx.conf" ]; then
+    echo "nginx.conf found using it"
+    cp /config/nginx.conf /etc/nginx/conf.d/default.conf
+else
+    echo "nginx.conf not found, falling back to default-nginx.conf"
+    cp /config/default-nginx.conf /etc/nginx/conf.d/default.conf
+fi
+
 nginx -g "daemon off;"


### PR DESCRIPTION
Bind mount /config to the frontend read only and copy either nginx.conf or default-nginx.conf to /etc/nginx/conf.d/default.conf when the frontend starts.  This allows either the git tracked default-nginx.conf to be used with no user config, or if customization is needed the user can copy default-nginx.conf to nginx.conf and edit as they like and it will be used instead.