### PR TITLE
fix: TypeError when votemap whitelist contains unknown map IDs

### DIFF
--- a/rcon/vote_map/service.py
+++ b/rcon/vote_map/service.py
@@ -73,7 +73,9 @@ def validate_maps(func):
         elif isinstance(map_arg, Iterable) and not isinstance(map_arg, Layer):
             invalid = [map for map in map_arg if map not in all_maps]
             if invalid:
-                raise Exception(f"Invalid maps: {', '.join(invalid)}")
+                raise Exception(
+                    f"Invalid maps: {', '.join(str(map) for map in invalid)}"
+                )
         else:
             raise Exception("Invalid argument type for map(s)")
         return func(self, map_arg, *args, **kwargs)

--- a/tests/test_vote_map.py
+++ b/tests/test_vote_map.py
@@ -351,10 +351,10 @@ def test_add_invalid_map_to_whitelist(votemap):
 
 
 def test_set_invalid_maps_to_whitelist(votemap):
-    """Test adding maps with invalid id to the whitelist raises error"""
-    with pytest.raises(Exception):
-        whitelist = votemap.get_map_whitelist()
-        whitelist.add(INVALID_MAP)
+    """Test adding maps with invalid id to the whitelist raises error naming them"""
+    whitelist = list(votemap.get_map_whitelist())
+    whitelist.append(INVALID_MAP)
+    with pytest.raises(Exception, match="Invalid maps: invalid"):
         votemap.add_maps_to_whitelist(whitelist)
 
 


### PR DESCRIPTION
Invalid votemap entries are Layer objects, but the validation error used ", ".join(invalid), causing a TypeError instead of showing the invalid map IDs.

Convert invalid layers to strings when building the error message.

Also fix test_set_invalid_maps_to_whitelist, which was passing because an unrelated AttributeError was swallowed by pytest.raises(Exception). The test now properly reaches the whitelist validation and checks the expected error message.

[2026-08-18 21:11:11,670][ERROR][CAV2][v12.0.1-31-g227a9c0e] rcon.rcon rcon.py:do_run_commands:164 | Unable to apply set_votemap_whitelist {'map_names': ['foy_warfare', 'stmariedumont_warfare', 'hurtgenforest_warfare_V2', 'utahbeach_warfare', 'stmereeglise_warfare', ....]}: sequence item 0: expected str instance, Layer found
Traceback (most recent call last):
  File "/code/rcon/rcon.py", line 158, in do_run_commands
    rcon.__getattribute__(command)(**params)
  File "/code/rcon/api_commands.py", line 726, in set_votemap_whitelist
    v.set_map_whitelist([v.parse_layer(map) for map in map_names])
  File "/code/rcon/vote_map/service.py", line 76, in wrapper
    raise Exception(f"Invalid maps: {', '.join(invalid)}")
                                     ^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, Layer found