### PR TITLE
player_id_id is actually playersteamid_id in the db

### DIFF
--- a/rcon/cli.py
+++ b/rcon/cli.py
@@ -597,11 +597,11 @@ def _merge_duplicate_player_ids(existing_ids: set[str] | None = None):
                 {"ids": ids},
             )
             session.execute(
-                text("DELETE FROM player_soldier WHERE player_id_id = ANY(:ids)"),
+                text("DELETE FROM player_soldier WHERE playersteamid_id = ANY(:ids)"),
                 {"ids": ids},
             )
             session.execute(
-                text("DELETE FROM player_account WHERE player_id_id = ANY(:ids)"),
+                text("DELETE FROM player_account WHERE playersteamid_id = ANY(:ids)"),
                 {"ids": ids},
             )
             session.execute(


### PR DESCRIPTION
For `player_soldier` see: https://github.com/MarechJ/hll_rcon_tool/blob/b7a0f7db5b3af77c163e9a402b498f8eb036abb8/rcon/models.py#L297
and for `player_account` see:
https://github.com/MarechJ/hll_rcon_tool/blob/b7a0f7db5b3af77c163e9a402b498f8eb036abb8/rcon/models.py#L429

Right now, these SQL statements fail and generate error messages in the maintenance container that might fool people into having a broken setup.