### PR TITLE
Revert add_vip RCON payload key from Comment back to Description

### DIFF
--- a/rcon/commands.py
+++ b/rcon/commands.py
@@ -653,7 +653,7 @@ class ServerCtl:
     @_escape_params
     def add_vip(self, player_id: str, description: str) -> bool:
         return self.exchange_success(
-            "AddVip", 2, {"PlayerId": player_id, "Comment": description}
+            "AddVip", 2, {"PlayerId": player_id, "Description": description}
         )
 
     def remove_vip(self, player_id) -> bool:


### PR DESCRIPTION
Revert back to the correct command name to fix the `AddVip` command.