### PR TITLE
Fix Records->Players to load faster

### DIFF
--- a/alembic/versions/8699b1c44bfa_records_players_load_faster.py
+++ b/alembic/versions/8699b1c44bfa_records_players_load_faster.py
@@ -1,0 +1,22 @@
+"""records-players load faster
+
+Revision ID: 8699b1c44bfa
+Revises: 5cf1dd099fd3
+Create Date: 2026-09-06 13:46:44.931698
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '8699b1c44bfa'
+down_revision = '5cf1dd099fd3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_player_sessions_playersteamid_id_end_start_created', 'player_sessions', ['playersteamid_id', 'end', 'start', 'created'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_player_sessions_playersteamid_id_end_start_created', table_name='player_sessions')

--- a/rcon/models.py
+++ b/rcon/models.py
@@ -701,6 +701,15 @@ class PlayerName(Base):
 
 class PlayerSession(Base):
     __tablename__ = "player_sessions"
+    __table_args__ = (
+        Index(
+            "ix_player_sessions_playersteamid_id_end_start_created",
+            "playersteamid_id",
+            "end",
+            "start",
+            "created",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     player_id_id: Mapped[int] = mapped_column(


### PR DESCRIPTION
Massive speedup on db's with high player counts/sessions.  Example: a 7M row player_sessions table resulted in the Records->Player page taking 17.69s to load, this dropped it to 1.68s.