### PR TITLE
Fix/log recorder last log

### DIFF
--- a/alembic/versions/5cf1dd099fd3_improve_indexing_on_log_lines.py
+++ b/alembic/versions/5cf1dd099fd3_improve_indexing_on_log_lines.py
@@ -1,0 +1,44 @@
+"""Improve indexing on log_lines
+
+Revision ID: 5cf1dd099fd3
+Revises: 3f12a7b9c4d1
+Create Date: 2026-08-24 18:00:16.458454
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '5cf1dd099fd3'
+down_revision = '3f12a7b9c4d1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+    op.drop_index(op.f('ix_log_lines_player1_steamid'), table_name='log_lines')
+    op.drop_index(op.f('ix_log_lines_player2_steamid'), table_name='log_lines')
+    op.create_index('ix_log_lines_player1_name_event_time', 'log_lines', ['player1_name', 'event_time'], unique=False)
+    op.create_index('ix_log_lines_player1_name_trgm', 'log_lines', ['player1_name'], unique=False, postgresql_using='gin', postgresql_ops={'player1_name': 'gin_trgm_ops'})
+    op.create_index('ix_log_lines_player1_steamid_event_time', 'log_lines', ['player1_steamid', 'event_time'], unique=False)
+    op.create_index('ix_log_lines_player2_name_event_time', 'log_lines', ['player2_name', 'event_time'], unique=False)
+    op.create_index('ix_log_lines_player2_name_trgm', 'log_lines', ['player2_name'], unique=False, postgresql_using='gin', postgresql_ops={'player2_name': 'gin_trgm_ops'})
+    op.create_index('ix_log_lines_player2_steamid_event_time', 'log_lines', ['player2_steamid', 'event_time'], unique=False)
+    op.create_index('ix_log_lines_server_event_time_id', 'log_lines', ['server', 'event_time', 'id'], unique=False)
+    op.create_index('ix_log_lines_type_event_time', 'log_lines', ['type', 'event_time'], unique=False)
+    op.create_index('ix_log_lines_type_trgm', 'log_lines', ['type'], unique=False, postgresql_using='gin', postgresql_ops={'type': 'gin_trgm_ops'})
+
+
+def downgrade():
+    op.drop_index('ix_log_lines_type_trgm', table_name='log_lines', postgresql_using='gin', postgresql_ops={'type': 'gin_trgm_ops'})
+    op.drop_index('ix_log_lines_type_event_time', table_name='log_lines')
+    op.drop_index('ix_log_lines_server_event_time_id', table_name='log_lines')
+    op.drop_index('ix_log_lines_player2_steamid_event_time', table_name='log_lines')
+    op.drop_index('ix_log_lines_player2_name_trgm', table_name='log_lines', postgresql_using='gin', postgresql_ops={'player2_name': 'gin_trgm_ops'})
+    op.drop_index('ix_log_lines_player2_name_event_time', table_name='log_lines')
+    op.drop_index('ix_log_lines_player1_steamid_event_time', table_name='log_lines')
+    op.drop_index('ix_log_lines_player1_name_trgm', table_name='log_lines', postgresql_using='gin', postgresql_ops={'player1_name': 'gin_trgm_ops'})
+    op.drop_index('ix_log_lines_player1_name_event_time', table_name='log_lines')
+    op.create_index(op.f('ix_log_lines_player2_steamid'), 'log_lines', ['player2_steamid'], unique=False)
+    op.create_index(op.f('ix_log_lines_player1_steamid'), 'log_lines', ['player1_steamid'], unique=False)
+    op.execute("DROP EXTENSION IF EXISTS pg_trgm;")

--- a/rcon/logs/recorder.py
+++ b/rcon/logs/recorder.py
@@ -37,7 +37,7 @@ class LogRecorder:
         last_log = (
             sess.query(LogLine)
             .filter(LogLine.server == self.server_id)
-            .order_by(desc(LogLine.event_time))
+            .order_by(desc(LogLine.event_time), desc(LogLine.id))
             .limit(1)
             .one_or_none()
         )
@@ -58,6 +58,7 @@ class LogRecorder:
                 )
                 break
             to_store.append(log)
+        to_store.reverse()
         return to_store
 
     def _collect_player_ids(

--- a/rcon/models.py
+++ b/rcon/models.py
@@ -34,7 +34,7 @@ from sqlalchemy.orm import (
     relationship,
     sessionmaker,
 )
-from sqlalchemy.schema import UniqueConstraint
+from sqlalchemy.schema import Index, UniqueConstraint
 
 from rcon.maps import Team
 from rcon.types import (
@@ -733,7 +733,37 @@ class PlayersAction(Base):
 
 class LogLine(Base):
     __tablename__ = "log_lines"
-    __table_args__ = (UniqueConstraint("event_time", "raw", name="unique_log_line"),)
+    __table_args__ = (
+        UniqueConstraint("event_time", "raw", name="unique_log_line"),
+        Index("ix_log_lines_server_event_time_id", "server", "event_time", "id"),
+        Index("ix_log_lines_type_event_time", "type", "event_time"),
+        Index(
+            "ix_log_lines_player1_steamid_event_time", "player1_steamid", "event_time"
+        ),
+        Index(
+            "ix_log_lines_player2_steamid_event_time", "player2_steamid", "event_time"
+        ),
+        Index("ix_log_lines_player1_name_event_time", "player1_name", "event_time"),
+        Index("ix_log_lines_player2_name_event_time", "player2_name", "event_time"),
+        Index(
+            "ix_log_lines_type_trgm",
+            "type",
+            postgresql_using="gin",
+            postgresql_ops={"type": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_log_lines_player1_name_trgm",
+            "player1_name",
+            postgresql_using="gin",
+            postgresql_ops={"player1_name": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_log_lines_player2_name_trgm",
+            "player2_name",
+            postgresql_using="gin",
+            postgresql_ops={"player2_name": "gin_trgm_ops"},
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(default=1)
@@ -744,11 +774,11 @@ class LogLine(Base):
     type: Mapped[str] = mapped_column(nullable=True)
     player1_name: Mapped[str] = mapped_column(nullable=True)
     player1_player_id: Mapped[int] = mapped_column(
-        "player1_steamid", ForeignKey("steam_id_64.id"), nullable=True, index=True
+        "player1_steamid", ForeignKey("steam_id_64.id"), nullable=True
     )
     player2_name: Mapped[str] = mapped_column(nullable=True)
     player2_player_id: Mapped[int] = mapped_column(
-        "player2_steamid", ForeignKey("steam_id_64.id"), nullable=True, index=True
+        "player2_steamid", ForeignKey("steam_id_64.id"), nullable=True
     )
     weapon: Mapped[str] = mapped_column()
     raw: Mapped[str] = mapped_column(nullable=False)


### PR DESCRIPTION
This should address #1285.  Insert logs oldest to newest and then tie break matching timestamps by the newer log line id.  Add some indexes to cover how log lines gets queried by game logs and the recorder.