### PR TITLE
Fix redis migration to exclude global db by default

### DIFF
--- a/rcon/cache_migrations/redis_databases.py
+++ b/rcon/cache_migrations/redis_databases.py
@@ -3,17 +3,29 @@
 import redis
 
 
+GLOBAL_REDIS_DATABASE = 0
+
+
 def redis_client_for_database(client: redis.Redis, database: int) -> redis.Redis:
     connection_kwargs = dict(client.connection_pool.connection_kwargs)
     connection_kwargs["db"] = database
     return redis.Redis(connection_pool=redis.ConnectionPool(**connection_kwargs))
 
 
-def populated_database_numbers(client: redis.Redis) -> list[int]:
+def populated_database_numbers(
+    client: redis.Redis, *, include_global_database: bool = False
+) -> list[int]:
+    """Return populated Redis databases.
+
+    Database 0 is shared global state and must be opted into explicitly. Cache
+    migrations are server-scoped by default.
+    """
     databases = {int(client.connection_pool.connection_kwargs.get("db", 0))}
     for name in client.info("keyspace"):
         if isinstance(name, bytes):
             name = name.decode()
         if name.startswith("db") and name[2:].isdigit():
             databases.add(int(name[2:]))
+    if not include_global_database:
+        databases.discard(GLOBAL_REDIS_DATABASE)
     return sorted(databases)

--- a/rcon/cache_migrations/redis_databases.py
+++ b/rcon/cache_migrations/redis_databases.py
@@ -2,7 +2,6 @@
 
 import redis
 
-
 GLOBAL_REDIS_DATABASE = 0
 
 

--- a/tests/test_maps_history_migration.py
+++ b/tests/test_maps_history_migration.py
@@ -113,6 +113,17 @@ def test_populated_database_discovery_includes_all_server_databases():
     assert _populated_database_numbers(client) == [1, 3, 7]
 
 
+def test_populated_database_discovery_requires_opt_in_for_global_database():
+    client = fakeredis.FakeRedis(db=0)
+    client.info = lambda section: {
+        "db0": {"keys": 2},
+        "db1": {"keys": 4},
+    }
+
+    assert _populated_database_numbers(client) == [1]
+    assert _populated_database_numbers(client, include_global_database=True) == [0, 1]
+
+
 def test_maintenance_migrates_maps_history_in_every_populated_database(monkeypatch):
     discovery_client = fakeredis.FakeRedis(db=0)
     discovery_client.info = lambda section: {

--- a/tests/test_votemap_cache_migration.py
+++ b/tests/test_votemap_cache_migration.py
@@ -98,7 +98,7 @@ def test_votemap_state_instantiation_does_not_run_migrations():
     assert client.get(VotemapKeys.VERSION) is None
 
 
-def test_maintenance_migrates_votemap_state_in_every_populated_database(monkeypatch):
+def test_maintenance_migrates_votemap_state_only_in_server_databases(monkeypatch):
     discovery_client = _client()
     discovery_client.info = lambda section: {
         "db1": {"keys": 2},
@@ -117,5 +117,8 @@ def test_maintenance_migrates_votemap_state_in_every_populated_database(monkeypa
         lambda _client, database: clients[database],
     )
 
-    assert migrate_all_votemap_states("redis://unused/0") == (3, 3)
-    assert all(client.get(VotemapKeys.VERSION) == b"1" for client in clients.values())
+    assert migrate_all_votemap_states("redis://unused/0") == (2, 2)
+    assert clients[0].get(VotemapKeys.VERSION) is None
+    assert all(
+        clients[database].get(VotemapKeys.VERSION) == b"1" for database in (1, 7)
+    )


### PR DESCRIPTION
I found `votemap:version` in the global redis database = 0 which was caused by a redis db discovery in a migration code.