### PR TITLE
Fix Seeder VIP notifications for HLL Vietnam

### DIFF
--- a/rcon/seed_vip/service.py
+++ b/rcon/seed_vip/service.py
@@ -25,6 +25,14 @@ from rcon.user_config.seed_vip import SeedVIPUserConfig
 
 logger = getLogger(__name__)
 
+DRY_RUN_DISCORD_PREFIX = (
+    "🧪 **DRY RUN – SIMULATION**\nNo VIPs or in-game reward messages will be sent.\n\n"
+)
+
+
+def format_discord_message(message: str, dry_run: bool) -> str:
+    return f"{DRY_RUN_DISCORD_PREFIX}{message}" if dry_run else message
+
 
 def run():
     config = SeedVIPUserConfig.load_from_db()
@@ -172,8 +180,11 @@ def run():
                         f"Making embed for `{config.player_messages.seeding_complete_message}`"
                     )
                     embed = make_seed_announcement_embed(
-                        message=config.player_messages.seeding_complete_message,
-                        current_map=rcon_api.current_map.pretty_name,
+                        message=format_discord_message(
+                            config.player_messages.seeding_complete_message,
+                            config.dry_run,
+                        ),
+                        current_map=gamestate["current_map"]["pretty_name"],
                         time_remaining=gamestate["raw_time_remaining"],
                         player_count_message=config.player_messages.player_count_message,
                         num_allied_players=gamestate["num_allied_players"],
@@ -239,10 +250,13 @@ def run():
                     prev_announced_bucket = next_player_bucket
 
                     embed = make_seed_announcement_embed(
-                        message=config.player_messages.seeding_in_progress_message.format(
-                            player_count=total_players
+                        message=format_discord_message(
+                            config.player_messages.seeding_in_progress_message.format(
+                                player_count=total_players
+                            ),
+                            config.dry_run,
                         ),
-                        current_map=rcon_api.current_map.pretty_name,
+                        current_map=gamestate["current_map"]["pretty_name"],
                         time_remaining=gamestate["raw_time_remaining"],
                         player_count_message=config.player_messages.player_count_message,
                         num_allied_players=gamestate["num_allied_players"],

--- a/rcon/seed_vip/service.py
+++ b/rcon/seed_vip/service.py
@@ -26,7 +26,7 @@ from rcon.user_config.seed_vip import SeedVIPUserConfig
 logger = getLogger(__name__)
 
 DRY_RUN_DISCORD_PREFIX = (
-    "🧪 **DRY RUN – SIMULATION**\nNo VIPs or in-game reward messages will be sent.\n\n"
+    "🧪 **DRY RUN – SIMULATION** "
 )
 
 

--- a/rcon/seed_vip/service.py
+++ b/rcon/seed_vip/service.py
@@ -25,9 +25,7 @@ from rcon.user_config.seed_vip import SeedVIPUserConfig
 
 logger = getLogger(__name__)
 
-DRY_RUN_DISCORD_PREFIX = (
-    "🧪 **DRY RUN – SIMULATION** "
-)
+DRY_RUN_DISCORD_PREFIX = "🧪 **DRY RUN – SIMULATION** "
 
 
 def format_discord_message(message: str, dry_run: bool) -> str:

--- a/tests/test_seed_vip_service.py
+++ b/tests/test_seed_vip_service.py
@@ -1,0 +1,21 @@
+from rcon.seed_vip.service import (
+    DRY_RUN_DISCORD_PREFIX,
+    format_discord_message,
+)
+
+
+def test_format_discord_message_marks_dry_run():
+    message = "Server has reached 10 players"
+
+    result = format_discord_message(message, dry_run=True)
+
+    assert result == f"{DRY_RUN_DISCORD_PREFIX}{message}"
+    assert "DRY RUN" in result
+
+
+def test_format_discord_message_does_not_modify_live_message():
+    message = "Server has reached 10 players"
+
+    result = format_discord_message(message, dry_run=False)
+
+    assert result == message


### PR DESCRIPTION
## Summary

This fixes two issues affecting Seeder VIP Discord notifications:

* Dry-run notifications were indistinguishable from live notifications.
* The current map could be displayed as `unknown Domination`, especially on Hell Let Loose: Vietnam servers.

## Changes

* Adds a clear dry-run prefix to Seeder VIP Discord notifications:

```text
🧪 DRY RUN – SIMULATION
No VIPs or in-game reward messages will be sent.
```

* Applies the prefix to both:

  * seeding progress notifications,
  * seeding complete notifications.
* Uses the current map returned by `get_gamestate()` instead of the controller's potentially stale `current_map` property.
* Adds tests covering dry-run and live Discord message formatting.

## Previous behavior

Seeder VIP notifications sent to Discord during dry-run mode looked identical to live notifications. Administrators could therefore not tell whether VIP rewards and in-game reward messages were actually being sent.

The Discord embed also used `rcon_api.current_map.pretty_name`. On HLL Vietnam servers, this property could remain initialized as unknown and produce:

```text
Current Map
unknown Domination
```

## New behavior

Dry-run notifications are clearly identified as simulations.

The current map is taken from the same gamestate used for player counts and remaining time. This correctly displays Vietnam maps, for example:

```text
Current Map
Vạn Tường Warfare
```

Existing VIP rewards and in-game player messages are unchanged.

## Testing

* Verified Python syntax using `py_compile`.
* Verified the changes using `git diff --check`.
* Added tests for dry-run and live message formatting.
* Tested the patched Seeder VIP service against a live HLL Vietnam server.
* Confirmed that:

  * dry-run notifications are visibly marked,
  * the correct player counts are displayed,
  * `Vạn Tường Warfare` is displayed instead of `unknown Domination`,
  * the `seed_vip` process restarts and remains running without errors.
