### PR TITLE
Feat/get maps objectives

### DIFF
--- a/rcon/maps.py
+++ b/rcon/maps.py
@@ -40,6 +40,7 @@ class MapType(typing_extensions.TypedDict):
     allies: "FactionType"
     axis: "FactionType"
     orientation: str
+    objectives: typing_extensions.NotRequired[list[list[str]]]
 
 
 class LayerType(typing_extensions.TypedDict):
@@ -235,6 +236,9 @@ class Map(pydantic.BaseModel):
     allies: "Faction"
     axis: "Faction"
     orientation: Orientation
+    objectives: list[list[str]] | None = pydantic.Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
     def __str__(self) -> str:
         return self.id

--- a/rcon/rcon.py
+++ b/rcon/rcon.py
@@ -24,7 +24,7 @@ from rcon.commands import (
     VipId,
 )
 from rcon.connection import HLLCommandError
-from rcon.maps import UNKNOWN_MAP_NAME, Layer, is_server_loading_map
+from rcon.maps import UNKNOWN_MAP_NAME, Layer, Map, is_server_loading_map
 from rcon.models import PlayerID, PlayerVIP, enter_session
 from rcon.perf_statistics import PerformanceStatistics
 from rcon.player_history import (
@@ -1020,8 +1020,32 @@ class Rcon(ServerCtl):
         }
 
     @ttl_cache(ttl=60 * 60 * 24)
-    def get_maps(self) -> list[Layer]:
-        return [self.game_profile.parse_layer(m) for m in super().get_maps()]
+    def get_maps(self, include: str | None = None) -> list[Layer]:
+        includes = (
+            [x.strip() for x in include.split(",") if x.strip()] if include else []
+        )
+        layers = [self.game_profile.parse_layer(m) for m in super().get_maps()]
+        if "objectives" not in includes:
+            return layers
+
+        objectives_by_map: dict[str, list[list[str]]] = {}
+        enriched_layers: list[Layer] = []
+        for layer in layers:
+            objectives = objectives_by_map.get(layer.map.id)
+            if objectives is None:
+                objectives = self._get_objective_rows_for_layer(layer)
+                objectives_by_map[layer.map.id] = objectives
+            enriched_layers.append(
+                layer.model_copy(
+                    update={
+                        "map": layer.map.model_copy(update={"objectives": objectives})
+                    }
+                )
+            )
+        return enriched_layers
+
+    def _get_objective_rows_for_layer(self, layer: Layer) -> list[list[str]]:
+        raise NotImplementedError
 
     # TODO: fix typing
     def get_server_settings(self):
@@ -1647,6 +1671,26 @@ class Rcon(ServerCtl):
 
 
 class HLLRcon(Rcon, HLLServerCtl):
+    def _get_objective_rows_for_layer(self, layer: Layer) -> list[list[str]]:
+        map_sectors = next(
+            (
+                candidate.sectors
+                for candidate in hllrcon.HLLLayer.all()
+                if candidate.map.id.casefold() == layer.map.id.casefold()
+                and len(candidate.sectors) == 5
+                and all(len(sector.capture_zones) == 3 for sector in candidate.sectors)
+            ),
+            None,
+        )
+        if map_sectors is None:
+            raise ValueError(
+                f"Map for layer {layer.id!r} does not define a 5x3 sector layout"
+            )
+        return [
+            [capture_zone.strongpoint.name for capture_zone in sector.capture_zones]
+            for sector in map_sectors
+        ]
+
     def set_game_layout(
         self,
         objectives: Sequence[str | int | None],
@@ -1665,6 +1709,26 @@ class HLLRcon(Rcon, HLLServerCtl):
 
 
 class HLLVRcon(Rcon, HLLVServerCtl):
+    def _get_objective_rows_for_layer(self, layer: Layer) -> list[list[str]]:
+        map_sectors = next(
+            (
+                candidate.sectors
+                for candidate in hllrcon.HLLVLayer.all()
+                if candidate.map.id.casefold() == layer.map.id.casefold()
+                and len(candidate.sectors) == 5
+                and all(len(sector.capture_zones) == 3 for sector in candidate.sectors)
+            ),
+            None,
+        )
+        if map_sectors is None:
+            raise ValueError(
+                f"Map for layer {layer.id!r} does not define a 5x3 sector layout"
+            )
+        return [
+            [capture_zone.strongpoint.name for capture_zone in sector.capture_zones]
+            for sector in map_sectors
+        ]
+
     def get_game_layout(self, map_name: str) -> list[str] | None:
         layout = super().get_game_layout(map_name)
         if not layout:
@@ -1708,34 +1772,19 @@ class HLLVRcon(Rcon, HLLVServerCtl):
 
     def get_objective_rows(self, map_name: str) -> list[list[str]]:
         try:
-            layer = hllrcon.HLLVLayer.by_id(map_name)
+            hllrcon_layer = hllrcon.HLLVLayer.by_id(map_name)
         except ValueError as exc:
             raise ValueError(f"Unknown HLL Vietnam layer ID: {map_name!r}") from exc
 
-        if layer.map.id.casefold() == "unknown":
+        if hllrcon_layer.map.id.casefold() == "unknown":
             raise ValueError(f"Unknown HLL Vietnam layer ID: {map_name!r}")
 
-        map_ = layer.map
-        map_sectors = next(
-            (
-                candidate.sectors
-                for candidate in hllrcon.HLLVLayer.all()
-                if candidate.map == map_
-                and len(candidate.sectors) == 5
-                and all(len(sector.capture_zones) == 3 for sector in candidate.sectors)
-            ),
-            None,
+        map_ = Map.from_hllrcon(hllrcon_layer.map)
+        layer = Layer.from_hllrcon(
+            hllrcon_layer,
+            map_catalog={map_.id.casefold(): map_},
         )
-        if map_sectors is None:
-            raise ValueError(
-                f"Map for layer {map_name!r} does not define a 5x3 sector layout"
-            )
-
-        objective_rows = [
-            [capture_zone.strongpoint.name for capture_zone in sector.capture_zones]
-            for sector in map_sectors
-        ]
-        return objective_rows
+        return self._get_objective_rows_for_layer(layer)
 
     def game_test_command(self) -> GameEnum:
         return GameEnum.HLL_VIETNAM

--- a/rconweb/api/apps.py
+++ b/rconweb/api/apps.py
@@ -2,8 +2,9 @@ from logging import getLogger
 
 import django.db.utils
 from django.apps import AppConfig
+from django.conf import settings
 
-from rcon.cache_utils import invalidates
+from rcon.cache_utils import RedisCached, get_redis_pool, invalidates
 
 logger = getLogger(__name__)
 
@@ -16,6 +17,11 @@ class ApiConfig(AppConfig):
 
         # Can't import from rconweb.api until Django is ready
         from .auth import get_moderators_accounts
+
+        # Cached values can outlive several development server reloads. Clear
+        # them on startup so code changes are immediately visible.
+        if settings.DEBUG:
+            RedisCached.clear_all_caches(get_redis_pool())
 
         # Invalidate the cache on start up because you can modify Django
         # records while CRCON is offline (through the CLI, etc.)

--- a/tests/test_game_profiles.py
+++ b/tests/test_game_profiles.py
@@ -15,7 +15,7 @@ from rcon.commands import HLLServerCtl, HLLVServerCtl
 from rcon.game import get_game_profile
 from rcon.game.hll.profile import HLL_PROFILE
 from rcon.game.hllv.profile import HLLV_PROFILE
-from rcon.maps import UNKNOWN_MAP_NAME, GameMode, Team, parse_map_string
+from rcon.maps import UNKNOWN_MAP_NAME, GameMode, Map, Team, parse_map_string
 from rcon.rcon import HLLRcon, HLLVRcon, Rcon, create_rcon
 from rcon.types import GameEnum, GameIntEnum, ServerInfo
 from rcon.utils import guess_map_from_log
@@ -346,6 +346,46 @@ def test_hllv_get_objective_rows_uses_core_map_sector_definitions():
         ["Jungle Hill", "Maintenance Market", "Communications Centre"],
     ]
     ctl.exchange.assert_not_called()
+
+
+def test_map_objectives_are_omitted_when_not_included():
+    map_ = Map.model_validate(HLL_PROFILE.maps["carentan"].model_dump())
+
+    assert "objectives" not in map_.model_dump()
+
+
+def test_hll_get_maps_can_include_objectives(monkeypatch):
+    ctl = object.__new__(HLLRcon)
+    ctl.game_profile = HLL_PROFILE
+    monkeypatch.setattr(
+        HLLServerCtl,
+        "get_maps",
+        lambda self: ["carentan_warfare", "CAR_S_1944_Day_P_Skirmish"],
+    )
+
+    result = HLLRcon.get_maps.__wrapped__(ctl, " layers, objectives, ")
+
+    assert result[0].map.objectives == result[1].map.objectives
+    assert result[0].map.objectives[0] == [
+        "Blactot",
+        "502nd Start",
+        "Farm Ruins",
+    ]
+    assert all(len(row) == 3 for row in result[1].map.objectives)
+
+
+def test_hllv_get_maps_can_include_objectives(monkeypatch):
+    ctl = object.__new__(HLLVRcon)
+    ctl.game_profile = HLLV_PROFILE
+    monkeypatch.setattr(
+        HLLVServerCtl,
+        "get_maps",
+        lambda self: ["wdeve_conquest_day"],
+    )
+
+    result = HLLVRcon.get_maps.__wrapped__(ctl, "objectives")
+
+    assert result[0].map.objectives == ctl.get_objective_rows(result[0].id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Clear all redis cache on dev server startup

- Maps extended with `objectives` attribute
- New `include=objectives` param for `get_maps`

This will make it easier for the `Maps -> Objectives` page rather than creating a new endpoint for the objective names only

`GET /api/get_maps?include=objectives`
```json
        {
            "id": "wdeva_warfare_day",
            "map": {
                "id": "wdeva",
                "name": "VẠN TƯỜNG",
                "tag": "VAN",
                "pretty_name": "Vạn Tường",
                "shortname": "Vạn Tường",
                "allies": {
                    "name": "us",
                    "team": "allies"
                },
                "axis": {
                    "name": "nva",
                    "team": "axis"
                },
                "orientation": "horizontal",
                "objectives": [
                    [
                        "An Cuờng (2)",
                        "LZ Blue Perimeter",
                        "Route To Nam Yên"
                    ],
                    [
                        "River Checkpoint",
                        "Lagoon Overlook",
                        "Jungle Clearing Camp"
                    ],
                    [
                        "Jungle Outpost",
                        "Fortified An Cường",
                        "Riverside Village"
                    ],
                    [
                        "An Cường Outskirts",
                        "NVA Relay Station",
                        "Cầu Bàu Chiếu"
                    ],
                    [
                        "Phase Line Apple",
                        "An Cường (1)",
                        "River's End"
                    ]
                ]
            },
            "game_mode": "warfare",
            "attackers": null,
            "environment": "day",
            "pretty_name": "Vạn Tường Warfare",
            "image_name": "wdeva-day.webp"
        }
```