### PR TITLE
Enhance team detection logic in PlayerStats based on units

### DIFF
--- a/rcon/models.py
+++ b/rcon/models.py
@@ -928,6 +928,52 @@ class PlayerStats(Base):
     map: Mapped[Maps] = relationship(back_populates="player_stats")
 
     def detect_team(self) -> PlayerTeamAssociation:
+        # Unit history is a direct record of the player's team and is therefore
+        # more reliable than inferring it from weapons. Each entry applies until
+        # the next one; unassigned and offline spans are excluded.
+        unit_team_map = {1: Team.ALLIES, 2: Team.AXIS}
+        ordered_units = sorted(self.units or [], key=lambda unit: unit["ts"])
+        team_seconds = {Team.ALLIES: 0, Team.AXIS: 0}
+        unit_teams = set()
+        match_time = self.map.match_time if self.map is not None else None
+        for index, unit in enumerate(ordered_units):
+            team = unit_team_map.get(unit["team"])
+            if team is None:
+                continue
+            unit_teams.add(team)
+            end = (
+                ordered_units[index + 1]["ts"]
+                if index + 1 < len(ordered_units)
+                else match_time
+            )
+            if end is not None:
+                team_seconds[team] += max(0, end - unit["ts"])
+
+        if len(unit_teams) > 1:
+            allies_seconds = team_seconds[Team.ALLIES]
+            axis_seconds = team_seconds[Team.AXIS]
+            total_seconds = allies_seconds + axis_seconds
+            if allies_seconds == axis_seconds:
+                side = Team.UNKNOWN
+                ratio = 50
+            elif allies_seconds > axis_seconds:
+                side = Team.ALLIES
+                ratio = round(allies_seconds / total_seconds * 100, 2)
+            else:
+                side = Team.AXIS
+                ratio = round(axis_seconds / total_seconds * 100, 2)
+            return PlayerTeamAssociation(
+                side=side,
+                confidence=PlayerTeamConfidence.MIXED,
+                ratio=ratio,
+            )
+        if unit_teams:
+            return PlayerTeamAssociation(
+                side=unit_teams.pop(),
+                confidence=PlayerTeamConfidence.STRONG,
+                ratio=100,
+            )
+
         def get_value(item):
             return item[1]
 

--- a/tests/test_player_stats.py
+++ b/tests/test_player_stats.py
@@ -4,7 +4,13 @@ import pytest
 
 os.environ["HLL_MAINTENANCE_CONTAINER"] = "1"
 from rcon.maps import Team
-from rcon.models import PlayerID, PlayerSoldier, PlayerStats, calc_weapon_type_usage
+from rcon.models import (
+    Maps,
+    PlayerID,
+    PlayerSoldier,
+    PlayerStats,
+    calc_weapon_type_usage,
+)
 from rcon.player_stats import BaseStats
 from rcon.types import PlayerTeamAssociation, PlayerTeamConfidence
 
@@ -61,6 +67,79 @@ def test_detects_no_kills_no_deaths():
 
     assert p.detect_team() == PlayerTeamAssociation(
         side=Team.UNKNOWN, confidence=PlayerTeamConfidence.STRONG, ratio=0
+    )
+
+
+@pytest.mark.parametrize("team_id, expected", [(1, Team.ALLIES), (2, Team.AXIS)])
+def test_detects_team_from_units_before_weapons(team_id, expected):
+    p = PlayerStats(
+        units=[{"ts": 10, "team": team_id, "squad": 1, "role": 1}],
+        weapons={"M1A1 THOMPSON": 1_000},
+        death_by_weapons={},
+    )
+
+    assert p.detect_team() == PlayerTeamAssociation(
+        side=expected, confidence=PlayerTeamConfidence.STRONG, ratio=100
+    )
+
+
+def test_detects_mixed_team_from_units():
+    p = PlayerStats(
+        units=[
+            {"ts": 10, "team": 1, "squad": 1, "role": 1},
+            {"ts": 20, "team": 2, "squad": 1, "role": 1},
+            {"ts": 30, "team": -111, "squad": -111, "role": -111},
+        ],
+        weapons={"M1A1 THOMPSON": 1_000},
+        death_by_weapons={},
+    )
+
+    assert p.detect_team() == PlayerTeamAssociation(
+        side=Team.UNKNOWN, confidence=PlayerTeamConfidence.MIXED, ratio=50
+    )
+
+
+def test_detects_mixed_team_ratio_from_time_played():
+    p = PlayerStats(
+        units=[
+            {"ts": 10, "team": 1, "squad": 1, "role": 1},
+            {"ts": 20, "team": 2, "squad": 1, "role": 1},
+            {"ts": 50, "team": -111, "squad": -111, "role": -111},
+        ],
+        weapons={"M1A1 THOMPSON": 1_000},
+        death_by_weapons={},
+    )
+
+    assert p.detect_team() == PlayerTeamAssociation(
+        side=Team.AXIS, confidence=PlayerTeamConfidence.MIXED, ratio=75
+    )
+
+
+def test_detects_mixed_team_ratio_through_match_end():
+    p = PlayerStats(
+        units=[
+            {"ts": 10, "team": 1, "squad": 1, "role": 1},
+            {"ts": 20, "team": 2, "squad": 1, "role": 1},
+        ],
+        weapons={},
+        death_by_weapons={},
+    )
+    p.map = Maps(match_time=50)
+
+    assert p.detect_team() == PlayerTeamAssociation(
+        side=Team.AXIS, confidence=PlayerTeamConfidence.MIXED, ratio=75
+    )
+
+
+def test_detect_team_uses_weapons_when_units_have_no_team():
+    p = PlayerStats(
+        units=[{"ts": 10, "team": -111, "squad": -111, "role": -111}],
+        weapons={"M1A1 THOMPSON": 1},
+        death_by_weapons={},
+    )
+
+    assert p.detect_team() == PlayerTeamAssociation(
+        side=Team.ALLIES, confidence=PlayerTeamConfidence.STRONG, ratio=100
     )
 
 


### PR DESCRIPTION
Since the unit changes are being tracked the team detection does not need to solely rely on kills