### PR TITLE
Fix HLL Vietnam live session display

### DIFF
--- a/rcongui/src/components/table/styles.jsx
+++ b/rcongui/src/components/table/styles.jsx
@@ -9,6 +9,8 @@ export function getVariantWidth(variant) {
       return "1.25em";
     case "short":
       return "4em";
+    case "unit":
+      return "12ch";
     case "time":
       return "16ch";
     case "name":
@@ -42,6 +44,8 @@ export function getVariantMinWidth(variant) {
       return "1.25em";
     case "short":
       return "4em";
+    case "unit":
+      return "12ch";
     case "time":
       return "16ch";
     case "name":

--- a/rcongui/src/pages/stats/live-sessions/columns.jsx
+++ b/rcongui/src/pages/stats/live-sessions/columns.jsx
@@ -121,7 +121,7 @@ export const columns = [
       );
     },
     meta: {
-      variant: "short",
+      variant: "unit",
     },
   },
   {
@@ -132,7 +132,15 @@ export const columns = [
       const themedImg = useThemedImages();
       const iconKey = row.original.type ?? row.original.role;
 
-      return row.team !== "neutral" ? (
+      if (row.original.team === "neutral" || !iconKey) {
+        return (
+          <Center>
+            <Square />
+          </Center>
+        );
+      }
+
+      return (
         <Center>
           <Square>
             <img
@@ -144,7 +152,7 @@ export const columns = [
             />
           </Square>
         </Center>
-      ) : null;
+      );
     },
     meta: {
       variant: "icon",
@@ -212,7 +220,7 @@ export const columns = [
             textOverflow: "ellipsis",
             overflow: "hidden",
             textWrap: "nowrap",
-            width: "20ch",
+            width: "30ch",
           }}
         >
           <span>{row.original.name}</span>

--- a/rcongui/src/utils/lib.js
+++ b/rcongui/src/utils/lib.js
@@ -230,7 +230,16 @@ export function getGameDuration(start, end) {
 }
 
 export function isLeader(role) {
-  return ["officer", "tankcommander", "spotter", "armycommander"].includes(role);
+  return [
+    "officer",
+    "squadleader",
+    "tankcommander",
+    "spotter",
+    "armycommander",
+    "artilleryobserver",
+    "mortarobserver",
+    "helicopterlogisticsofficer",
+  ].includes(role);
 }
 
 export function isSteamPlayer(player) {


### PR DESCRIPTION
## Summary

This fixes several display issues in the Live Sessions table, particularly on Hell Let Loose: Vietnam servers.

## Changes

* Adds the missing HLL Vietnam leader roles to the frontend leader detection:

  * `squadleader`
  * `artilleryobserver`
  * `mortarobserver`
  * `helicopterlogisticsofficer`
* Keeps the existing HLL leader roles unchanged.
* Fixes the broken role image shown for unassigned players.
* Displays an empty themed field when no valid role icon is available.
* Adds a dedicated `unit` table-column variant with a width of `12ch`.
* Prevents `COMMAND` and `UNASSIGNED` from overlapping adjacent columns.
* Increases the player-name display width from `20ch` to `30ch`.

## Previous behavior

The backend already recognized the additional HLL Vietnam leader roles, but the Live Sessions frontend used a separate, incomplete list.

As a result, valid Vietnam squad leaders were displayed as:

```text
No Leader
Level 0
```

The role column also checked `row.team` instead of `row.original.team`. Since the team value is stored on the original row data, unassigned rows attempted to load a role image with an invalid or missing source.

Long unit names such as `COMMAND` and `UNASSIGNED` were displayed in a column intended for short values and could overlap the role and level columns.

## New behavior

* Vietnam squad leaders are displayed with their correct name and level.
* WW2 leader detection continues to work as before.
* Unassigned rows show a clean empty field instead of a broken image.
* Unit, role and level columns no longer overlap.
* Longer player names have more space before being truncated.

## Testing

* Verified the changes with `git diff --check`.
* Successfully built the complete frontend Docker image.
* Deployed and tested the frontend against a live HLL Vietnam server.
* Confirmed that:

  * Vietnam squad leaders are correctly displayed,
  * squad names and leader levels are populated,
  * `COMMAND` and `UNASSIGNED` no longer overlap adjacent columns,
  * the broken Unassigned role image is no longer displayed,
  * player names have additional display space,
  * squad expansion and the remaining Live Sessions columns continue to work.
