### PR TITLE
nit warn from nginx for gzip_types text/html

### DIFF
--- a/config/default-nginx.conf
+++ b/config/default-nginx.conf
@@ -94,7 +94,7 @@ server {
         gzip_comp_level 6;
         gzip_proxied any;
         gzip_vary on;
-        gzip_types text/plain text/css image/svg+xml application/xml text/html application/json text/javascript application/javascript;
+        gzip_types text/plain text/css image/svg+xml application/xml application/json text/javascript application/javascript;
 
         location = /runtime-config.js {
             if_modified_since off;
@@ -215,7 +215,7 @@ server {
         gzip_comp_level 6;
         gzip_proxied any;
         gzip_vary on;
-        gzip_types text/plain text/css image/svg+xml application/xml text/html application/json text/javascript application/javascript;
+        gzip_types text/plain text/css image/svg+xml application/xml application/json text/javascript application/javascript;
 
         location = /runtime-config.js {
             if_modified_since off;


### PR DESCRIPTION
gzip_types always includes text/html already
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/conf.d/default.conf:97
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/conf.d/default.conf:218