### PR TITLE
Disable socket timeout like redis-py 7.x

### DIFF
--- a/rconweb/rconweb/settings.py
+++ b/rconweb/rconweb/settings.py
@@ -122,6 +122,7 @@ CHANNEL_LAYERS = {
             "hosts": [
                 {
                     "address": os.getenv("HLL_REDIS_URL"),
+                    "socket_timeout": None,
                 }
             ],
         },


### PR DESCRIPTION
Looks like this is an alternative fix to #1404 suggested from https://github.com/redis/redis-py/issues/4091