### PR TITLE
fix: configure Django settings before ASGI imports

### DIFF
--- a/rconweb/rconweb/asgi.py
+++ b/rconweb/rconweb/asgi.py
@@ -9,13 +9,15 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 
 import os
 
-# This has to be imported *after* setting DJANGO_SETTINGS_MODULE
-from api import barricade, log_stream
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rconweb.settings")
+
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rconweb.settings")
 django_asgi_app = get_asgi_application()
+
+# This has to be imported *after* setting DJANGO_SETTINGS_MODULE
+from api import barricade, log_stream
 
 application = ProtocolTypeRouter(
     {


### PR DESCRIPTION
Daphne failed to start because `api` was imported before `DJANGO_SETTINGS_MODULE` was set, causing `ImproperlyConfigured` and breaking WebSocket connections and live log streaming.

Move the settings initialization before the guarded imports to prevent Ruff from reordering them again.