### PR TITLE
Fix Maps → Objectives page crashing on Conquest servers

### DIFF
--- a/rcongui/src/pages/settings/maps/objectives/error.jsx
+++ b/rcongui/src/pages/settings/maps/objectives/error.jsx
@@ -3,12 +3,13 @@ import { Stack, Typography, Button, Paper } from "@mui/material";
 
 export default function RouteError() {
   const error = useRouteError();
-  const isSkirmishMode =
-    error.message === "skirmish" ||
-    error?.data?.command === "get_objective_rows" &&
-    error?.data?.text === "get objectiverow_0";
+  // The backend throws a HTTP 400 (bad request) if the game mode doesn't support
+  // selecting the objectives
+  const isUnsupportedMode =
+    error.message === "unsupported_mode" ||
+    (error?.data?.command === "get_objective_rows" && error?.status === 400);
   // other error let handle higher error handler
-  if (!isSkirmishMode) throw error;
+  if (!isUnsupportedMode) throw error;
   return (
     <Stack
       id="error-page"
@@ -23,7 +24,7 @@ export default function RouteError() {
     >
       <Typography variant="h1">Unsupported mode</Typography>
       <Typography variant="h2">
-        Changing objectives is not supported in Skirmish mode.
+        Changing objectives is not supported in this game mode.
       </Typography>
       <Button
         variant="contained"

--- a/rcongui/src/pages/settings/maps/objectives/helpers.js
+++ b/rcongui/src/pages/settings/maps/objectives/helpers.js
@@ -52,8 +52,10 @@ export const getMapLayerImageSrc = (mapLayer) =>
   `/maps/icons/${mapLayer?.image_name ?? "unknown.webp"}`;
 export const getTacMapImageSrc = (mapLayer) =>
   `/tac-maps/${mapLayer.map.id}.webp`;
+// Only Warfare/Offensive has the pre-round 5-sector objective layout; Skirmish and
+// Conquest don't return Sector_* parameters for SetSectorLayout.
 export const isNotSupportedGameMode = (mapLayer) =>
-  unifiedGamemodeName(mapLayer.game_mode) === "skirmish";
+  ["skirmish", "conquest"].includes(unifiedGamemodeName(mapLayer.game_mode));
 
 export const getSelectedObjectives = (states, objectiveNames, orientation) => {
   const grid = orientation === "vertical" ? states : zip(...states);

--- a/rcongui/src/pages/settings/maps/objectives/hll/index.jsx
+++ b/rcongui/src/pages/settings/maps/objectives/hll/index.jsx
@@ -5,8 +5,8 @@ import {
   flip,
   generateObjectivesGrid,
   getSelectedObjectives,
+  isNotSupportedGameMode,
   reduceToInts,
-  unifiedGamemodeName,
 } from "../helpers";
 import {
   Box,
@@ -199,8 +199,8 @@ function HLLMapObjectivesPage() {
     refetchObjectiveNames();
   }, [currentMap, gameState?.current_map]);
 
-  if (unifiedGamemodeName(currentMap.game_mode) === "skirmish") {
-    throw new Error("skirmish")
+  if (isNotSupportedGameMode(currentMap)) {
+    throw new Error("unsupported_mode")
   }
 
   return (


### PR DESCRIPTION
Conquest doesn't return the Sector_* parameters SetSectorLayout expects (only Warfare/Offensive do), so get_objective_rows() always 400s. The frontend only excluded Skirmish from the objectives page.

- Fold Conquest into the existing unsupported-mode check alongside Skirmish (helpers.js, hll/index.jsx).
- Generalize error handling by matching the API command name + HTTP 400 for any future game modes that fail.

Built and verified this on a server that was set to conquest:

<img width="667" height="340" alt="image" src="https://github.com/user-attachments/assets/63ac677d-4583-43b8-98a8-a6dd86197260" />
