### PR TITLE
Add audit webhook thread ID support

### DIFF
--- a/rcon/discord.py
+++ b/rcon/discord.py
@@ -130,7 +130,9 @@ def send_to_discord_audit(
 
     if webhookurls is None:
         config = AuditWebhooksUserConfig.load_from_db()
-        webhookurls = [hook.url for hook in config.hooks]
+        webhook_destinations = [(hook.url, hook.thread_id) for hook in config.hooks]
+    else:
+        webhook_destinations = [(url, None) for url in webhookurls]
 
     server_config = RconServerSettingsUserConfig.load_from_db()
 
@@ -138,7 +140,7 @@ def send_to_discord_audit(
     if flatten:
         message = message.replace("\n", " ")
     logger.info("Audit: [%s] %s, %s", by, command_name, message.replace("\n", " "))
-    if not webhookurls:
+    if not webhook_destinations:
         logger.debug("No webhooks set for audit log")
         return
     try:
@@ -149,8 +151,9 @@ def send_to_discord_audit(
             DiscordWebhook(
                 url=str(url),
                 content=content,
+                thread_id=thread_id,
             )
-            for url in webhookurls
+            for url, thread_id in webhook_destinations
             if url
         ]
 

--- a/rcon/user_config/webhooks.py
+++ b/rcon/user_config/webhooks.py
@@ -1,5 +1,5 @@
 import re
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 import pydantic
 
@@ -19,8 +19,17 @@ class WebhookType(TypedDict):
     url: pydantic.HttpUrl
 
 
+class AuditWebhookType(TypedDict):
+    url: pydantic.HttpUrl
+    thread_id: NotRequired[str | None]
+
+
 class RawWebhookType(TypedDict):
     hooks: list[WebhookType]
+
+
+class RawAuditWebhookType(TypedDict):
+    hooks: list[AuditWebhookType]
 
 
 class RawWebhookMentionType(TypedDict):
@@ -46,6 +55,16 @@ class DiscordWebhook(pydantic.BaseModel):
     @pydantic.field_serializer("url")
     def serialize_url(self, server_url: pydantic.HttpUrl, _info):
         return str(server_url)
+
+
+class AuditDiscordWebhook(DiscordWebhook):
+    """A Discord audit webhook with an optional destination thread."""
+
+    thread_id: str | None = pydantic.Field(
+        default=None,
+        description="Discord thread ID to send audit messages to",
+        pattern=r"^\d+$",
+    )
 
 
 class DiscordMentionWebhook(DiscordWebhook):
@@ -212,8 +231,39 @@ class ChatWebhooksUserConfig(BaseWebhookUserConfig):
             set_user_config(validated_conf.NAME, validated_conf)
 
 
-class AuditWebhooksUserConfig(BaseWebhookUserConfig):
+class AuditWebhooksUserConfig(BaseUserConfig):
     NAME = "AuditWebhooksUserConfig"
+
+    hooks: list[AuditDiscordWebhook] = pydantic.Field(default_factory=list)
+
+    @classmethod
+    def save_to_db(cls, values: RawAuditWebhookType, dry_run=False) -> None:
+        key_check(
+            RawAuditWebhookType.__required_keys__,
+            RawAuditWebhookType.__optional_keys__,
+            values.keys(),
+        )
+        raw_hooks: list[AuditWebhookType] = values.get("hooks")
+        _listType(values=raw_hooks)
+
+        for obj in raw_hooks:
+            key_check(
+                AuditWebhookType.__required_keys__,
+                AuditWebhookType.__optional_keys__,
+                obj.keys(),
+            )
+
+        validated_hooks = [
+            AuditDiscordWebhook(
+                url=obj.get("url"),
+                thread_id=obj.get("thread_id"),
+            )
+            for obj in raw_hooks
+        ]
+        validated_conf = cls(hooks=validated_hooks)
+
+        if not dry_run:
+            set_user_config(validated_conf.NAME, validated_conf)
 
 
 class KillsWebhooksUserConfig(BaseWebhookUserConfig):

--- a/tests/test_audit_webhooks.py
+++ b/tests/test_audit_webhooks.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import HttpUrl, ValidationError
+
+from rcon import discord
+from rcon.user_config.webhooks import AuditDiscordWebhook, AuditWebhooksUserConfig
+
+
+def test_audit_webhook_config_supports_optional_thread_id():
+    config = AuditWebhooksUserConfig(
+        hooks=[
+            AuditDiscordWebhook(
+                url=HttpUrl("https://discord.com/api/webhooks/1/token"),
+                thread_id="123456789012345678",
+            ),
+            AuditDiscordWebhook(
+                url=HttpUrl("https://discord.com/api/webhooks/2/token"),
+            ),
+        ]
+    )
+
+    assert config.hooks[0].thread_id == "123456789012345678"
+    assert config.hooks[1].thread_id is None
+
+
+def test_audit_webhook_config_rejects_non_numeric_thread_id():
+    with pytest.raises(ValidationError):
+        AuditDiscordWebhook(
+            url=HttpUrl("https://discord.com/api/webhooks/1/token"),
+            thread_id="not-a-thread-id",
+        )
+
+
+def test_audit_delivery_passes_configured_thread_id(monkeypatch):
+    created_hooks = []
+    queued_messages = []
+
+    class FakeWebhook:
+        def __init__(self, **kwargs):
+            created_hooks.append(kwargs)
+            self.json = {
+                **kwargs,
+                "webhook_id": "1",
+                "rate_limit_retry": False,
+            }
+
+    config = AuditWebhooksUserConfig(
+        hooks=[
+            AuditDiscordWebhook(
+                url=HttpUrl("https://discord.com/api/webhooks/1/token"),
+                thread_id="123456789012345678",
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        discord.AuditWebhooksUserConfig,
+        "load_from_db",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        discord.RconServerSettingsUserConfig,
+        "load_from_db",
+        lambda: SimpleNamespace(short_name="TEST"),
+    )
+    monkeypatch.setattr(discord, "get_server_number", lambda: 1)
+    monkeypatch.setattr(discord, "DiscordWebhook", FakeWebhook)
+    monkeypatch.setattr(
+        discord,
+        "enqueue_message",
+        lambda *, message: queued_messages.append(message),
+    )
+
+    discord.send_to_discord_audit("changed settings", "test_command")
+
+    assert created_hooks[0]["thread_id"] == "123456789012345678"
+    assert queued_messages[0].payload["thread_id"] == "123456789012345678"


### PR DESCRIPTION
## Summary

- add an optional Discord thread ID to each audit webhook configuration
- route queued audit webhook messages to the configured thread
- preserve compatibility with existing URL-only audit webhook configurations
- validate thread IDs and cover configuration and delivery behavior with tests

## Testing

- `DEBUG=1 SERVER_NUMBER=1 uv run pytest -q tests/test_audit_webhooks.py tests/test_discord_handler.py` (12 passed)
- `uv run ruff check rcon/discord.py rcon/user_config/webhooks.py tests/test_audit_webhooks.py`
- `uv run ruff format --check rcon/discord.py rcon/user_config/webhooks.py tests/test_audit_webhooks.py`
- `git diff --check origin/master..HEAD`

The complete local suite additionally reached 443 passing tests; four failures and three errors require the repository's database-backed test environment and are unrelated to this change.

## Worked on by

- AceClaw519
